### PR TITLE
Revert "ostree: removing unnecessary composefs patches"

### DIFF
--- a/recipes-extended/ostree/files/0001-mount-Allow-building-when-macro-MOUNT_ATTR_IDMAP-is-.patch
+++ b/recipes-extended/ostree/files/0001-mount-Allow-building-when-macro-MOUNT_ATTR_IDMAP-is-.patch
@@ -1,0 +1,64 @@
+From c5241e94030f774df5f410e07c4de894d41e64e2 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Tue, 6 Feb 2024 23:14:20 -0300
+Subject: [PATCH 1/2] mount: Allow building when macro MOUNT_ATTR_IDMAP is not
+ available
+
+This is to allow building the software on machines not having the
+MOUNT_ATTR_IDMAP macro in header "linux/mount.h". When that macro is not
+available, the dependency on struct mount_attr is also eliminated (which
+is good since both the macro and the struct were added to the kernel
+uapi virtually at the same time).
+
+With the changes in this commit, errors would be thrown at runtime when
+mounting the erofs image, but only if the idmap feature is used; this
+resembles the behavior when the "new mount API" is not detected.
+
+Upstream-Status: Accepted [https://github.com/containers/composefs/pull/253]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ libcomposefs/lcfs-mount.c |  6 ++++++
+ 2 files changed, 17 insertions(+)
+
+diff --git a/composefs/libcomposefs/lcfs-mount.c b/composefs/libcomposefs/lcfs-mount.c
+index 0a4b08f..5285833 100644
+--- a/composefs/libcomposefs/lcfs-mount.c
++++ b/composefs/libcomposefs/lcfs-mount.c
+@@ -108,6 +108,7 @@ static int syscall_move_mount(int from_dfd, const char *from_pathname, int to_df
+ #endif
+ }
+ 
++#ifdef HAVE_MOUNT_ATTR_IDMAP
+ static int syscall_mount_setattr(int dfd, const char *path, unsigned int flags,
+ 				 struct mount_attr *attr, size_t usize)
+ {
+@@ -122,6 +123,7 @@ static int syscall_mount_setattr(int dfd, const char *path, unsigned int flags,
+ 	return -1;
+ #endif
+ }
++#endif
+ 
+ #define MAX_DIGEST_SIZE 64
+ 
+@@ -381,6 +383,7 @@ static int lcfs_mount_erofs(const char *source, const char *target,
+ 		return -errno;
+ 
+ 	if (use_idmap) {
++#ifdef HAVE_MOUNT_ATTR_IDMAP
+ 		struct mount_attr attr = {
+ 			.attr_set = MOUNT_ATTR_IDMAP,
+ 			.userns_fd = state->options->idmap_fd,
+@@ -390,6 +393,9 @@ static int lcfs_mount_erofs(const char *source, const char *target,
+ 					    sizeof(struct mount_attr));
+ 		if (res < 0)
+ 			return -errno;
++#else
++		return -ENOTSUP;
++#endif
+ 	}
+ 
+ 	res = syscall_move_mount(fd_mnt, "", AT_FDCWD, target,
+-- 
+2.25.1
+

--- a/recipes-extended/ostree/files/0002-mount-Allow-building-when-macro-LOOP_CONFIGURE-is-no.patch
+++ b/recipes-extended/ostree/files/0002-mount-Allow-building-when-macro-LOOP_CONFIGURE-is-no.patch
@@ -1,0 +1,47 @@
+From ebb4e195b94074cb66d031d1f449d55cba86a182 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Tue, 6 Feb 2024 23:36:15 -0300
+Subject: [PATCH 2/2] mount: Allow building when macro LOOP_CONFIGURE is not
+ available
+
+This is to allow building the software on machines not having the macro
+LOOP_CONFIGURE or the struct loop_config in header "linux/loop.h" (both
+of which added to the kernel uapi at the same time); the code snippet
+providing them was taken from package util-linux, source file
+"include/loopdev.h".
+
+Upstream-Status: Accepted [https://github.com/containers/composefs/pull/253]
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ libcomposefs/lcfs-mount.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/composefs/libcomposefs/lcfs-mount.c b/composefs/libcomposefs/lcfs-mount.c
+index 5285833..8acc7b9 100644
+--- a/composefs/libcomposefs/lcfs-mount.c
++++ b/composefs/libcomposefs/lcfs-mount.c
+@@ -49,6 +49,20 @@
+ #include "lcfs-utils.h"
+ #include "lcfs-internal.h"
+ 
++#ifndef LOOP_CONFIGURE
++/* Snippet from util-linux/include/loopdev.h */
++/*
++ * Since Linux v5.8-rc1 (commit 3448914e8cc550ba792d4ccc74471d1ca4293aae)
++ */
++#define LOOP_CONFIGURE 0x4C0A
++struct loop_config {
++	uint32_t fd;
++	uint32_t block_size;
++	struct loop_info64 info;
++	uint64_t __reserved[8];
++};
++#endif
++
+ static int syscall_fsopen(const char *fs_name, unsigned int flags)
+ {
+ #if defined __NR_fsopen
+-- 
+2.25.1
+

--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -7,6 +7,8 @@ SRC_URI:append = " \
     file://0002-Add-support-for-the-fdtfile-variable-in-uEnv.txt.patch \
     file://0003-ostree-fetcher-curl-set-max-parallel-connections.patch \
     file://0004-curl-Make-socket-callback-during-cleanup-into-no-op.patch \
+    file://0001-mount-Allow-building-when-macro-MOUNT_ATTR_IDMAP-is-.patch \
+    file://0002-mount-Allow-building-when-macro-LOOP_CONFIGURE-is-no.patch \
     file://ostree-pending-reboot.service \
     file://ostree-pending-reboot.path \
 "


### PR DESCRIPTION
This reverts commit 72922783bb0057c3929bdad9caa73f2638d6937c.

Unfortunately we cannot yet remove the patches for dealing with missing MOUNT_ATTR_IDMAP and LOOP_CONFIGURE because ostree 2024.5 still refers to composefs v1.0.3 (as a submodule) whereas the patches have been applied upstream only in v1.0.4.

@EdTheBearded Sorry, I gave you wrong information that led you to this removal but now checking the errors in CI I realized we actually couldn't remove the patches on scarthgap.
