### PR TITLE
bump SRCREV to latest for Torizon OS 6.8.0 quarterly release

### DIFF
--- a/recipes-kernel/linux/linux-toradex-kmeta.inc
+++ b/recipes-kernel/linux/linux-toradex-kmeta.inc
@@ -1,4 +1,4 @@
-SRCREV_meta = "9a7d962306ff1bcd847ece3f6170a86dfd5584f4"
+SRCREV_meta = "c8df6466e976f742552e3b88358fac0a0f552103"
 SRCREV_meta:use-head-next = "${AUTOREV}"
 
 KMETABRANCH = "kirkstone-6.x.y"

--- a/recipes-sota/rac/rac_git.bb
+++ b/recipes-sota/rac/rac_git.bb
@@ -14,7 +14,7 @@ SRC_URI = " \
 
 SRCREV_FORMAT = "rac_tough"
 
-SRCREV_rac = "15845bcaad19b9cbb79816b84184547df559e6b5"
+SRCREV_rac = "81ed67af3399bcc45141315412a08b12caa72706"
 SRCREV_tough = "9316c096b32196df75ba17a8a5502b19baffe24e"
 
 # Disable AUTOREV, it does not guarantee work, since the below crate


### PR DESCRIPTION
Related-to: TOR-3516