### PR TITLE
avahi: make avahi depend on network-pre target

### DIFF
--- a/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/recipes-connectivity/avahi/avahi_%.bbappend
@@ -1,0 +1,6 @@
+do_install:append() {
+    # On Torizon we use avahi-daemon to setup the hostname. So we need to properly
+    # order it's service to only run after 'set-hostname.service' finishes.
+    sed -i '/^After=/ s/$/ network-pre.target/' ${D}${systemd_system_unitdir}/avahi-daemon.service
+    sed -i '/^Description=/a\Wants=network-pre.target' ${D}${systemd_system_unitdir}/avahi-daemon.service
+}


### PR DESCRIPTION
 Since avahi-daemon uses the hostname to create the address, it needs
to be correctly set beforehand.
And since 'set-hostname' service is already ordered to run before
network-pre, we can make sura avahi-daemon only runs aftter that target,
and this way we'll be sure to use the correct hostname.

Related-to: TOR-3562