### PR TITLE
Change the CPU frequency tool from cpufrequtils to cpupower

### DIFF
--- a/recipes-images/images/torizon-core-common.inc
+++ b/recipes-images/images/torizon-core-common.inc
@@ -25,7 +25,7 @@ SPLASH = "plymouth"
 # Base packages
 CORE_IMAGE_BASE_INSTALL:append = " \
     alsa-ucm-conf-tdx \
-    cpufrequtils \
+    cpupower \
     curl \
     ethtool \
     evtest \


### PR DESCRIPTION
The image size increased 20 kB, the dependencies doensn't change.
The image was tested on a Verdin iMX8MP and cpupower tool is working.