### PR TITLE
setup-environment-internal: add error message for too many arguments

### DIFF
--- a/scripts/setup-environment-internal
+++ b/scripts/setup-environment-internal
@@ -96,6 +96,7 @@ fi
 
 if [ $# -gt 1 ]; then
     usage
+    echo "ERROR: too many arguments ($*). Exiting..." >&2
     return 1
 fi
 


### PR DESCRIPTION
The script checks if the number of arguments is greater than 1 and prints the usage and exits. If the user does not check the script code it makes difficult to understand why the script is exiting.