### PR TITLE
torizon-base: add NXP's ISP support for iMX8 Plus downstream

### DIFF
--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -82,6 +82,10 @@ CORE_IMAGE_BASE_INSTALL:append:verdin-am62 = " \
     ti-img-rogue-driver \
 "
 
+CORE_IMAGE_BASE_INSTALL:append:mx8mp-nxp-bsp = " \
+    kernel-module-isp-vvcam \
+"
+
 nss_altfiles_set_users_groups () {
 	# Make a temporary directory to be used by pseudo to find the real /etc/passwd,/etc/group
 	pseudo_dir=${WORKDIR}/pseudo-rootfs${sysconfdir}


### PR DESCRIPTION
Related-to: TOR-3547