### PR TITLE
base-passwd: amend group numbers

### DIFF
--- a/recipes-core/base-passwd/base-passwd/0001-Add-TorizonCore-specific-groups.patch
+++ b/recipes-core/base-passwd/base-passwd/0001-Add-TorizonCore-specific-groups.patch
@@ -1,10 +1,11 @@
-From e7507f802575c4f9b81007e270fced2abcfbd5b0 Mon Sep 17 00:00:00 2001
+From a59e624753e1a7864f86c285c25a4f519bca376f Mon Sep 17 00:00:00 2001
 From: Sergio Prado <sergio.prado@toradex.com>
 Date: Thu, 28 Sep 2023 10:32:46 +0000
-Subject: [PATCH] Add TorizonCore specific groups
+Subject: [PATCH 1/2] Add TorizonCore specific groups
 
 Upstream-Status: Inappropriate [configuration]
 
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 Signed-off-by: Eduardo Ferreira <eduardo.barbosa@toradex.com>
 Signed-off-by: Sergio Prado <sergio.prado@toradex.com>
 Signed-off-by: Stefan Agner <stefan.agner@toradex.com>
@@ -13,10 +14,10 @@ Signed-off-by: Stefan Agner <stefan.agner@toradex.com>
  1 file changed, 6 insertions(+)
 
 diff --git a/group.master b/group.master
-index 5b622841be8f..f115390feecb 100644
+index e54fd1d..0fa81a3 100644
 --- a/group.master
 +++ b/group.master
-@@ -35,9 +35,15 @@
+@@ -35,9 +35,15 @@ sasl:*:45:
  plugdev:*:46:
  kvm:*:47:
  sgx:*:48:

--- a/recipes-core/base-passwd/base-passwd/0002-Adapt-group-numbers-to-match-the-static-assignment-i.patch
+++ b/recipes-core/base-passwd/base-passwd/0002-Adapt-group-numbers-to-match-the-static-assignment-i.patch
@@ -1,0 +1,54 @@
+From 83a5272353249b1ea06638eaa6b421bee7cab43a Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Sat, 24 Aug 2024 15:11:09 -0300
+Subject: [PATCH 2/2] Adapt group numbers to match the static assignment in
+ torizon
+
+Some Unix groups (input, kvm, sgx) defined in OpenEmbedded layers have
+numeric IDs that differ from the ones used by Torizon OS (as defined by
+the "torizon-static-group" file) which may lead to users created during
+build being assigned to wrong group numbers. Here we fix this situation
+by changing them to match the assignment in the torizon-static-group
+file; this is also helpful to ensure that group numbers remain the same
+as in previous releases of the OS.
+
+Upstream-Status: Inappropriate [configuration]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ group.master | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/group.master b/group.master
+index 0fa81a3..33d9ec7 100644
+--- a/group.master
++++ b/group.master
+@@ -12,7 +12,6 @@ uucp:*:10:
+ man:*:12:
+ proxy:*:13:
+ kmem:*:15:
+-input:*:19:
+ dialout:*:20:
+ fax:*:21:
+ voice:*:22:
+@@ -33,8 +32,6 @@ utmp:*:43:
+ video:*:44:
+ sasl:*:45:
+ plugdev:*:46:
+-kvm:*:47:
+-sgx:*:48:
+ gpio:*:49:
+ staff:*:50:
+ i2cdev:*:51:
+@@ -45,5 +42,8 @@ shutdown:*:70:
+ wheel:*:80:
+ nobody:*:99:
+ users:*:100:
++input:*:101:
++kvm:*:102:
+ render:*:103:
++sgx:*:104:
+ nogroup:*:65534:
+-- 
+2.25.1
+

--- a/recipes-core/base-passwd/base-passwd_%.bbappend
+++ b/recipes-core/base-passwd/base-passwd_%.bbappend
@@ -2,4 +2,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI += " \
     file://0001-Add-TorizonCore-specific-groups.patch \
+    file://0002-Adapt-group-numbers-to-match-the-static-assignment-i.patch \
 "


### PR DESCRIPTION
Patch master group file in order to set the numeric IDs of some Unix groups (input, kvm, sgx) to the same values they had in previous versions of Torizon OS and as defined by the static assignments file in the OS (torizon-static-group).

Related-to: TOR-3538
