### PR TITLE
networkmanager: unmanage any uap interface

### DIFF
--- a/recipes-connectivity/networkmanager/networkmanager/99-disable-uap.conf
+++ b/recipes-connectivity/networkmanager/networkmanager/99-disable-uap.conf
@@ -3,3 +3,4 @@ plugins=keyfile
 
 [keyfile]
 unmanaged-devices=interface-name:uap*
+

--- a/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -27,8 +27,7 @@ do_install:append() {
     done
 
     chmod 0600 ${D}${sysconfdir}/NetworkManager/system-connections/network?.nmconnection
+
+    install -m 0600 ${WORKDIR}/99-disable-uap.conf ${D}${sysconfdir}/NetworkManager/conf.d/99-disable-uap.conf
 }
 
-do_install:append() {
-    install -m 0600 ${UNPACKDIR}/99-disable-uap.conf ${D}${sysconfdir}/NetworkManager/conf.d/99-disable-uap.conf
-}


### PR DESCRIPTION
Since NetworkManager can't play nice with uap interfaces, we're marking them as unmanaged, so this won't affect other connections.

Merging the two 'do_install' tasks, since this is now a permanent solution.

Related-to: TOR-3545
Closes #108 