### PR TITLE
fluent-bit: update v2.2.3 SRCREV with backport fix for CVE-2024-4323

### DIFF
--- a/recipes-extended/fluent-bit/fluent-bit_git.bb
+++ b/recipes-extended/fluent-bit/fluent-bit_git.bb
@@ -17,7 +17,7 @@ SRC_URI = "\
            file://fluent-bit.conf \
            file://emmc-health \
            "
-SRCREV = "18e5eda4b644723fcfbe6a46524de8430f856fe5"
+SRCREV = "be238e162cf97669fa3be3bfb6c7830a8dc6ce9d"
 PV = "2.2.3+git${SRCPV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
As per https://fluentbit.io/blog/2024/05/21/statement-on-cve-2024-4323-and-its-fix/ Fluent Bit version 2.2.3 has been updated with a backport fix for CVE-2024-4323.

Since our current Yocto recipe for Fluent Bit gets an outdated 2.2.3, updating SRCREV to get the fix should be enough. I did some quick tests and the updated recipe builds without problems.