### PR TITLE
neofetch: add info func for container engine

### DIFF
--- a/recipes-devtools/neofetch/files/0001-neofetch-add-info-func-for-container-engine.patch
+++ b/recipes-devtools/neofetch/files/0001-neofetch-add-info-func-for-container-engine.patch
@@ -1,0 +1,68 @@
+From 851319436beaae97badbd7e8998ea19e7de10a17 Mon Sep 17 00:00:00 2001
+From: Ming Liu <ming.liu@toradex.com>
+Date: Mon, 19 Feb 2024 13:01:14 +0100
+Subject: [PATCH] neofetch: add info func for container engine
+
+Add a info function to print out container engine and its version by
+checking /etc/os-release for VARIANT.
+
+Also fix a invalid shell information in OE, sh is a symbolic link to
+bash.bash but not bash in OE, handle that case by checking
+BASH_VERSION, in case that's present, treat sh as bash.
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Ming Liu <ming.liu@toradex.com>
+---
+ neofetch | 21 ++++++++++++++++++++-
+ 1 file changed, 20 insertions(+), 1 deletion(-)
+
+diff --git a/neofetch b/neofetch
+index b453850..8b245f2 100755
+--- a/neofetch
++++ b/neofetch
+@@ -59,6 +59,7 @@ print_info() {
+     info "OS" distro
+     info "Host" model
+     info "Kernel" kernel
++    info "Container Engine" container_engine
+     info "Uptime" uptime
+     info "Packages" packages
+     info "Shell" shell
+@@ -1384,6 +1385,17 @@ get_kernel() {
+         esac
+ }
+ 
++get_container_engine() {
++    source /etc/os-release
++    case $VARIANT in
++        Podman|Docker)
++            VARIANT_VERSION="$(docker --version | cut -d " " -f3)"
++            VARIANT_VERSION="${VARIANT_VERSION%,}"
++            container_engine="$VARIANT ${VARIANT_VERSION}"
++        ;;
++    esac
++}
++
+ get_uptime() {
+     # Get uptime in seconds.
+     case $os in
+@@ -1638,7 +1650,14 @@ get_shell() {
+             shell+=${BASH_VERSION/-*}
+         ;;
+ 
+-        sh|ash|dash|es) ;;
++        sh)
++            if [[ $BASH_VERSION ]]; then
++                BASH_VERSION=$("$SHELL" -c "printf %s \"\$BASH_VERSION\"")
++                shell="bash ${BASH_VERSION/-*}"
++            fi
++        ;;
++
++        ash|dash|es) ;;
+ 
+         *ksh)
+             shell+=$("$SHELL" -c "printf %s \"\$KSH_VERSION\"")
+-- 
+2.34.1
+

--- a/recipes-devtools/neofetch/neofetch_7.1.0.bb
+++ b/recipes-devtools/neofetch/neofetch_7.1.0.bb
@@ -14,6 +14,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.md;md5=d300b86297c170b6498705fbb6794e3f"
 SRC_URI="\
 	git://github.com/dylanaraps/neofetch.git;protocol=https;branch=master \
 	file://0001-Add-TorizonCore-OS.patch \
+	file://0001-neofetch-add-info-func-for-container-engine.patch \
 "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Add a info function to print out container engine and its version by checking /etc/os-release for VARIANT.

Also fix a invalid shell information in OE, sh is a symbolic link to bash.bash instead of bash in OE, handle that case by checking BASH_VERSION, provided that's present, treat sh as bash.

before the change, neofetch output:

```
OS: TorizonCore 6.6.0-devel-20240219121314+build.0 (kirkstone) aarch64
Kernel: 5.15.124-6.6.0-devel+git.f0e7afd5948f
Uptime: 1 min
Shell: sh
Resolution: 1024x768
Terminal: /dev/pts/0
CPU: (4)
Memory: 90MiB / 1989MiB
```

after the change, neofetch output:

```
OS: TorizonCore 6.6.0-devel-20240219121314+build.0 (kirkstone) aarch64
Kernel: 5.15.124-6.6.0-devel+git.f0e7afd5948f
Container Engine: Podman 4.8.2
Uptime: 1 min
Shell: bash 5.1.16
Resolution: 1024x768
Terminal: /dev/pts/0
CPU: (4)
Memory: 90MiB / 1989MiB
```

Fix: https://github.com/torizon/meta-toradex-torizon/issues/19