### PR TITLE
systemd-conf: re-enable systemd HW Watchdog for Verdin AM62

### DIFF
--- a/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/recipes-core/systemd/systemd-conf_%.bbappend
@@ -19,7 +19,3 @@ do_install:append() {
 
 	sed -i "s/@@MACHINE@@/${MACHINE}/g" ${D}${systemd_unitdir}/system.conf.d/10-${BPN}.conf
 }
-
-do_install:append:ti-soc() {
-	sed -i '$ d' ${D}${systemd_unitdir}/system.conf.d/10-${BPN}.conf
-}


### PR DESCRIPTION
This issue has been fixed by BSP
(https://lore.kernel.org/all/20240403212426.582727-1-jm@ti.com/), and now we can re-enable this watchdog.

closes #53