### PR TITLE
linux-toradex-kmeta: refactor to be used with BSP's Kernel Cache

### DIFF
--- a/recipes-kernel/linux/linux-toradex-kmeta.inc
+++ b/recipes-kernel/linux/linux-toradex-kmeta.inc
@@ -1,10 +1,13 @@
-SRCREV_meta = "99e38525088a105d6e7d99bd0eb07c9880606d64"
-SRCREV_meta:use-head-next = "${AUTOREV}"
+SRCREV_torizon-meta = "99e38525088a105d6e7d99bd0eb07c9880606d64"
+SRCREV_torizon-meta:use-head-next = "${AUTOREV}"
 
-KMETABRANCH = "kirkstone-6.x.y"
-KMETA = "kernel-meta"
+KMETABRANCH = "scarthgap-7.x.y"
+KMETATORIZON = "torizon-kernel-meta"
 
 KMETAREPOSITORY="github.com/toradex/toradex-kernel-cache.git"
 KMETAPROTOCOL="https"
 
-SRC_URI += "git://${KMETAREPOSITORY};protocol=${KMETAPROTOCOL};type=kmeta;name=meta;branch=${KMETABRANCH};destsuffix=${KMETA}"
+SRC_URI += "git://${KMETAREPOSITORY};protocol=${KMETAPROTOCOL};type=kmeta;name=torizon-meta;branch=${KMETABRANCH};destsuffix=${KMETATORIZON}"
+
+## Compose Torizon top level .scc file and include it to our build.
+KERNEL_FEATURES += "bsp/${MACHINE}-${LINUX_KERNEL_TYPE}-torizon.scc"


### PR DESCRIPTION
Cherry-picking #105 into master.

Related-to: TOR-3534