### PR TITLE
networkmanager: unmanage any uap interface

### DIFF
--- a/recipes-connectivity/networkmanager/networkmanager/99-disable-uap.conf
+++ b/recipes-connectivity/networkmanager/networkmanager/99-disable-uap.conf
@@ -1,0 +1,5 @@
+[main]
+plugins=keyfile
+
+[keyfile]
+unmanaged-devices=interface-name:uap*

--- a/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -4,6 +4,7 @@ SRC_URI += "\
     file://0001-85-nm-unmanaged.rules-do-not-manage-docker-bridges.patch \
     file://toradex-nmconnection.conf \
     file://network.nmconnection.in \
+    file://99-disable-uap.conf \
 "
 
 # Depend on libedit as it has a more friendly license than readline (GPLv3)
@@ -26,4 +27,8 @@ do_install:append() {
     done
 
     chmod 0600 ${D}${sysconfdir}/NetworkManager/system-connections/network?.nmconnection
+}
+
+do_install:append {
+    install -m 0600 ${WORKDIR}/99-disable-uap.conf ${D}${sysconfdir}/NetworkManager/conf.d/99-disable-uap.conf
 }


### PR DESCRIPTION
Since NetworkManager can't play nice with uap interfaces, we're marking them as unmanaged, so this won't affect other connections.