### PR TITLE
Initial integration of authenticity (fs-verity) capability into the system (disabled atm)

### DIFF
--- a/classes/image_type_torizon.bbclass
+++ b/classes/image_type_torizon.bbclass
@@ -14,7 +14,11 @@ python() {
         d.setVar('TEZI_CONFIG_FORMAT', torizon_tezi)
 }
 
-TEZI_ROOT_FSOPTS:append:torizon-signed = " -O verity"
+# TODO: Consider always enabling verity.
+#       This would facilitate upgrades from "tdx-signed" to "torizon-signed";
+#       If not done beforehand, the upgrade process would require running
+#       "tune2fs -O verity" on the device.
+TEZI_ROOT_FSOPTS:append:cfs-signed = " -O verity"
 
 python adjust_tezi_artifacts() {
     artifacts = d.getVar('TEZI_ARTIFACTS').replace(d.getVar('KERNEL_IMAGETYPE'), '').replace(d.getVar('KERNEL_DEVICETREE'), '')

--- a/classes/image_type_torizon.bbclass
+++ b/classes/image_type_torizon.bbclass
@@ -117,6 +117,36 @@ EXTRA_OSTREE_COMMIT = " \
 
 IMAGE_CMD:ostreecommit[vardepsexclude] += "EXTRA_OSTREE_COMMIT OSTREE_COMMIT_SUBJECT"
 
+require recipes-extended/ostree/gen-cfs-keys.inc
+
+generate_cfs_keys[lockfiles] += "${DEPLOY_DIR_IMAGE}/cfskeys.lock"
+generate_cfs_keys() {
+    gen_cfs_keys
+}
+
+CFS_OSTREECOMMIT_PREFUNCS_COND ?= " generate_cfs_keys"
+CFS_OSTREECOMMIT_PREFUNCS ?= \
+    "${@d.getVar('CFS_OSTREECOMMIT_PREFUNCS_COND') if 'cfs-signed' in d.getVar('OVERRIDES') else ''}"
+
+CFS_OSTREECOMMIT_DEPENDS_COND ?= "\
+    coreutils-native:do_populate_sysroot \
+    openssl-native:do_populate_sysroot \
+"
+CFS_OSTREECOMMIT_DEPENDS ?= \
+    "${@d.getVar('CFS_OSTREECOMMIT_DEPENDS_COND') if 'cfs-signed' in d.getVar('OVERRIDES') else ''}"
+
+CFS_OSTREECOMMIT_FILE_CHECKSUMS ?= "${@cfs_get_key_file_checksums(d)}"
+
+do_image_ostreecommit[prefuncs] += "${CFS_OSTREECOMMIT_PREFUNCS}"
+do_image_ostreecommit[depends] += "${CFS_OSTREECOMMIT_DEPENDS}"
+do_image_ostreecommit[file-checksums] += "${CFS_OSTREECOMMIT_FILE_CHECKSUMS}"
+
+EXTRA_OSTREE_COMMIT:append:cfs-signed = "\
+    --generate-composefs-metadata \
+    --sign-from-file=${CFS_SIGN_KEYDIR}/${CFS_SIGN_KEYNAME}.sec \
+    --sign-type=ed25519 \
+"
+
 do_image_ostreecommit[postfuncs] += " generate_diff_file"
 generate_diff_file[lockfiles] += "${OSTREE_REPO}/ostree.lock"
 

--- a/classes/image_type_torizon.bbclass
+++ b/classes/image_type_torizon.bbclass
@@ -167,6 +167,16 @@ generate_diff_file () {
     fi
 }
 
+# Enable composefs and fsverity on the deployed ostree repo; setting
+# "ex-integrity.fsverity" to "maybe" rather than "true" is important here
+# because it allows the build to succeed on a host not having fsverity support
+# while causing ostree to enable fsverity upon deployments on the device (which
+# would have the support).
+#
+# TODO: Review this on bumping ostree (this is very likely to change).
+OSTREE_OTA_REPO_CONFIG:append:cfs-support = " ex-integrity.composefs:true"
+OSTREE_OTA_REPO_CONFIG:append:cfs-signed = " ex-integrity.fsverity:maybe"
+
 IMAGE_DATETIME_FILES ??= " \
     ${sysconfdir}/issue \
     ${sysconfdir}/issue.net \

--- a/classes/torizon-signed.bbclass
+++ b/classes/torizon-signed.bbclass
@@ -13,7 +13,24 @@ inherit tdx-signed
 #   the system will be capable of booting from a legacy ostree deployment (based
 #   on hardlinks).
 #
-# - cfs-signed: TBD (not yet implemented)
+# - cfs-signed: Enable the actual ostree commit signing at build time (plus the
+#   addition of the composefs digest into the commit metadata) and the signature
+#   verification at runtime.
 #
-# TODO: Get rid of remaining uses of override "torizon-signed".
-DISTROOVERRIDES:append = ":cfs-support"
+DISTROOVERRIDES:append = ":cfs-support:cfs-signed"
+
+# Variables a user will likely want to set up:
+#
+# - CFS_GENERATE_KEYS: Set to "1" or "0" to enable or disable the composefs key
+#   pair generation at build time.
+#
+# - CFS_SIGN_KEYDIR: Directory where the composefs keys are kept (retrieved from
+#   or generated into when not found (if the key generation is enabled)).
+#
+# - CFS_SIGN_KEYNAME: Base name of the key files; the file holding the secret
+#   key will be named ${CFS_SIGN_KEYNAME}.sec and the one with the public key
+#   will be ${CFS_SIGN_KEYNAME}.pub.
+#
+CFS_GENERATE_KEYS ?= "1"
+CFS_SIGN_KEYDIR ?= "${TOPDIR}/keys/ostree"
+CFS_SIGN_KEYNAME ?= "cfs-dev"

--- a/classes/torizon-signed.bbclass
+++ b/classes/torizon-signed.bbclass
@@ -17,7 +17,8 @@ inherit tdx-signed
 #   addition of the composefs digest into the commit metadata) and the signature
 #   verification at runtime.
 #
-DISTROOVERRIDES:append = ":cfs-support:cfs-signed"
+# TODO: DISTROOVERRIDES:append = ":cfs-support:cfs-signed"
+DISTROOVERRIDES:append = ":cfs-support"
 
 # Variables a user will likely want to set up:
 #

--- a/recipes-core/initramfs-framework/files/composefs
+++ b/recipes-core/initramfs-framework/files/composefs
@@ -2,6 +2,10 @@
 # Copyright (C) 2023 Toradex AG.
 # Licensed on MIT
 
+SYSROOT_DIR="/sysroot"
+COMPOSEFS_NAME=".ostree.cfs"
+PREPARE_ROOT_CFG="/usr/lib/ostree/prepare-root.conf"
+
 composefs_enabled() {
 	return 0
 }
@@ -10,14 +14,105 @@ composefs_error() {
 	fatal "$@"
 }
 
-composefs_run() {
-	info "Running composefs script..."
+# We could replace this whole function by:
+#
+# $ ostree admin post-copy --sysroot="${SYSROOT_DIR}"
+#
+# However this would bring in the dependency of ostree to the ramdisk
+# which doesn't look like a good idea. Instead, here we depend only on
+# "findutils" and "fsverity-utils".
+#
+composefs_enable_fsverity_all() {
+	# Enable verity in all repository objects.
+	find "${SYSROOT_DIR}/ostree/repo/objects" -exec fsverity enable '{}' \; 2>/dev/null
 
-	if [ -d "$ROOTFS_DIR" ]; then
+	# And also on the composefs file of every deployment.
+	for cfsfile_ in "${SYSROOT_DIR}/ostree/deploy"/*/deploy/*/"${COMPOSEFS_NAME}"; do
+		fsverity enable "${cfsfile_}" 2>/dev/null
+	done
+}
+
+composefs_ensure_fsverity() {
+	# Do we need fsverity?
+	if [ ! -f "${PREPARE_ROOT_CFG}" ]; then
+		debug "No ${PREPARE_ROOT_CFG} found - assuming fsverity is not needed"
+		return 0
+	fi
+
+	# Allow setting composefs.enabled config via kernel cmdline;
+	# "cfs.enabled" could be set to false|true|signed or any other value accepted
+	# by "ostree-prepare-root".
+	if [ "${bootparam_cfs_enabled}" ]; then
+		debug "Overriding composefs.enabled: setting to ${bootparam_cfs_enabled}"
+		sed -i -e "/^\[composefs\]/,/^\[.*\]/ {s/^enabled[[:space:]]*=.*\$/enabled = ${bootparam_cfs_enabled}/}" "${PREPARE_ROOT_CFG}"
+	fi
+
+	# Check configuration key composefs.enabled; this could be set to true|false|signed.
+	enabled="$(sed -n -e '/^\[composefs\]/,/^\[.*\]/ {s/^enabled[[:space:]]*=[[:space:]]*\([^[:space:]]*\)/\1/p}' "${PREPARE_ROOT_CFG}")"
+	debug "composefs.enabled=${enabled}"
+	if [ "${enabled}" != "signed" ]; then
+		debug "composefs signing is not enabled in ${PREPARE_ROOT_CFG}"
+		return 0
+	fi
+
+	if [ -z "${bootparam_ostree}" ]; then
+		debug "ostree= parameter not passed in kernel cmdline"
+		return 0
+	fi
+
+	# Determine deployment being booted from kernel cmdline:
+	deployment="$(realpath -e "${SYSROOT_DIR}${bootparam_ostree}" 2>/dev/null)"
+	cfsfile="${deployment}/${COMPOSEFS_NAME}"
+	lockfile="${cfsfile}.rdlock"
+
+	if [ -z "${deployment}" ]; then
+		debug "Could not determine current deployment (ostree=${bootparam_ostree})"
+		return 1
+	fi
+
+	# We want to enable fsverity in two cases:
+	#
+	# - If the lockfile exists (fsverity enabling operation may have been interrupted).
+	# - If fsverity is not enabled on the .cfs file.
+	#
+	if [ ! -f "${lockfile}" ] && fsverity measure "${cfsfile}" >/dev/null 2>/dev/null; then
+		debug "fsverity is already enabled in storage"
+		return 0
+	fi
+
+	# Stretch protected by a lockfile.
+	# ---
+	touch "${lockfile}" || return 1
+
+	msg "Enabling fsverity on ostree repository (this may take a while)..."
+
+	t0="$(date '+%s')"
+	composefs_enable_fsverity_all
+	t1="$(date '+%s')"
+
+	# ---
+	rm "${lockfile}"
+
+	# Final result comes from measuring the composefs file (again):
+	if fsverity measure "${cfsfile}" >/dev/null 2>/dev/null; then
+		msg "Enabling fsverity succeeded (after $((t1 - t0)) seconds)."
+	else
+		msg "Enabling fsverity failed (system will not boot)."
+		return 1
+	fi
+
+	return 0
+}
+
+composefs_run() {
+	debug "Running composefs script..."
+
+	if [ -d "${ROOTFS_DIR}" ]; then
 		# When built with composefs support ostree-prepare-root will
 		# look for objects under /sysroot which is actually the rootfs
 		# directory in the ramdisk.
-		ln -sf "$ROOTFS_DIR" /sysroot
+		ln -sf "${ROOTFS_DIR}" "${SYSROOT_DIR}"
+		composefs_ensure_fsverity
 	else
 		debug "No rootfs has been set"
 	fi

--- a/recipes-core/initramfs-framework/files/composefs
+++ b/recipes-core/initramfs-framework/files/composefs
@@ -14,6 +14,37 @@ composefs_error() {
 	fatal "$@"
 }
 
+# $1: number of currently processed items
+# $2: total number of items to process
+# $3: (optional) when set to "1", a newline is added at the end
+composefs_progress() {
+	bar_cur="${1}"
+	bar_tot="${2}"
+	bar_end="${3}"
+
+	bar_curtm="$(date '+%s')"
+	bar_updtm="${bar_updtm:-0}"
+	bar_difftm="$((bar_curtm - bar_updtm))"
+	if [ "${bar_difftm}" -lt 1 ] && [ "${bar_end}" != "1" ]; then
+		# Update only once every second
+		return
+	fi
+	bar_updtm="$(date '+%s')"
+
+	bar_len="50"
+	bar_done="$((bar_len * bar_cur / bar_tot))"
+	bar_todo="$((bar_len - bar_done))"
+	bar_str1="$(printf "%*s" ${bar_done} | tr ' ' '=')"
+	bar_str2="$(printf "%*s" ${bar_todo} | tr ' ' '.')"
+	bar_str3="$(printf "%d" ${bar_cur})"
+	bar_str4="$(printf "%d" ${bar_tot})"
+
+	bar_str="$(printf "\rProgress: [%s%s] (%5s/%5s)" "${bar_str1}" "${bar_str2}" "${bar_str3}" "${bar_str4}")"
+
+	msg -n "${bar_str}"
+	[ "${bar_end}" = "1" ] && msg ""
+}
+
 # We could replace this whole function by:
 #
 # $ ostree admin post-copy --sysroot="${SYSROOT_DIR}"
@@ -23,8 +54,17 @@ composefs_error() {
 # "findutils" and "fsverity-utils".
 #
 composefs_enable_fsverity_all() {
+	nfiles="$(find "${SYSROOT_DIR}/ostree/repo/objects" \! -type d | wc -l)"
+	count="0"
+
 	# Enable verity in all repository objects.
-	find "${SYSROOT_DIR}/ostree/repo/objects" -exec fsverity enable '{}' \; 2>/dev/null
+	find "${SYSROOT_DIR}/ostree/repo/objects" \! -type d | while read fname; do
+		composefs_progress "${count}" "${nfiles}"
+		fsverity enable "${fname}" 2>/dev/null
+		count=$((count + 1))
+	done
+
+	composefs_progress "${nfiles}" "${nfiles}" "1"
 
 	# And also on the composefs file of every deployment.
 	for cfsfile_ in "${SYSROOT_DIR}/ostree/deploy"/*/deploy/*/"${COMPOSEFS_NAME}"; do
@@ -70,7 +110,7 @@ composefs_ensure_fsverity() {
 		return 1
 	fi
 
-	# We want to enable fsverity in two cases:
+	# We want to enable fsverity in the following cases:
 	#
 	# - If the lockfile exists (fsverity enabling operation may have been interrupted).
 	# - If fsverity is not enabled on the .cfs file.
@@ -84,7 +124,9 @@ composefs_ensure_fsverity() {
 	# ---
 	touch "${lockfile}" || return 1
 
-	msg "Enabling fsverity on ostree repository (this may take a while)..."
+	msg ""
+	msg "Enabling fsverity on the ostree repository - this may take a few minutes."
+	msg ""
 
 	t0="$(date '+%s')"
 	composefs_enable_fsverity_all
@@ -95,8 +137,10 @@ composefs_ensure_fsverity() {
 
 	# Final result comes from measuring the composefs file (again):
 	if fsverity measure "${cfsfile}" >/dev/null 2>/dev/null; then
+		msg ""
 		msg "Enabling fsverity succeeded (after $((t1 - t0)) seconds)."
 	else
+		msg ""
 		msg "Enabling fsverity failed (system will not boot)."
 		return 1
 	fi

--- a/recipes-core/initramfs-framework/files/plymouth
+++ b/recipes-core/initramfs-framework/files/plymouth
@@ -25,7 +25,7 @@ plymouth_run() {
 	if [ "$bootparam_plymouth_debug" = "true" ]; then
 		PLYMOUTH_ARGS="--debug"
 	fi
-	PLYMOUTH_ARGS="${PLYMOUTH_ARGS} --mode=boot --pid-file=/run/plymouth/pid --attach-to-session"
+	PLYMOUTH_ARGS="${PLYMOUTH_ARGS} --mode=boot --pid-file=/run/plymouth/pid"
 	mkdir /dev/pts
 	mount -t devpts devpts /dev/pts
 	/usr/sbin/plymouthd ${PLYMOUTH_ARGS}

--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -37,6 +37,9 @@ FILES:initramfs-module-composefs = "\
     /init.d/94-composefs \
     ${nonarch_libdir}/ostree/prepare-root.conf \
 "
+FILES:initramfs-module-composefs:append:cfs-signed = "\
+    ${sysconfdir}/ostree/initramfs-root-binding.key \
+"
 
 SUMMARY:initramfs-module-kmod = "initramfs support for loading kernel modules"
 RDEPENDS:initramfs-module-kmod = "${PN}-base"
@@ -63,6 +66,36 @@ do_install:append:cfs-support() {
     install -d ${D}${nonarch_libdir}/ostree/
     install -m 0644 /dev/null ${D}${nonarch_libdir}/ostree/prepare-root.conf
     write_prepare_root_config ${D}${nonarch_libdir}/ostree/prepare-root.conf
+}
+
+require recipes-extended/ostree/gen-cfs-keys.inc
+
+generate_cfs_keys[lockfiles] += "${DEPLOY_DIR_IMAGE}/cfskeys.lock"
+generate_cfs_keys() {
+    gen_cfs_keys
+}
+
+CFS_INSTALL_PREFUNCS_COND ?= " generate_cfs_keys"
+CFS_INSTALL_PREFUNCS ?= \
+    "${@d.getVar('CFS_INSTALL_PREFUNCS_COND') if 'cfs-signed' in d.getVar('OVERRIDES') else ''}"
+CFS_INSTALL_DEPENDS_COND ?= "\
+    coreutils-native:do_populate_sysroot \
+    openssl-native:do_populate_sysroot \
+"
+CFS_INSTALL_DEPENDS ?= \
+    "${@d.getVar('CFS_INSTALL_DEPENDS_COND') if 'cfs-signed' in d.getVar('OVERRIDES') else ''}"
+
+CFS_INSTALL_FILE_CHECKSUMS ?= "${@cfs_get_key_file_checksums(d)}"
+
+do_install[prefuncs] += "${CFS_INSTALL_PREFUNCS}"
+do_install[depends] += "${CFS_INSTALL_DEPENDS}"
+do_install[file-checksums] += "${CFS_INSTALL_FILE_CHECKSUMS}"
+
+do_install:append:cfs-signed() {
+    # Bundled into initramfs-module-composefs package:
+    install -d ${D}${sysconfdir}/ostree/
+    install -m 0644 ${CFS_SIGN_KEYDIR}/${CFS_SIGN_KEYNAME}.pub \
+    	            ${D}${sysconfdir}/ostree/initramfs-root-binding.key
 }
 
 # Adding modules so plymouth can show the splash screen during boot

--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -33,6 +33,7 @@ FILES:initramfs-module-ostree = "/init.d/95-ostree"
 
 SUMMARY:initramfs-module-composefs = "initramfs support for booting composefs images"
 RDEPENDS:initramfs-module-composefs = "${PN}-base kernel-module-erofs kernel-module-overlay"
+RDEPENDS:initramfs-module-composefs:append:cfs-signed = " fsverity-utils"
 FILES:initramfs-module-composefs = "\
     /init.d/94-composefs \
     ${nonarch_libdir}/ostree/prepare-root.conf \

--- a/recipes-extended/ostree/gen-cfs-keys.inc
+++ b/recipes-extended/ostree/gen-cfs-keys.inc
@@ -1,0 +1,55 @@
+gen_cfs_keys0() {
+    local keydir="${1}"
+    local keyname="${2}"
+
+    local pubkey="${keydir}/${keyname}.pub"
+    local seckey="${keydir}/${keyname}.sec"
+
+    mkdir -p "${keydir}"
+
+    local pem="$(openssl genpkey -algorithm ed25519 -outform PEM)"
+    local pub="$(printf "%s" "${pem}" | openssl pkey -outform DER -pubout | tail -c 32 | base64)"
+    local seed="$(printf "%s" "${pem}" | openssl pkey -outform DER | tail -c 32 | base64)"
+
+    # Save secret key (concatenate seed and pub key); see libtest.sh in the ostree code base:
+    (printf "%s" "${seed}" | base64 -d && \
+     printf "%s" "${pub}"  | base64 -d) | base64 > "${seckey}"
+
+    # Save public key:
+    printf "%s" "${pub}" > "${pubkey}"
+}
+
+gen_cfs_keys() {
+    if [ -z "${CFS_SIGN_KEYDIR}" ] || [ -z "${CFS_SIGN_KEYNAME}" ] || [ -z "${CFS_GENERATE_KEYS}" ]; then
+        bbfatal "Secure boot signing not correctly set up."
+    fi
+
+    local pubkey="${CFS_SIGN_KEYDIR}/${CFS_SIGN_KEYNAME}.pub"
+    local seckey="${CFS_SIGN_KEYDIR}/${CFS_SIGN_KEYNAME}.sec"
+
+    if [ "${CFS_GENERATE_KEYS}" = "1" ]; then
+        if [ -f "${pubkey}" ] && [ -f "${seckey}" ]; then
+	    bbnote "Key pair \"${CFS_SIGN_KEYNAME}\" already exists; skipping generation."
+	else
+	    # Generate the key pair:
+	    bbnote "Generating key pair \"${CFS_SIGN_KEYNAME}\" (.pub, .sec)."
+	    gen_cfs_keys0 "${CFS_SIGN_KEYDIR}" "${CFS_SIGN_KEYNAME}"
+	fi
+    fi
+
+    if [ ! -f "${seckey}" ]; then
+        bbfatal "Could not find key file \"${seckey}\"."
+    fi
+}
+
+def cfs_get_key_file_checksums(d):
+    if "cfs-signed" not in d.getVar("OVERRIDES"):
+        return ""
+    seckey = os.path.join(d.getVar("CFS_SIGN_KEYDIR"),
+                          d.getVar("CFS_SIGN_KEYNAME") + ".sec")
+    pubkey = os.path.join(d.getVar("CFS_SIGN_KEYDIR"),
+                          d.getVar("CFS_SIGN_KEYNAME") + ".pub")
+    return " ".join([
+        seckey + (":True" if os.path.exists(seckey) else ":False"),
+        pubkey + (":True" if os.path.exists(pubkey) else ":False")
+    ])

--- a/recipes-extended/ostree/ostree-torizon.inc
+++ b/recipes-extended/ostree/ostree-torizon.inc
@@ -21,6 +21,9 @@ PACKAGECONFIG:remove = "gpgme"
 PACKAGECONFIG:append:cfs-support = " composefs"
 PACKAGECONFIG:remove:cfs-support = "static"
 
+# Ensure ed25519 is available for signing commits.
+PACKAGECONFIG:append:cfs-signed = " ed25519-libsodium"
+
 SYSTEMD_SERVICE:${PN} += "ostree-pending-reboot.path ostree-pending-reboot.service"
 
 def is_ti(d):

--- a/recipes-images/images/torizon-core-common.inc
+++ b/recipes-images/images/torizon-core-common.inc
@@ -113,7 +113,7 @@ PSEUDO_PASSWD:prepend = "${@bb.utils.contains('DISTRO_FEATURES', 'stateless-syst
 # from the list of supported IDs in the Tezi image
 TORADEX_PRODUCT_IDS:remove:colibri-imx6 = "0014 0016"
 
-CORE_IMAGE_BASE_INSTALL:append:torizon-signed = "\
+CORE_IMAGE_BASE_INSTALL:append:cfs-signed = "\
     fsverity-utils \
 "
 


### PR DESCRIPTION
This initial integration covers:

- Enabling commit signing in ostree;
- Generating the keys for signing as part of the build process;
- Adding the composefs image digest to the commit metadata and signing it;
- Saving the verification (public) key into the ramdisk;
- Ensuring fsverity is enabled on the repository upon boot;
- Asking ostree to check the deployment about to be booted with the key.

Please refer to the commit messages for further details.

Note: The commits are intentionally referring to an internal ticket (TOR-3379) because I didn't want GitHub to close #46 yet (until we actually finish the integration, which requires the kernel patches for fsverity).
