### PR TITLE
container-host-config: add transient-store PACKAGECONFIG

### DIFF
--- a/recipes-containers/container-host-config/container-host-config.bbappend
+++ b/recipes-containers/container-host-config/container-host-config.bbappend
@@ -22,4 +22,9 @@ do_install:append() {
         sed -i -e "/^\[registries.search\]/{n;d}" ${D}${sysconfdir}/containers/registries.conf
         sed -i -e "/^\[registries.search\]/a $registries" ${D}${sysconfdir}/containers/registries.conf
     fi
+
+    if ${@bb.utils.contains('PACKAGECONFIG', 'transient-store', 'true', 'false', d)}; then
+        # Enable transient container storage
+        sed -i -e "/\[storage\]/a # Enable transient container storage\ntransient_store = true" ${D}${sysconfdir}/containers/storage.conf
+    fi
 }


### PR DESCRIPTION
When it's enabled by:

```
PACKAGECONFIG = "transient-store"
```

a "transient_store = true" option would be added to ${sysconfdir}/containers/storage.conf, so podman will start containers with transient storage mode.

Reference about increase podman startup speed with transient storage:
https://www.redhat.com/sysadmin/speed-containers-podman-raspberry-pi

transient-store PACKAGECONFIG is disabled by default.

Related-to: TOR-3302