### PR TITLE
auto-provisioning: add service restart for remote access (RAC)

### DIFF
--- a/recipes-sota/auto-provisioning/auto-provisioning/auto-provisioning.sh
+++ b/recipes-sota/auto-provisioning/auto-provisioning/auto-provisioning.sh
@@ -138,6 +138,11 @@ function restart_services()
     log "Enabling and restarting fluent-bit"
     touch /etc/fluent-bit/enabled
     systemctl restart fluent-bit
+
+    if systemctl is-enabled remote-access; then
+        log "Restarting Remote Access Client (RAC)"
+        systemctl restart remote-access
+    fi
 }
 
 function main()


### PR DESCRIPTION
If we pre-enable RAC and set the image to auto-provision itself, it could be that remote-access.service fails to start due to the fact that the device wasn't provisioned when it checked.

This way, after the device is auto provisioned, it checks if RAC is enabled and if so restarts the service.
