### PR TITLE
torizon.inc: adjust CURLVERSION to 8.6.0

### DIFF
--- a/conf/distro/include/torizon.inc
+++ b/conf/distro/include/torizon.inc
@@ -96,7 +96,7 @@ GOVERSION ?= "1.20%"
 # Rust toolchain preferred versions:
 RUSTVERSION ?= "1.70%"
 
-CURLVERSION ?= "8.4.0"
+CURLVERSION ?= "8.6.0"
 
 PREFERRED_VERSION_cargo ?= "${RUSTVERSION}"
 PREFERRED_VERSION_cargo-native ?= "${RUSTVERSION}"


### PR DESCRIPTION
We have upgraded curl to 8.6.0, let's adjust CURLVERSION accordingly.