### PR TITLE
setup-environment-internal: fix detection of integration manifests

### DIFF
--- a/scripts/setup-environment-internal
+++ b/scripts/setup-environment-internal
@@ -216,11 +216,12 @@ MANIFEST_FILE="${MANIFESTS}"/../manifest.xml
 INTEGRATION_BUILD=0
 
 if [ -L "$MANIFEST_FILE" ]; then
-    if [ "$(basename `readlink -f "$MANIFEST_FILE"`)" != "default.xml" ]; then
+    if [ "$(basename `readlink -f "$MANIFEST_FILE"`)" == "integration.xml" ] ||
+       [ "$(basename `readlink -f "$MANIFEST_FILE"`)" == "next.xml" ]; then
         INTEGRATION_BUILD=1
     fi
 else
-    if ! cat $MANIFEST_FILE | grep -q "torizoncore/default.xml"; then
+    if cat $MANIFEST_FILE | grep -q "torizoncore/integration.xml\|torizoncore/next.xml"; then
         INTEGRATION_BUILD=1
     fi
 fi


### PR DESCRIPTION
We were presuming that any manifest name other then 'default.xml' was one of our integration manifests, thus activating the 'use-head-next' override. What was also happening was that some clients that created a top level manifest to also sync their own layers, or even Common Torizon (which uses common.xml) were wrongly interpreted as integration manifests.

Now we explicitly check for 'integration.xml' and 'next.xml' as they're our integration layers.

Closes #86