### PR TITLE
ostree: make OTA updates possible when composefs is employed

### DIFF
--- a/recipes-extended/ostree/ostree-2024.4/0001-deploy-Ensure-boot-directory-is-open-before-accessin.patch
+++ b/recipes-extended/ostree/ostree-2024.4/0001-deploy-Ensure-boot-directory-is-open-before-accessin.patch
@@ -1,0 +1,32 @@
+From 3f8dba21c5913b09e36f76215e77b7d6e7816453 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Tue, 12 Mar 2024 17:02:58 -0300
+Subject: [PATCH] deploy: Ensure boot directory is open before accessing it
+
+This fixes a bug in the (early) deployment pruning function which before
+tried to access the boot directory without opening it first.
+
+Upstream-Status: Accepted
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ src/libostree/ostree-sysroot-deploy.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/libostree/ostree-sysroot-deploy.c b/src/libostree/ostree-sysroot-deploy.c
+index df1254df..0af76f86 100644
+--- a/src/libostree/ostree-sysroot-deploy.c
++++ b/src/libostree/ostree-sysroot-deploy.c
+@@ -2624,6 +2624,9 @@ auto_early_prune_old_deployments (OstreeSysroot *self, GPtrArray *new_deployment
+   if (self->booted_deployment == NULL)
+     return TRUE;
+ 
++  if (!_ostree_sysroot_ensure_boot_fd (self, error))
++    return FALSE;
++
+   {
+     struct stat stbuf;
+     if (!glnx_fstatat (self->boot_fd, ".", &stbuf, 0, error))
+-- 
+2.25.1
+

--- a/recipes-extended/ostree/ostree-prepare-root.inc
+++ b/recipes-extended/ostree/ostree-prepare-root.inc
@@ -17,5 +17,8 @@ transient = ${PREP_ROOT_ETC_TRANSIENT}
 
 [composefs]
 enabled = ${PREP_ROOT_CFS_ENABLED}
+
+[sysroot]
+readonly = false
 EOF
 }

--- a/recipes-extended/ostree/ostree_2024.4.bbappend
+++ b/recipes-extended/ostree/ostree_2024.4.bbappend
@@ -13,6 +13,7 @@ SRC_URI:append = " \
     file://0001-update-default-grub-cfg-header.patch \
     file://0002-Add-support-for-the-fdtfile-variable-in-uEnv.txt.patch \
     file://0003-ostree-fetcher-curl-set-max-parallel-connections.patch \
+    file://0001-deploy-Ensure-boot-directory-is-open-before-accessin.patch \
     file://0001-mount-Allow-building-when-macro-MOUNT_ATTR_IDMAP-is-.patch \
     file://0002-mount-Allow-building-when-macro-LOOP_CONFIGURE-is-no.patch \
 "


### PR DESCRIPTION
Minor changes that make OTA updates work with secure-boot images having `composefs` enabled.

See the commit message for details.

Resolves #40
