### PR TITLE
Enable hardening on BSP images (scarthgap)

### DIFF
--- a/conf/distro/include/torizon.inc
+++ b/conf/distro/include/torizon.inc
@@ -86,3 +86,14 @@ PREFERRED_RPROVIDER_aktualizr-shared-prov = "aktualizr-torizon"
 
 # disable warning message from meta-security
 SKIP_META_SECURITY_SANITY_CHECK = "1"
+
+# Configure the "kernel command-line protection" for Torizon OS (relevant when
+# the tdx-signed class is in use).
+TOS_SECBOOT_REQUIRED_BOOTARGS ?= "root=LABEL=otaroot rootfstype=ext4 ${OSTREE_KERNEL_ARGS}"
+TDX_SECBOOT_REQUIRED_BOOTARGS:imx-generic-bsp:tdx-signed = "${TOS_SECBOOT_REQUIRED_BOOTARGS}"
+TDX_SECBOOT_REQUIRED_BOOTARGS:apalis-imx6:tdx-signed = "enable_wait_mode=off vmalloc=400M ${TOS_SECBOOT_REQUIRED_BOOTARGS}"
+TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx6:tdx-signed = "enable_wait_mode=off galcore.contiguousSize=50331648 ${TOS_SECBOOT_REQUIRED_BOOTARGS}"
+TDX_SECBOOT_REQUIRED_BOOTARGS:colibri-imx6ull-emmc:tdx-signed = "user_debug=30 ${TOS_SECBOOT_REQUIRED_BOOTARGS}"
+TDX_SECBOOT_REQUIRED_BOOTARGS:apalis-imx8:tdx-signed = "pci=nomsi ${TOS_SECBOOT_REQUIRED_BOOTARGS}"
+TDX_SECBOOT_REQUIRED_BOOTARGS:verdin-am62:tdx-signed = ""
+TDX_SECBOOT_REQUIRED_BOOTARGS:qemuarm64:tdx-signed = ""

--- a/conf/distro/include/torizon.inc
+++ b/conf/distro/include/torizon.inc
@@ -18,6 +18,9 @@ IMX_DEFAULT_BSP:upstream = "mainline"
 SDK_NAME_PREFIX = "${DISTRO}"
 SDK_VERSION = "${DISTRO_VERSION}"
 
+# Override shared by all torizon distros
+DISTROOVERRIDES .= ":torizon-distro"
+
 # Torizon machine specific overrides
 INHERIT += "torizon"
 

--- a/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
@@ -19,6 +19,8 @@ do_compile:append () {
         ${WORKDIR}/uEnv.txt.in > uEnv.txt
 }
 
+TDX_AMEND_BOOT_SCRIPT:torizon-distro = "0"
+
 do_install () {
     install -d ${D}${libdir}/ostree-boot
     install -m 0644 uEnv.txt ${D}${libdir}/ostree-boot/

--- a/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
@@ -4,17 +4,18 @@ SRC_URI:append = " \
     file://uEnv.txt.in \
 "
 
-# DISTRO_BOOT_PREDEF_FITCONF: String in this variable will be added by the boot script to the string
-# passed to 'bootm' when booting a FIT image. This can be leveraged to force some FIT configurations
-# (such as configurations representing device-tree overlays) to be used when booting.
-DISTRO_BOOT_PREDEF_FITCONF ??= ""
+# FITCONF_FDT_OVERLAYS: String in this variable will be added by the boot
+# script to the string passed to 'bootm' when booting a FIT image. This can
+# be leveraged to force some FIT configurations (such as configurations
+# representing device-tree overlays) to be used when booting.
+FITCONF_FDT_OVERLAYS ??= ""
 
 do_compile:append () {
     bbdebug 1 "Building uEnv.txt..."
     sed -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
         -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
         -e 's/@@KERNEL_DTB_PREFIX@@/${DTB_PREFIX}/' \
-        -e 's/@@DISTRO_BOOT_PREDEF_FITCONF@@/${DISTRO_BOOT_PREDEF_FITCONF}/' \
+        -e 's/@@FITCONF_FDT_OVERLAYS@@/${FITCONF_FDT_OVERLAYS}/' \
         ${WORKDIR}/uEnv.txt.in > uEnv.txt
 }
 

--- a/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
+++ b/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
@@ -1,7 +1,7 @@
 kernel_image_type=@@KERNEL_IMAGETYPE@@
 overlays_file="overlays.txt"
 otaroot=1
-fitconf_fdt_overlays="@@DISTRO_BOOT_PREDEF_FITCONF@@"
+fitconf_fdt_overlays="@@FITCONF_FDT_OVERLAYS@@"
 
 set_bootargs=env set bootcmd_args env set bootargs ${defargs} root=LABEL=otaroot rootfstype=ext4 ${bootargs} ${tdxargs}
 


### PR DESCRIPTION
This is part of the work of enabling hardening on BSP images and it depends on related work on layer `meta-toradex-bsp-common` and on [meta-toradex-security](https://github.com/toradex/meta-toradex-security/pull/63).

At the moment, changes to the former are under review by the BSP team and due to that I'm leaving this as draft to prevent the merge but it should be ready for review.
