### PR TITLE
Bump SRCREV for Kernel cache and Aktualizr

### DIFF
--- a/recipes-kernel/linux/linux-toradex-kmeta.inc
+++ b/recipes-kernel/linux/linux-toradex-kmeta.inc
@@ -1,4 +1,4 @@
-SRCREV_meta = "fb591a9972b0e48dfbbe536d60cbe3806aedbb79"
+SRCREV_meta = "17baa943ac1ee6fb9dd68df0c2e6329202a79188"
 SRCREV_meta:use-head-next = "${AUTOREV}"
 
 KMETABRANCH = "kirkstone-6.x.y"

--- a/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
+++ b/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
@@ -14,7 +14,7 @@ SRC_URI = " \
   https://tuf-cli-releases.ota.here.com/cli-${GARAGE_SIGN_PV}.tgz;unpack=0;name=garagesign \
 "
 
-SRCREV = "171aba3cb52388ecadef577724d94307f878253f"
+SRCREV = "1523e48df0c0ef68c8c05c519ef4c834ece7b46c"
 SRCREV:use-head-next = "${AUTOREV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Bumping SRCREV with use-head-next in preparation for Torizon 6.6.1 release.