### PR TITLE
udev: add dma rules

### DIFF
--- a/recipes-core/udev/files/95-toradex-dma.rules
+++ b/recipes-core/udev/files/95-toradex-dma.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="dma_heap", GROUP="video", MODE="0660"

--- a/recipes-core/udev/udev-toradex-rules.bbappend
+++ b/recipes-core/udev/udev-toradex-rules.bbappend
@@ -7,6 +7,7 @@ SRC_URI:append = " \
     file://92-toradex-spidev.rules \
     file://93-toradex-backlight.rules \
     file://94-toradex-pwm.rules \
+    file://95-toradex-dma.rules \
     file://toradex-net-rename.sh \
 "
 
@@ -17,6 +18,7 @@ do_install:append () {
     install -m 0644 ${WORKDIR}/92-toradex-spidev.rules ${D}${sysconfdir}/udev/rules.d/
     install -m 0644 ${WORKDIR}/93-toradex-backlight.rules ${D}${sysconfdir}/udev/rules.d/
     install -m 0644 ${WORKDIR}/94-toradex-pwm.rules ${D}${sysconfdir}/udev/rules.d/
+    install -m 0644 ${WORKDIR}/95-toradex-dma.rules ${D}${sysconfdir}/udev/rules.d/
 
     install -d ${D}${bindir}
     install -m 0755 ${WORKDIR}/toradex-net-rename.sh ${D}${bindir}/


### PR DESCRIPTION
Set read and/or write access to the dma_heap using video group. Access is required for using g2d renderer on Apalis iMX8 and Colibri iMX8X.

Related-to: TCCP-830