### PR TITLE
initramfs-framework: no longer depend on overlay being a module

### DIFF
--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -32,8 +32,9 @@ RDEPENDS:initramfs-module-ostree = "${PN}-base ostree-switchroot"
 FILES:initramfs-module-ostree = "/init.d/95-ostree"
 
 SUMMARY:initramfs-module-composefs = "initramfs support for booting composefs images"
-RDEPENDS:initramfs-module-composefs = "${PN}-base kernel-module-erofs kernel-module-overlay"
+RDEPENDS:initramfs-module-composefs = "${PN}-base"
 RDEPENDS:initramfs-module-composefs:append:cfs-signed = " fsverity-utils"
+RRECOMMENDS:initramfs-module-composefs = "kernel-module-erofs kernel-module-overlay"
 FILES:initramfs-module-composefs = "\
     /init.d/94-composefs \
     ${nonarch_libdir}/ostree/prepare-root.conf \


### PR DESCRIPTION
Make initramfs-module-composefs only recommend rather than strictly depend on initramfs-module-overlay and initramfs-module-erofs. With this, now the corresponding drivers (overlay, erofs) can be compiled as built-in or as modules. Before there was the assumption that those drivers would be always modules but that assumption was broken on scarthgap where the overlay driver became built-in due to changes at the kernel side that in turn lead meta-virtualization to apply certain configuration fragments to the kernel, one of which impacting how the overlay driver was built.

The changes here should only impact images utilizing composefs, which currently means those inheriting class "torizon-signed".
