### PR TITLE
linux: include erofs scc/cfg from linux-toradex-kmeta.inc

### DIFF
--- a/recipes-kernel/linux/linux-toradex-kmeta.inc
+++ b/recipes-kernel/linux/linux-toradex-kmeta.inc
@@ -8,3 +8,5 @@ KMETAREPOSITORY="github.com/toradex/toradex-kernel-cache.git"
 KMETAPROTOCOL="https"
 
 SRC_URI += "git://${KMETAREPOSITORY};protocol=${KMETAPROTOCOL};type=kmeta;name=meta;branch=${KMETABRANCH};destsuffix=${KMETA}"
+
+KERNEL_FEATURES:append:cfs-support = " features/erofs/erofs.scc"

--- a/recipes-kernel/linux/linux-torizon.inc
+++ b/recipes-kernel/linux/linux-torizon.inc
@@ -11,5 +11,3 @@ kernel_do_deploy:append() {
 	head=`git --git-dir=${S}/.git rev-parse --verify --short HEAD 2> /dev/null`
 	printf "%s" $head > ${DEPLOYDIR}/.kernel_scmversion
 }
-
-KERNEL_FEATURES:append:cfs-support = " features/erofs/erofs.scc"


### PR DESCRIPTION
linux-torizon.inc is being shared by linux-yocto and linux-toradex recipes, including erofs scc/cfg from there would break linux-yocto build since there is no features/erofs/erofs.scc file in yocto-kernel-cache.

Let's move it to linux-toradex-kmeta.inc.