### PR TITLE
recipes-image: introduce ti-img-rogue-driver as dependency

### DIFF
--- a/recipes-images/images/torizon-core-common.inc
+++ b/recipes-images/images/torizon-core-common.inc
@@ -77,6 +77,10 @@ CORE_IMAGE_BASE_INSTALL:append:mx8-nxp-bsp = " \
     kernel-module-imx-gpu-viv \
 "
 
+CORE_IMAGE_BASE_INSTALL:append:verdin-am62 = " \
+    ti-img-rogue-driver \
+"
+
 nss_altfiles_set_users_groups () {
 	# Make a temporary directory to be used by pseudo to find the real /etc/passwd,/etc/group
 	pseudo_dir=${WORKDIR}/pseudo-rootfs${sysconfdir}


### PR DESCRIPTION
Commit c90cb38 dropped Pango as a dependency, which dropped the virtual/egl dependency which made the out-of-tree GPU stack for AM62 to never actually make into the final image.

This was detected using bisect and discovered due to the missing firmware files in /usr/lib/firmware in the rootfs, more specifically the rgx* binary blobs that the kernel module loads into the PVR core, which is done at runtime when the kernel module gets exercised with the correct IOCTLs (done by the libdrm component of the mesa-pvr userspace stack, present in the Torizon OS reference containers).

This commit re-introduce this dependency, much like b40b911.

Closes #49.