### PR TITLE
fluent-bit: Setup include files for easy customization.

### DIFF
--- a/recipes-extended/fluent-bit/files/custom-empty.conf
+++ b/recipes-extended/fluent-bit/files/custom-empty.conf
@@ -1,0 +1,2 @@
+# Empty custom fluent bit config file
+# This exists so that the glob in fluent-bit.conf matches at least one file.

--- a/recipes-extended/fluent-bit/files/fluent-bit.conf
+++ b/recipes-extended/fluent-bit/files/fluent-bit.conf
@@ -89,3 +89,5 @@
     tls.key_file /var/sota/import/pkey.pem
     tls.crt_file /var/sota/import/client.pem
     Retry_Limit  10
+
+@INCLUDE /etc/fluent-bit/fluent-bit.d/custom-*.conf

--- a/recipes-extended/fluent-bit/fluent-bit_git.bb
+++ b/recipes-extended/fluent-bit/fluent-bit_git.bb
@@ -28,6 +28,7 @@ SRC_URI = "\
            file://fluent-bit.service \
            file://fluent-bit.conf \
            file://emmc-health \
+           file://custom-empty.conf \
            "
 SRCREV = "a6feacd6e92e08c0e5290f255864e70b12301fa8"
 
@@ -73,4 +74,6 @@ do_install:append() {
     install -d ${D}${sysconfdir}/fluent-bit/
     install -m 0755 ${UNPACKDIR}/fluent-bit.conf ${D}${sysconfdir}/fluent-bit/fluent-bit.conf
     install -m 0755 ${UNPACKDIR}/emmc-health ${D}${bindir}
+    install -d ${D}${sysconfdir}/fluent-bit/fluent-bit.d
+    install -m 0644 ${UNPACKDIR}/custom-empty.conf ${D}${sysconfdir}/fluent-bit/fluent-bit.d
 }


### PR DESCRIPTION
If the users have to modify fluent-bit.conf to add their customizations, that adds a maintenance burden requiring them to merge in changes on every new release.  With this change, user customizations can be stored in seperate include files negaiting that merge step.