### PR TITLE
set-hostname: fix service dependency on avahi

### DIFF
--- a/recipes-core/set-hostname/set-hostname_%.bbappend
+++ b/recipes-core/set-hostname/set-hostname_%.bbappend
@@ -1,3 +1,10 @@
+do_install:append() {
+    # On Torizon we use avahi-daemon to setup the hostname. So we need to properly
+    # order it's service to only run after 'set-hostname.service' finishes.
+    sed -i '/^Before=network-pre.target/ s/$/ avahi-daemon.service/' ${D}${systemd_system_unitdir}/set-hostname.service
+    sed -i '/^WantedBy=network.target/ s/$/ avahi-daemon.service/' ${D}${systemd_system_unitdir}/set-hostname.service
+}
+
 do_install:append:qemuarm64() {
     # Use the only rootdiski's PARTUUID as the serial number
     sed -i -e '/\/bin\/sh/ahexpartuuid="0x$(ls /dev/disk/by-partuuid | head -1 | tr - 1 | cut -c -8)"' ${D}${bindir}/sethostname


### PR DESCRIPTION
Since avahi-daemon uses the hostname to create the address, it needs to be correctly set beforehand.
By changing the set-hostname service to run before avahi-daemon service, we eliminate the race condition we have now and guarantee the correct hostname for avahi.

Related-to: TOR-3562