### PR TITLE
Add static group, user, and meta-tpm bblayer for fTPM OP-TEE support

### DIFF
--- a/conf/template/bblayers.conf
+++ b/conf/template/bblayers.conf
@@ -42,6 +42,7 @@ BBLAYERS = " \
   ${OEROOT}/layers/meta-toradex-security \
   ${OEROOT}/layers/meta-toradex-distro \
   ${OEROOT}/layers/meta-toradex-bsp-common \
+  ${OEROOT}/layers/meta-security/meta-tpm \
   ${BASELAYERS} \
   ${BSPLAYERS} \
   ${EXTRALAYERS} \

--- a/files/torizon-static-group
+++ b/files/torizon-static-group
@@ -46,6 +46,7 @@ kvm:x:102:
 render:x:103:
 sgx:x:104:
 ptest:x:529:
+tss:x:983:
 systemd-bus-proxy:x:984:
 systemd-timesync:x:985:
 systemd-resolve:x:986:

--- a/files/torizon-static-passwd
+++ b/files/torizon-static-passwd
@@ -16,6 +16,7 @@ list:x:38:38:Mailing List Manager:/var/list:/bin/sh
 irc:x:39:39:ircd:/var/run/ircd:/bin/sh
 gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/bin/sh
 ptest:x:529:529::/:/bin/nologin
+tss:x:983:983::/var/lib/tpm:/bin/false
 distcc:x:986:65534::/:/bin/nologin
 avahi:x:987:989::/run/avahi-daemon:/bin/false
 systemd-bus-proxy:x:988:984::/:/bin/nologin


### PR DESCRIPTION
fTPM under OP-TEE requires the meta-tpm layer from meta-security to be added to bblayers.conf, and for the tss group and user to exist. Since we use useradd-staticids, we need to add the group and user manually.