### PR TITLE
neofetch: set CLEANBROKEN to 1

### DIFF
--- a/recipes-devtools/neofetch/neofetch_7.1.0.bb
+++ b/recipes-devtools/neofetch/neofetch_7.1.0.bb
@@ -22,6 +22,8 @@ S = "${WORKDIR}/git"
 SRCREV="60d07dee6b76769d8c487a40639fb7b5a1a7bc85"
 PV = "7.1.0+git${SRCPV}"
 
+CLEANBROKEN = "1"
+
 do_install(){	
 	install -d ${D}${bindir}
 	install -m 0755 ${S}/neofetch ${D}${bindir}


### PR DESCRIPTION
neofetch's Makefile does not have a clean target in it, let's set CLEANBROKEN to avoid breaking do_configure.

Fix: https://github.com/torizon/meta-toradex-torizon/issues/25