### PR TITLE
Start using uptane-sign and bump to latest version

### DIFF
--- a/conf/distro/include/torizon.inc
+++ b/conf/distro/include/torizon.inc
@@ -32,6 +32,7 @@ PACKAGECONFIG:append:pn-${PREFERRED_PROVIDER_virtual/docker} = " seccomp"
 PACKAGECONFIG:append:pn-systemd = " seccomp"
 
 # SOTA
+GARAGE_SIGN_TOOL = "uptane-sign"
 OSTREE_OSNAME = "torizon"
 OSTREE_MULTI_DEVICETREE_SUPPORT = "1"
 SOTA_CLIENT_FEATURES:append = " ubootenv"

--- a/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
+++ b/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
@@ -2,16 +2,16 @@ SUMMARY = "Toradex implementation of the Aktualizr SOTA client"
 LICENSE = "MPL-2.0"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=815ca599c9df247a0c7f619bab123dad"
 
-GARAGE_SIGN_PV = "0.8.0"
-SRC_URI[garagesign.md5sum] = "40017561a4fe9ffcf57f2112ae4ea420"
-SRC_URI[garagesign.sha256sum] = "2bac2d50b551b7a6b1949fdb25424bc0bc457b2a9b119bd808fd22d922bb2324"
+UPTANE_SIGN_PV = "3.2.6"
+SRC_URI[uptanesign.md5sum] = "e8bc3dc4fd816cfa8aab16de7d56afdd"
+SRC_URI[uptanesign.sha256sum] = "cf97ea2bda7dd251cb18786b80741ee485ce2104d57329de2a3d8a4a8384f146"
 
 SRC_URI = " \
   gitsm://github.com/toradex/aktualizr.git;protocol=https;branch=toradex-master \
   file://aktualizr-torizon.service \
   file://gateway.url \
   file://root.crt \
-  https://github.com/uptane/ota-tuf/releases/download/v${GARAGE_SIGN_PV}/cli-${GARAGE_SIGN_PV}.tgz;unpack=0;name=garagesign \
+  https://github.com/uptane/ota-tuf/releases/download/v${UPTANE_SIGN_PV}/cli-${UPTANE_SIGN_PV}.tgz;unpack=0;name=uptanesign \
 "
 
 SRCREV = "0377fb86459855689365f173769e3b78c050f8c8"
@@ -37,7 +37,7 @@ PACKAGECONFIG[ostree] = "-DBUILD_OSTREE=ON,-DBUILD_OSTREE=OFF,ostree,"
 PACKAGECONFIG[ubootenv] = ",,u-boot-fw-utils,u-boot-fw-utils"
 PACKAGECONFIG:remove:class-native = "ubootenv"
 PACKAGECONFIG:class-native = "sota-tools"
-PACKAGECONFIG[sota-tools] = "-DBUILD_SOTA_TOOLS=ON -DGARAGE_SIGN_ARCHIVE=${UNPACKDIR}/cli-${GARAGE_SIGN_PV}.tgz, -DBUILD_SOTA_TOOLS=OFF,glib-2.0,"
+PACKAGECONFIG[sota-tools] = "-DBUILD_SOTA_TOOLS=ON -DGARAGE_SIGN_ARCHIVE=${UNPACKDIR}/cli-${UPTANE_SIGN_PV}.tgz -DGARAGE_SIGN_TOOL=${GARAGE_SIGN_TOOL}, -DBUILD_SOTA_TOOLS=OFF,glib-2.0,"
 
 PROVIDES += "aktualizr"
 RPROVIDES:${PN} += "aktualizr aktualizr-info aktualizr-shared-prov"


### PR DESCRIPTION
In order for us to be able to use `uptane-sign` we need some changes on `meta-updater`'s `classes/image_types_ostree.bbclass` and `classes/sota.bbclass`.  
On `classes/image_types_ostree.bbclass` I've changed the task `IMAGE_CMD:garagesign` to instead of using a hardcoded `garage-sign` to call `${GARAGE_SIGN_TOOL}`.
And `${GARAGE_SIGN_TOOL}` is being defined in `classes/sota.bbclass` with `garage-sign` as its default value. This made sense to me to not disrupt other users of this layer that might still be using `garage-sign`.
Then we go into `conf/distro/include/torizon.inc` and redefine `GARAGE_SIGN_TOOL` to `uptane-sign`.
These are the only changes made on those bbclasses, all else remains as is on `meta-updater`.

And on our Aktualizr recipe, I've bumped the version used to the latest (v3.2.4), and changed the variable names accordingly.

Related-to: TOR-3496