### PR TITLE
rpcbind: fix a systemd dependency issue

### DIFF
--- a/recipes-extended/rpcbind/rpcbind/0001-rpcbind.service-run-after-systemd-tmpfiles-setup.patch
+++ b/recipes-extended/rpcbind/rpcbind/0001-rpcbind.service-run-after-systemd-tmpfiles-setup.patch
@@ -1,0 +1,29 @@
+From 2a28043f82f781a5fdf988123f2309442964918d Mon Sep 17 00:00:00 2001
+From: Ming Liu <ming.liu@toradex.com>
+Date: Thu, 21 Mar 2024 14:01:12 +0100
+Subject: [PATCH] rpcbind.service: run after systemd-tmpfiles-setup.service
+
+This ensures /var/run present when rpcbind runs.
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Ming Liu <ming.liu@toradex.com>
+---
+ systemd/rpcbind.service.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/systemd/rpcbind.service.in b/systemd/rpcbind.service.in
+index f45ee1e..a707fc4 100644
+--- a/systemd/rpcbind.service.in
++++ b/systemd/rpcbind.service.in
+@@ -8,6 +8,7 @@ RequiresMountsFor=@statedir@
+ # rpcbind.socket, no matter how this unit is started.
+ Requires=rpcbind.socket
+ Wants=rpcbind.target
++After=systemd-tmpfiles-setup.service
+ 
+ [Service]
+ Type=notify
+-- 
+2.34.1
+

--- a/recipes-extended/rpcbind/rpcbind_%.bbappend
+++ b/recipes-extended/rpcbind/rpcbind_%.bbappend
@@ -1,3 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI:append:sota = " file://0001-rpcbind.service-run-after-systemd-tmpfiles-setup.patch"
+
 # we are using nss-altfiles and /etc/passwd and related files are palced in 
 # /usr/lib/
 PACKAGECONFIG:append = ' ${@bb.utils.contains("DISTRO_FEATURES", "stateless-system", "nss-altfiles", "", d)}'


### PR DESCRIPTION
rpcbind.service must run after systemd-tmpfiles-setup.service, or else /var/run might not be created yet when rpcbind starts, which leads to a runtime issue.