### PR TITLE
rac: revert "rac: bump SRCREV to latest"

### DIFF
--- a/recipes-sota/rac/rac_git.bb
+++ b/recipes-sota/rac/rac_git.bb
@@ -14,7 +14,7 @@ SRC_URI = " \
 
 SRCREV_FORMAT = "rac_tough"
 
-SRCREV_rac = "81ed67af3399bcc45141315412a08b12caa72706"
+SRCREV_rac = "15845bcaad19b9cbb79816b84184547df559e6b5"
 SRCREV_tough = "9316c096b32196df75ba17a8a5502b19baffe24e"
 
 # Disable AUTOREV, it does not guarantee work, since the below crate


### PR DESCRIPTION
Due to the implementation of MQTT, rac requires Rust 1.75+, while we are currently using version 1.70, which caused build failures on Torizon 6. Therefore, it was decided to bump RAC only on scarthgap and not on kirkstone.

This reverts commit ffaaef66df05537ac77aca0edbe3f9cff8743abc.

Related-to: TOR-3516