### PR TITLE
torizon-core-common: add Alsa UCM configuration

### DIFF
--- a/recipes-images/images/torizon-core-common.inc
+++ b/recipes-images/images/torizon-core-common.inc
@@ -24,6 +24,7 @@ SPLASH = "plymouth"
 
 # Base packages
 CORE_IMAGE_BASE_INSTALL:append = " \
+    alsa-ucm-conf-tdx \
     cpufrequtils \
     curl \
     ethtool \


### PR DESCRIPTION
Due to BSP changes, ALSA configuration files were reworked into a new recipe.

Removing old config:
https://git.toradex.com/cgit/meta-toradex-nxp.git/commit/?h=kirkstone-6.x.y&id=54721dc86ece6b41d88f5e9de4262b575efc5393 https://git.toradex.com/cgit/meta-toradex-ti.git/commit/?h=kirkstone-6.x.y&id=d5d48dc1cc1ab54b3a498a0d5ea19646cab381ee

Adding new UCM config:
https://git.toradex.com/cgit/meta-toradex-bsp-common.git/commit/?h=kirkstone-6.x.y&id=5183100ea2bb3fe29702f96657e05f4e905433b5