### PR TITLE
systemd: Add script to recover from rescue or emergency mode

### DIFF
--- a/recipes-core/systemd/systemd/0003-emergency-rescue.service.in-Use-torizon-specific-scr.patch
+++ b/recipes-core/systemd/systemd/0003-emergency-rescue.service.in-Use-torizon-specific-scr.patch
@@ -1,0 +1,49 @@
+From 173e1fb5b196439dedbac85d01445e739193c558 Mon Sep 17 00:00:00 2001
+From: Jeremias Cordoba <jeremias.cordoba@toradex.com>
+Date: Wed, 10 Jul 2024 17:19:55 -0700
+Subject: [PATCH] emergency/rescue.service.in: Use torizon specific script
+ instead
+
+Torizon OS systems will be doing unattended updates in the field. If a
+failed update puts the device into emergency/rescue mode then it will
+require manual intervention instead of rolling back to a good state.
+
+Instead Use a script that can recover the device and rollback a bad update.
+
+Upstream-Status: Inappropriate [Torizon OS specific]
+
+Signed-off-by: Jeremias Cordoba <jeremias.cordoba@toradex.com>
+---
+ units/emergency.service.in | 2 +-
+ units/rescue.service.in    | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/units/emergency.service.in b/units/emergency.service.in
+index a126ad9bb1..da4a5e13d2 100644
+--- a/units/emergency.service.in
++++ b/units/emergency.service.in
+@@ -20,7 +20,7 @@ Before=rescue.service
+ Environment=HOME=/root
+ WorkingDirectory=-/root
+ ExecStartPre=-{{ROOTBINDIR}}/plymouth --wait quit
+-ExecStart=-{{ROOTLIBEXECDIR}}/systemd-sulogin-shell emergency
++ExecStart=-{{ROOTLIBEXECDIR}}/torizon-recover emergency
+ Type=idle
+ StandardInput=tty-force
+ StandardOutput=inherit
+diff --git a/units/rescue.service.in b/units/rescue.service.in
+index 74b933726e..94fb6bc5a4 100644
+--- a/units/rescue.service.in
++++ b/units/rescue.service.in
+@@ -19,7 +19,7 @@ Before=shutdown.target
+ Environment=HOME=/root
+ WorkingDirectory=-/root
+ ExecStartPre=-{{ROOTBINDIR}}/plymouth --wait quit
+-ExecStart=-{{ROOTLIBEXECDIR}}/systemd-sulogin-shell rescue
++ExecStart=-{{ROOTLIBEXECDIR}}/torizon-recover rescue
+ Type=idle
+ StandardInput=tty-force
+ StandardOutput=inherit
+-- 
+2.30.2
+

--- a/recipes-core/systemd/systemd/torizon-recover
+++ b/recipes-core/systemd/systemd/torizon-recover
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# make sure links for storage devices are available for a proper fw_printenv usage
+udevadm settle -t 30
+
+UPGRADE_AVAILABLE=$(fw_printenv upgrade_available | cut -d '=' -f 2)
+
+# Trigger reboot if it appears the system is doing an update
+if [ "$UPGRADE_AVAILABLE" = "1" ]; then
+    reboot
+    exit 0
+fi
+
+# Otherwise execute default command
+/usr/lib/systemd/systemd-sulogin-shell $1

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -5,7 +5,9 @@ ALTERNATIVE_PRIORITY[resolv-conf] = "300"
 SRC_URI:append = " \
     file://0001-tmpfiles-tmp.conf-reduce-cleanup-age-to-half.patch \
     file://0002-systemd-networkd-wait-online.service.in-use-any-by-d.patch \
+    file://0003-emergency-rescue.service.in-Use-torizon-specific-scr.patch \
     file://systemd-timesyncd-update.service \
+    file://torizon-recover \
 "
 
 SRC_URI:append:genericx86-64 = " file://0001-rules-whitelist-hd-devices.patch"
@@ -15,6 +17,7 @@ RRECOMMENDS:${PN}:remove = "os-release"
 
 # /var is expected to be rw, so drop volatile-binds service files
 RDEPENDS:${PN}:remove = "volatile-binds"
+RDEPENDS:${PN} += "bash"
 
 DEF_FALLBACK_NTP_SERVERS="time.cloudflare.com time1.google.com time2.google.com time3.google.com time4.google.com"
 
@@ -56,4 +59,6 @@ do_install:append() {
 
     # The default SaveIntervalSec (60 secs) is too frequent, change to 1 hour
     sed -i -e "s/^.*SaveIntervalSec.*$/SaveIntervalSec=3600/" ${D}${sysconfdir}/systemd/timesyncd.conf
+
+    install -m 755 ${WORKDIR}/torizon-recover ${D}${rootlibexecdir}/systemd
 }


### PR DESCRIPTION
Several services can trigger rescue or emergency mode on failure. If either mode is triggered after an OTA update the device will require manual intervention. This is not desirable for Torizon OS as updates should be able to recover on their own during failure.

Add a script that will trigger a reboot that will eventually cause a rollback if emergency or rescue mode is triggered while in the middle of an update.

Related-to: TOR-3390