### PR TITLE
libdevmapper: scarthgap: add inherit nopackages

### DIFF
--- a/recipes-support/lvm2/libdevmapper_%.bbappend
+++ b/recipes-support/lvm2/libdevmapper_%.bbappend
@@ -1,0 +1,1 @@
+inherit nopackages


### PR DESCRIPTION
With buildhistory recent changes in scarthgap, it breaks libdevmapper recipe. The issue has been fixed in master:
https://git.openembedded.org/meta-openembedded/commit/meta-oe/recipes-support/lvm2/libdevmapper.bb?id=90f96e053ad3eefa7693d9748efdfbfa72d7dcfd

And it's being backported to scarthgap:
https://git.openembedded.org/meta-openembedded-contrib/commit/?h=stable/scarthgap-nut&id=e318c5df6993ca714c1a56abeeb32c243e4d2cde

In the meantime, apply the bbappend to fix the build failure when building -next manifest and before the pinned hashes are updated (will pull the buildhistory changes in -default manifest).