### PR TITLE
cfs-signed: use immediate assignment to DISTROOVERRIDES

### DIFF
--- a/classes/cfs-signed.bbclass
+++ b/classes/cfs-signed.bbclass
@@ -20,7 +20,7 @@
 #   addition of the composefs digest into the commit metadata) and the signature
 #   verification at runtime.
 #
-DISTROOVERRIDES:append = ":cfs-support:cfs-signed"
+DISTROOVERRIDES .= ":cfs-support:cfs-signed"
 
 # Variables a user will likely want to set up:
 #


### PR DESCRIPTION
Make immediate assignment rather using the override syntax to add the cfs-signed and cfs-support overrides to variable DISTROOVERRIDES. This allows one to check that variable in situations where the immediate value is needed, for example in conditional includes/requires.

Minor change just to be consistent with similar changes being done in `meta-toradex-security`:
https://github.com/toradex/meta-toradex-security/pull/83