### PR TITLE
python3-urllib3: scarthgap: disable 0001-setup.cfg-drop-all-extras.patch

### DIFF
--- a/recipes-devtools/python/python3-urllib3_%.bbappend
+++ b/recipes-devtools/python/python3-urllib3_%.bbappend
@@ -1,5 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
-SRC_URI:append:class-target = " file://0001-setup.cfg-drop-all-extras.patch"
+SRC_URI:append:class-target = " file://0001-setup.cfg-drop-all-extras.patch;apply=no"
 
 RDEPENDS:${PN}:remove:class-target = "${PYTHON_PN}-certifi ${PYTHON_PN}-cryptography ${PYTHON_PN}-idna ${PYTHON_PN}-pyopenssl"


### PR DESCRIPTION
The patch doesn't apply on scarthgap, with python3-urllib3 2.2.1 release.