### PR TITLE
torizon.inc: remove BBMASK from meta-freescale/cairo append

### DIFF
--- a/recipes-images/images/torizon-core-common.inc
+++ b/recipes-images/images/torizon-core-common.inc
@@ -77,6 +77,10 @@ CORE_IMAGE_BASE_INSTALL:append:mx8-nxp-bsp = " \
     kernel-module-imx-gpu-viv \
 "
 
+CORE_IMAGE_BASE_INSTALL:append:verdin-am62 = " \
+    ti-img-rogue-driver \
+"
+
 nss_altfiles_set_users_groups () {
 	# Make a temporary directory to be used by pseudo to find the real /etc/passwd,/etc/group
 	pseudo_dir=${WORKDIR}/pseudo-rootfs${sysconfdir}


### PR DESCRIPTION
Having this BBMASK makes it impossible to have DISTRO_FEATURES such as x11 or wayland on iMX8, which is an issue for users of torizon-minimal.

As the append is imxgpu-specific, it shouldn't affect any other machines. It also shouldn't affect the other torizon builds as no package from those depends/requires cairo.