### PR TITLE
initramfs-framework: add modules to support plymouth on AM62

### DIFF
--- a/recipes-core/initramfs-framework/files/50-am62-graphics.conf
+++ b/recipes-core/initramfs-framework/files/50-am62-graphics.conf
@@ -1,0 +1,12 @@
+pwm_tiehrpwm
+fb_sys_fops
+sysimgblt
+sysfillrect
+syscopyarea
+drm_kms_helper
+drm_dma_helper
+tidss
+display_connector
+tc358768
+ti_sn65dsi83
+lontium_lt8912b

--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -68,3 +68,24 @@ do_install:append:mx8-nxp-bsp() {
     install -d ${D}/etc/modules-load.d/
     install -m 0755 ${WORKDIR}/50-imx8-graphics.conf ${D}/etc/modules-load.d/50-imx8-graphics.conf
 }
+
+SRC_URI:append:ti-soc = " file://50-am62-graphics.conf"
+RDEPENDS:initramfs-module-kmod:append:ti-soc = " \
+    kernel-module-pwm-tiehrpwm \
+    kernel-module-fb-sys-fops \
+    kernel-module-sysimgblt \
+    kernel-module-sysfillrect \
+    kernel-module-syscopyarea \
+    kernel-module-drm-kms-helper \
+    kernel-module-drm-dma-helper \
+    kernel-module-tidss \
+    kernel-module-display-connector \
+    kernel-module-tc358768 \
+    kernel-module-ti-sn65dsi83 \
+    kernel-module-lontium-lt8912b \
+"
+
+do_install:append:ti-soc() {
+    install -d ${D}/etc/modules-load.d/
+    install -m 0755 ${WORKDIR}/50-am62-graphics.conf ${D}/etc/modules-load.d/50-am62-graphics.conf
+}


### PR DESCRIPTION
For AM62, plymouth wasn't able to show the splash screen due to the framebuffer not being ready on initramfs.

So we needed to add tidss module (and it's dependencies), pwm and DSI bridges modules to make it work with our DSI to LVDS adapter. With this modification, it also made required that we insert the necessary modules for the DSI to HDMI adapter to work, thats why we also see display_connector and the lontium module.

fixes #30