### PR TITLE
torizon.inc: remove TCLIBCAPPEND variable

### DIFF
--- a/conf/distro/include/torizon.inc
+++ b/conf/distro/include/torizon.inc
@@ -2,8 +2,6 @@ require conf/distro/include/tdx-base.inc
 
 MAINTAINER = "Toradex Torizon OS Team <torizon.os@toradex.com>"
 
-TCLIBCAPPEND = ""
-
 COPY_LIC_MANIFEST = "1"
 COPY_LIC_DIRS = "1"
 


### PR DESCRIPTION
In oe-core the TCLIBCAPPEND variable was deprecated, so we need to remove it from our layer.

[1] https://git.openembedded.org/openembedded-core/commit/?id=992ba784c168710328749fd61a0e2869df519dea