### PR TITLE
[Kirkstone] ostree: backport Curl patch

### DIFF
--- a/recipes-extended/ostree/ostree-2021.6/0005-curl-Make-socket-callback-during-cleanup-into-no-op.patch
+++ b/recipes-extended/ostree/ostree-2021.6/0005-curl-Make-socket-callback-during-cleanup-into-no-op.patch
@@ -1,0 +1,67 @@
+From fc0ecf5e2b2dd08d6c346693caf205c7d3225428 Mon Sep 17 00:00:00 2001
+From: Eduardo Ferreira <eduardo.barbosa@toradex.com>
+Date: Thu, 21 Nov 2024 16:45:27 +0000
+Subject: [PATCH] curl: Make socket callback during cleanup into no-op
+
+Because curl_multi_cleanup may invoke callbacks, we effectively have
+some circular references going on here. See discussion in
+
+https://github.com/curl/curl/issues/14860
+
+Basically what we do is the socket callback libcurl may invoke into a no-op when
+we detect we're finalizing. The data structures are owned by this object and
+not by the callbacks, and will be destroyed below. Note that
+e.g. g_hash_table_unref() may itself invoke callbacks, which is where
+some data is cleaned up.
+
+Upstream-Status: Backport [https://github.com/ostreedev/ostree/pull/3307/commits/4d755a85225ea0a02d4580d088bb8a97138cb040]
+
+Signed-off-by: Colin Walters <walters@verbum.org>
+Signed-off-by: Eduardo Ferreira <eduardo.barbosa@toradex.com>
+---
+ src/libostree/ostree-fetcher-curl.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/src/libostree/ostree-fetcher-curl.c b/src/libostree/ostree-fetcher-curl.c
+index d6534b46..a35f9286 100644
+--- a/src/libostree/ostree-fetcher-curl.c
++++ b/src/libostree/ostree-fetcher-curl.c
+@@ -79,6 +79,7 @@ struct OstreeFetcher
+   struct curl_slist *extra_headers;
+   int tmpdir_dfd;
+   char *custom_user_agent;
++  bool finalizing; // Set if we're in the process of teardown
+ 
+   GMainContext *mainctx;
+   CURLM *multi;
+@@ -177,6 +178,16 @@ _ostree_fetcher_finalize (GObject *object)
+ {
+   OstreeFetcher *self = OSTREE_FETCHER (object);
+ 
++  // Because curl_multi_cleanup may invoke callbacks, we effectively have
++  // some circular references going on here. See discussion in
++  // https://github.com/curl/curl/issues/14860
++  // Basically what we do is make most callbacks libcurl may invoke into no-ops when
++  // we detect we're finalizing. The data structures are owned by this object and
++  // not by the callbacks, and will be destroyed below. Note that
++  // e.g. g_hash_table_unref() may itself invoke callbacks, which is where
++  // some data is cleaned up.
++  self->finalizing = true;
++
+   curl_multi_cleanup (self->multi);
+   g_free (self->remote_name);
+   g_free (self->tls_ca_db_path);
+@@ -523,6 +534,10 @@ sock_cb (CURL *easy, curl_socket_t s, int what, void *cbp, void *sockp)
+   OstreeFetcher *fetcher = cbp;
+   SockInfo *fdp = (SockInfo*) sockp;
+ 
++  // We do nothing if we're in the process of teardown; see below.
++  if (fetcher->finalizing)
++    return 0;
++
+   if (what == CURL_POLL_REMOVE)
+     {
+       if (!g_hash_table_remove (fetcher->sockets, fdp))
+-- 
+2.34.1
+

--- a/recipes-extended/ostree/ostree_2021.6.bbappend
+++ b/recipes-extended/ostree/ostree_2021.6.bbappend
@@ -5,6 +5,7 @@ SRC_URI:append = " \
     file://0002-Add-support-for-the-fdtfile-variable-in-uEnv.txt.patch \
     file://0003-ostree-fetcher-curl-handle-non-404-errors-as-G_IO_ER.patch \
     file://0004-ostree-fetcher-curl-set-max-parallel-connections.patch \
+    file://0005-curl-Make-socket-callback-during-cleanup-into-no-op.patch \
 "
 
 require recipes-extended/ostree/ostree-torizon.inc


### PR DESCRIPTION
An issue was found during some automated tests, and it was related to OSTree. Looking upstream, there was already an issue opened about this [2], and a fix was recently published [1].
Since this is only available on v2024.9 and were some version behind, we backported this patch.

Related-to: TOR-3649

[1] https://github.com/ostreedev/ostree/pull/3307/commits/4d755a85225ea0a02d4580d088bb8a97138cb040
[2] https://github.com/ostreedev/ostree/issues/3299