### PR TITLE
auto-provisioning.service: make it depend on system time sync

### DIFF
--- a/recipes-sota/auto-provisioning/auto-provisioning/auto-provisioning.service
+++ b/recipes-sota/auto-provisioning/auto-provisioning/auto-provisioning.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Automatically provision the device to the Platform Services
-After=network-online.target
+After=network-online.target systemd-time-wait-sync.service
 Wants=network-online.target
+Requires=systemd-time-wait-sync.service
 ConditionPathExists=/var/sota/auto-provisioning.json
 ConditionPathExists=!/var/sota/import/pkey.pem
 


### PR DESCRIPTION
Due to the device booting with an older system date, there was a race condition between auto-provisioning and the service that syncs the system time. If auto-provision would run first, the certificates would be invalid, because the current date is prior to theur validity, and the service script would fail.

Closes #90