### PR TITLE
initramfs-framework: remove unnecessary kernel modules from ramfs

### DIFF
--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -117,12 +117,6 @@ do_install:append:mx8-nxp-bsp() {
 SRC_URI:append:ti-soc = " file://50-am62-graphics.conf"
 RDEPENDS:initramfs-module-kmod:append:ti-soc = " \
     kernel-module-pwm-tiehrpwm \
-    kernel-module-fb-sys-fops \
-    kernel-module-sysimgblt \
-    kernel-module-sysfillrect \
-    kernel-module-syscopyarea \
-    kernel-module-drm-kms-helper \
-    kernel-module-drm-dma-helper \
     kernel-module-tidss \
     kernel-module-display-connector \
     kernel-module-tc358768 \


### PR DESCRIPTION
After the bump to Kernel 6.6 we got a build error that some kernel modules could not be found. After checking TI Kernel config, either those configs were now builtin or non-existent, so they were removed.

Plymouth (boot splash screen) was tested and is working for both DSI to LVDS and DSI to HDMI.