### PR TITLE
plymouth: drop pango and some themes

### DIFF
--- a/recipes-core/plymouth/files/0001-themes-only-install-spinner.patch
+++ b/recipes-core/plymouth/files/0001-themes-only-install-spinner.patch
@@ -1,0 +1,26 @@
+From 518e22cb0ca23f73509e137260ee383a957edcfe Mon Sep 17 00:00:00 2001
+From: Ming Liu <ming.liu@toradex.com>
+Date: Thu, 15 Feb 2024 21:29:01 +0100
+Subject: [PATCH] themes: only install spinner
+
+We dont really need other themes, this can save some space in
+rootfs/initramfs.
+
+Upstream-Status: Inappropriate [embedded specific]
+
+Signed-off-by: Ming Liu <ming.liu@toradex.com>
+---
+ themes/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/themes/Makefile.am b/themes/Makefile.am
+index 8e4566e..40c92c0 100644
+--- a/themes/Makefile.am
++++ b/themes/Makefile.am
+@@ -1,2 +1,2 @@
+-SUBDIRS = spinfinity fade-in text details solar glow script spinner tribar bgrt
++SUBDIRS = spinner
+ MAINTAINERCLEANFILES = Makefile.in
+-- 
+2.34.1
+

--- a/recipes-core/plymouth/plymouth_%.bbappend
+++ b/recipes-core/plymouth/plymouth_%.bbappend
@@ -2,11 +2,12 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://0001-disable-boot-splash-later.patch \
+    file://0001-themes-only-install-spinner.patch \
     file://torizonlogo-white.png \
     file://spinner.plymouth \
 "
 
-PACKAGECONFIG = "pango drm"
+PACKAGECONFIG = "drm"
 
 EXTRA_OECONF += "--with-udev --with-runtimedir=/run"
 


### PR DESCRIPTION
plymouth has a dependent chain like:
```
plymouth -> pango -> cairo -> virtual/egl, virtual/egl2
```

When PACKAGECONFIG 'pango' is enabled, it leads to all the above packages installed to initramfs-ostree-torizon-image, as a result, the initramfs size is 32M for apalis-imx8 machines.

While PACKAGECONFIG 'pango' is needed only for text rendering of user prompts (allowing user to input passwd and so on), we dont really need it, let's drop it.

Also we are only using spinner theme, let's drop the other themes.

By doing this, the initramfs size for a apalis-imx8 machine is reduced to 16M from 32M.

Fix: https://github.com/torizon/meta-toradex-torizon/issues/16