### PR TITLE
disable Verdin AM62 Watchdog

### DIFF
--- a/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/recipes-core/systemd/systemd-conf_%.bbappend
@@ -19,3 +19,7 @@ do_install:append() {
 
 	sed -i "s/@@MACHINE@@/${MACHINE}/g" ${D}${systemd_unitdir}/system.conf.d/10-${BPN}.conf
 }
+
+do_install:append:ti-soc() {
+	sed -i '/^RuntimeWatchdogSec=/d' ${D}${systemd_unitdir}/system.conf.d/10-${BPN}.conf
+}


### PR DESCRIPTION
During release process we've re-enabled AM62 Watchdog, when we should have waited. The Kernel patch that fixes this issue is not present in the release, so we saw the reboot issues again.