### PR TITLE
meta: dont check VARIANT to get container engine

### DIFF
--- a/classes/image_type_torizon.bbclass
+++ b/classes/image_type_torizon.bbclass
@@ -182,24 +182,27 @@ ROOTFS_POSTPROCESS_COMMAND += "tweak_os_release_variant;"
 tweak_os_release_variant () {
 	if [ -n "${IMAGE_VARIANT}" ]; then
 		sed -i -e "s/^VARIANT=.*$/VARIANT=\"${IMAGE_VARIANT}\"/g" ${IMAGE_ROOTFS}${sysconfdir}/os-release
-
-		if [ "${IMAGE_VARIANT}" = "Docker" ]; then
-			# We build docker-compose as a standalone binary in docker-compose recipe,
-			# which is installed as ${bindir}/docker-compose, but we'd also like to
-			# allow it to be run as a docker plugin 'docker compose', create the link
-			# to support that.
-			install -d ${IMAGE_ROOTFS}${nonarch_libdir}/docker/cli-plugins
-			ln -sf ${bindir}/docker-compose ${IMAGE_ROOTFS}${nonarch_libdir}/docker/cli-plugins/docker-compose
-		fi
-
-		if [ "${IMAGE_VARIANT}" = "Podman" ]; then
-			# Allow torizon user to execute podman without password
-			echo >> ${IMAGE_ROOTFS}${sysconfdir}/sudoers.d/50-torizon
-			echo "# torizon user can execute podman without password" >> ${IMAGE_ROOTFS}${sysconfdir}/sudoers.d/50-torizon
-			echo "torizon ALL=(ALL) NOPASSWD:/usr/bin/podman" >> ${IMAGE_ROOTFS}${sysconfdir}/sudoers.d/50-torizon
-		fi
 	else
 		bbwarn "IMAGE_VARIANT is missing, would be better to define it for a TorizonCore image recipe."
+	fi
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "adjust_container_engines;"
+
+# Ajust rootfs for container engines
+adjust_container_engines () {
+	if [ -f ${IMAGE_ROOTFS}${bindir}/podman ]; then
+		# Allow torizon user to execute podman without password
+		echo >> ${IMAGE_ROOTFS}${sysconfdir}/sudoers.d/50-torizon
+		echo "# torizon user can execute podman without password" >> ${IMAGE_ROOTFS}${sysconfdir}/sudoers.d/50-torizon
+		echo "torizon ALL=(ALL) NOPASSWD:/usr/bin/podman" >> ${IMAGE_ROOTFS}${sysconfdir}/sudoers.d/50-torizon
+	elif [ -f ${IMAGE_ROOTFS}${bindir}/docker ]; then
+		# We build docker-compose as a standalone binary in docker-compose recipe,
+		# which is installed as ${bindir}/docker-compose, but we'd also like to
+		# allow it to be run as a docker plugin 'docker compose', create the link
+		# to support that.
+		install -d ${IMAGE_ROOTFS}${nonarch_libdir}/docker/cli-plugins
+		ln -sf ${bindir}/docker-compose ${IMAGE_ROOTFS}${nonarch_libdir}/docker/cli-plugins/docker-compose
 	fi
 }
 

--- a/recipes-containers/docker-integrity-checker/files/docker-integrity-checker.sh
+++ b/recipes-containers/docker-integrity-checker/files/docker-integrity-checker.sh
@@ -2,11 +2,10 @@
 
 echo "docker-compose service has failed."
 
-VARIANT=`sed -n 's/VARIANT=\"\(.*\)\"/\1/p' /etc/os-release`
-if [ "$VARIANT" = "Podman" ]; then
+if [ -f /usr/bin/podman ]; then
    # detect graphroot from /etc/containers/storage.conf
    GRAPH_ROOT=`sed -n "s/graphroot.*=.*\"\(.*\)\"/\1/p" /etc/containers/storage.conf`
-elif [ "$VARIANT" = "Docker" ]; then
+elif [ -f /usr/bin/docker ]; then
    GRAPH_ROOT="/var/lib/docker"
 else
    echo "No container engine is installed on this filesystem."

--- a/recipes-devtools/neofetch/files/0001-neofetch-add-info-func-for-container-engine.patch
+++ b/recipes-devtools/neofetch/files/0001-neofetch-add-info-func-for-container-engine.patch
@@ -1,10 +1,10 @@
-From 851319436beaae97badbd7e8998ea19e7de10a17 Mon Sep 17 00:00:00 2001
+From 6d7c1f16b6fa2cd99fb1771b3f2bf16411eefa8a Mon Sep 17 00:00:00 2001
 From: Ming Liu <ming.liu@toradex.com>
 Date: Mon, 19 Feb 2024 13:01:14 +0100
 Subject: [PATCH] neofetch: add info func for container engine
 
 Add a info function to print out container engine and its version by
-checking /etc/os-release for VARIANT.
+checking podman/docker binary file.
 
 Also fix a invalid shell information in OE, sh is a symbolic link to
 bash.bash but not bash in OE, handle that case by checking
@@ -14,11 +14,11 @@ Upstream-Status: Inappropriate [OE specific]
 
 Signed-off-by: Ming Liu <ming.liu@toradex.com>
 ---
- neofetch | 21 ++++++++++++++++++++-
- 1 file changed, 20 insertions(+), 1 deletion(-)
+ neofetch | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
 
 diff --git a/neofetch b/neofetch
-index b453850..8b245f2 100755
+index b4538502..e781bb24 100755
 --- a/neofetch
 +++ b/neofetch
 @@ -59,6 +59,7 @@ print_info() {
@@ -29,25 +29,22 @@ index b453850..8b245f2 100755
      info "Uptime" uptime
      info "Packages" packages
      info "Shell" shell
-@@ -1384,6 +1385,17 @@ get_kernel() {
+@@ -1384,6 +1385,14 @@ get_kernel() {
          esac
  }
  
 +get_container_engine() {
-+    source /etc/os-release
-+    case $VARIANT in
-+        Podman|Docker)
-+            VARIANT_VERSION="$(docker --version | cut -d " " -f3)"
-+            VARIANT_VERSION="${VARIANT_VERSION%,}"
-+            container_engine="$VARIANT ${VARIANT_VERSION}"
-+        ;;
-+    esac
++    if [ -f /usr/bin/podman ]; then
++        container_engine="podman $(docker --version | cut -d " " -f3)"
++    elif [ -f /usr/bin/docker ]; then
++        container_engine="docker $(docker --version | cut -d " " -f3 | sed 's/,//')"
++    fi
 +}
 +
  get_uptime() {
      # Get uptime in seconds.
      case $os in
-@@ -1638,7 +1650,14 @@ get_shell() {
+@@ -1638,7 +1647,14 @@ get_shell() {
              shell+=${BASH_VERSION/-*}
          ;;
  


### PR DESCRIPTION
VARIANT can be set by end users in image recipes, so it does not always equal to "Docker/Podman", let's avoid checking it to get container engine. Instead, change to check docker/podman binaries on OS, this is safe because podman and docker are conflicting with each other, so they would be present on a same OS.