### PR TITLE
image_type_torizon: parse layer information only once

### DIFF
--- a/classes/image_type_torizon.bbclass
+++ b/classes/image_type_torizon.bbclass
@@ -94,6 +94,10 @@ def get_layer_revision_information(d):
         e = sys.exc_info()[0]
         bb.warn("Failed to get layers information. Exception: {}".format(e))
 
+# Use immediate expansion here to avoid calling a somewhat costly function whenever
+# EXTRA_OSTREE_COMMIT is expanded.
+OSTREE_LAYER_REVISION_INFO := "${@get_layer_revision_information(d)}"
+
 EXTRA_OSTREE_COMMIT[vardepsexclude] = "OSTREE_KERNEL_SOURCE_META_DATA"
 EXTRA_OSTREE_COMMIT = " \
     --add-metadata-string=oe.machine="${MACHINE}" \
@@ -109,7 +113,7 @@ EXTRA_OSTREE_COMMIT = " \
     --add-metadata-string=oe.garage-target-name="${GARAGE_TARGET_NAME}" \
     --add-metadata-string=oe.garage-target-version="${GARAGE_TARGET_VERSION}" \
     --add-metadata-string=oe.sota-hardware-id="${SOTA_HARDWARE_ID}" \
-    --add-metadata=oe.layers="${@get_layer_revision_information(d)} " \
+    --add-metadata=oe.layers="${OSTREE_LAYER_REVISION_INFO}" \
 "
 
 IMAGE_CMD:ostreecommit[vardepsexclude] += "EXTRA_OSTREE_COMMIT OSTREE_COMMIT_SUBJECT"


### PR DESCRIPTION
Obtaining layer information from Git was performed whenever variable EXTRA_OSTREE_COMMIT was expanded which caused metadata parsing to be very slow (20-30 minutes). Since layer information is not supposed to change during build, here we get the layer information only once by using the immediate expansion operator provided by Bitbake. This brings the parsing time to the usual values (1-2 minutes on a good machine).

Resolves #61
