### PR TITLE
u-boot: Add mechanism to programmatically set fuses for HAB/AHAB (i.M…

### DIFF
--- a/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
@@ -10,13 +10,154 @@ SRC_URI:append = " \
 # representing device-tree overlays) to be used when booting.
 FITCONF_FDT_OVERLAYS ??= ""
 
+# Machine specific values related to HAB/AHAB fusing (i.MX specific)
+BANK_WORD = ""
+FUSE_NUM = ""
+STATUS_CMD = ""
+CLOSE_CMD = ""
+
+IMX6_COMMON_BANK_WORD = "3 0;\
+3 1;\
+3 2;\
+3 3;\
+3 4;\
+3 5;\
+3 6;\
+3 7;\
+"
+
+IMX7_IMX8M_COMMON_BANK_WORD = "6 0;\
+6 1;\
+6 2;\
+6 3;\
+7 0;\
+7 1;\
+7 2;\
+7 3;\
+"
+
+FUSE_NUM_8 = "1 2 3 4 5 6 7 8"
+FUSE_NUM_16 = "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16"
+
+HAB_STATUS_CMD = "hab_status"
+AHAB_STATUS_CMD = "ahab_status"
+
+IMX6_COMMON_CLOSE_CMD = "fuse prog -y 0 6 0x00000002"
+IMX7_IMX8M_COMMON_CLOSE_CMD = "fuse prog -y 1 3 0x02000000"
+AHAB_CLOSE_CMD = "ahab_close"
+
+BANK_WORD:mx6ull-generic-bsp = "${IMX6_COMMON_BANK_WORD}"
+FUSE_NUM:mx6ull-generic-bsp = "${FUSE_NUM_8}"
+STATUS_CMD:mx6ull-generic-bsp = "${HAB_STATUS_CMD}"
+CLOSE_CMD:mx6ull-generic-bsp = "${IMX6_COMMON_CLOSE_CMD}"
+
+BANK_WORD:mx6q-generic-bsp = "${IMX6_COMMON_BANK_WORD}"
+FUSE_NUM:mx6q-generic-bsp = "${FUSE_NUM_8}"
+STATUS_CMD:mx6q-generic-bsp = "${HAB_STATUS_CMD}"
+CLOSE_CMD:mx6q-generic-bsp = "${IMX6_COMMON_CLOSE_CMD}"
+
+BANK_WORD:mx6dl-generic-bsp = "${IMX6_COMMON_BANK_WORD}"
+FUSE_NUM:mx6dl-generic-bsp = "${FUSE_NUM_8}"
+STATUS_CMD:mx6dl-generic-bsp = "${HAB_STATUS_CMD}"
+CLOSE_CMD:mx6dl-generic-bsp = "${IMX6_COMMON_CLOSE_CMD}"
+
+BANK_WORD:mx7-generic-bsp = "${IMX7_IMX8M_COMMON_BANK_WORD}"
+FUSE_NUM:mx7-generic-bsp = "${FUSE_NUM_8}"
+STATUS_CMD:mx7-generic-bsp = "${HAB_STATUS_CMD}"
+CLOSE_CMD:mx7-generic-bsp = "${IMX7_IMX8M_COMMON_CLOSE_CMD}"
+
+BANK_WORD:mx8m-generic-bsp = "${IMX7_IMX8M_COMMON_BANK_WORD}"
+FUSE_NUM:mx8m-generic-bsp = "${FUSE_NUM_8}"
+STATUS_CMD:mx8m-generic-bsp = "${HAB_STATUS_CMD}"
+CLOSE_CMD:mx8m-generic-bsp = "${IMX7_IMX8M_COMMON_CLOSE_CMD}"
+
+BANK_WORD:mx8qm-generic-bsp = "0 722;\
+0 723;\
+0 724;\
+0 725;\
+0 726;\
+0 727;\
+0 728;\
+0 729;\
+0 730;\
+0 731;\
+0 732;\
+0 733;\
+0 734;\
+0 735;\
+0 736;\
+0 737;\
+"
+FUSE_NUM:mx8qm-generic-bsp = "${FUSE_NUM_16}"
+STATUS_CMD:mx8qm-generic-bsp = "${AHAB_STATUS_CMD}"
+CLOSE_CMD:mx8qm-generic-bsp = "${AHAB_CLOSE_CMD}"
+
+BANK_WORD:mx8x-generic-bsp = "0 730;\
+0 731;\
+0 732;\
+0 733;\
+0 734;\
+0 735;\
+0 736;\
+0 737;\
+0 738;\
+0 739;\
+0 740;\
+0 741;\
+0 742;\
+0 743;\
+0 744;\
+0 745;\
+"
+FUSE_NUM:mx8x-generic-bsp = "${FUSE_NUM_16}"
+STATUS_CMD:mx8x-generic-bsp = "${AHAB_STATUS_CMD}"
+CLOSE_CMD:mx8x-generic-bsp = "${AHAB_CLOSE_CMD}"
+
+UENV_VARS_TO_DEL ?= ""
+# List of uEnv.txt variables not present during initial generation
+UENV_VARS_TO_DEL_EXTRA ?= "kernel_image \
+    ramdisk_image \
+    fdtdir \
+    bootargs \
+    kernel_image2 \
+    ramdisk_image2 \
+    fdtdir2 \
+    bootargs2 \
+    fdtfile2 \
+    kernel_image_type2 \
+    index \
+    temp \
+"
+
 do_compile:append () {
+    # Normalize input to a shell variable, otherwise following line causes yocto parser to error
+    bank_word_in="${BANK_WORD}"
+    bank_word=$(IFS=';'; i=1; for bw in ${bank_word_in}; do echo "fuse_bank_word_${i}=${bw}"; let "i=i+1"; done)
+    # Replace implicit newlines with explicit newlines
+    bank_word=$(echo "$bank_word" | sed -n -e '1h;2,$H;${g;s/\n/\\n/gp}')
+
     bbdebug 1 "Building uEnv.txt..."
     sed -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
         -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
         -e 's/@@KERNEL_DTB_PREFIX@@/${DTB_PREFIX}/' \
         -e 's/@@FITCONF_FDT_OVERLAYS@@/${FITCONF_FDT_OVERLAYS}/' \
-        ${WORKDIR}/uEnv.txt.in > uEnv.txt
+        -e "s/@@BANK_WORD@@/${bank_word}/" \
+        -e 's/@@FUSE_NUM@@/${FUSE_NUM}/' \
+        -e 's/@@STATUS_CMD@@/${STATUS_CMD}/' \
+        -e 's/@@CLOSE_CMD@@/${CLOSE_CMD}/' \
+        ${WORKDIR}/uEnv.txt.in > ${WORKDIR}/uEnv.txt.temp
+
+    vars_to_del="${UENV_VARS_TO_DEL}"
+    if [ -z "${vars_to_del}" ]; then
+        vars_to_del="$(cat ${WORKDIR}/uEnv.txt.temp | \
+                       sed -n -e 's/^\([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/gp')"
+        # Needed to remove newlines from previous output
+        vars_to_del=$(echo ${vars_to_del})
+    fi
+    vars_to_del="${vars_to_del} ${UENV_VARS_TO_DEL_EXTRA}"
+
+    sed -e "s/@@VARS_TO_DEL@@/${vars_to_del}/" \
+        ${WORKDIR}/uEnv.txt.temp > uEnv.txt
 }
 
 TDX_AMEND_BOOT_SCRIPT:torizon-distro = "0"

--- a/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
+++ b/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
@@ -2,6 +2,9 @@ kernel_image_type=@@KERNEL_IMAGETYPE@@
 overlays_file="overlays.txt"
 otaroot=1
 fitconf_fdt_overlays="@@FITCONF_FDT_OVERLAYS@@"
+@@BANK_WORD@@
+fuse_num=@@FUSE_NUM@@
+vars_to_del=@@VARS_TO_DEL@@
 
 set_bootargs=env set bootcmd_args env set bootargs ${defargs} root=LABEL=otaroot rootfstype=ext4 ${bootargs} ${tdxargs}
 
@@ -9,7 +12,7 @@ set_bootargs=env set bootcmd_args env set bootargs ${defargs} root=LABEL=otaroot
 # in case of booting a FIT image, the kernel load address will point to the
 # fitimage load address, which is calculated by adding 32M to the ramdisk
 # load address, i.e. the ramdisk image must not be bigger than 32M!
-set_kernel_load_addr=env set bootcmd_unzip_k ';'; \
+set_kernel_load_addr=env set bootcmd_unzip_k ";"; \
                      if test ${kernel_image_type} = "fitImage"; then \
                          env set fitimage_addr_r ${ramdisk_addr_r}; \
                          env set kernel_addr_load ${fitimage_addr_r}; \
@@ -18,7 +21,7 @@ set_kernel_load_addr=env set bootcmd_unzip_k ';'; \
                              env set kernel_addr_load ${loadaddr}; \
                          elif test ${kernel_image_type} = "Image.gz"; then \
                              env set kernel_addr_load ${loadaddr}; \
-                             env set bootcmd_unzip_k 'unzip $kernel_addr_load $kernel_addr_r'; \
+                             env set bootcmd_unzip_k "unzip $kernel_addr_load $kernel_addr_r"; \
                          else \
                              env set kernel_addr_load ${kernel_addr_r}; \
                          fi; \
@@ -109,6 +112,108 @@ bootcmd_boot=if test ${bootscript_debug} != 1; then \
                  fi; \
              fi || true
 
-bootcmd_run=run board_fixups && run check_rollback_needed && run set_bootargs && run set_fdt_path && \
+prog_fuses=if test -n "${fuse_prog_list}" && test "${fuse_status}" = "pending" || test "${fuse_status}" = "need-reboot"; then \
+               if test "${fuse_status}" = "pending"; then \
+                   env set index 1; \
+                   for fuse_val in ${fuse_prog_list}; do \
+                       if test "${fuse_status}" != "failed"; then \
+                           if test "${fuse_dry_run}" = "1"; then \
+                               env set temp echo DRY RUN: fuse prog \\$fuse_bank_word_$index ${fuse_val}; \
+                           else \
+                               env set temp fuse prog -y \\$fuse_bank_word_$index ${fuse_val}; \
+                           fi; \
+                           run temp; \
+                           if test $? != "0"; then \
+                               env set fuse_status failed; \
+                           fi; \
+                           if test "${fuse_dry_run}" = "1"; then \
+                               env set temp echo DRY RUN: fuse cmp \\$fuse_bank_word_$index ${fuse_val}; \
+                           else \
+                               env set temp fuse cmp \\$fuse_bank_word_$index ${fuse_val}; \
+                           fi; \
+                           run temp; \
+                           if test $? != "0"; then \
+                               env set fuse_status failed; \
+                           fi; \
+                       fi ; \
+                       setexpr index $index + 1; \
+                       if test "${index}" = "a"; then \
+                           env set index "10"; \
+                       fi; \
+                   done; \
+               elif test "${fuse_status}" = "need-reboot"; then \
+                   @@STATUS_CMD@@; \
+                   if test $? != "0"; then \
+                       env set fuse_status failed; \
+                   fi; \
+                   if test "${fuse_prog_close}" = "1" && test "${fuse_status}" != "failed"; then \
+                       if test "${fuse_dry_run}" = "1"; then \
+                           echo "DRY RUN: Closing is set"; \
+                       else \
+                           @@CLOSE_CMD@@; \
+                       fi; \
+                       if test $? != "0"; then \
+                           env set fuse_status failed; \
+                       fi; \
+                   fi; \
+               fi; \
+               env set save_vars 1; \
+               if test "${fuse_status}" = "pending"; then \
+                   env set fuse_status need-reboot; \
+               elif test "${fuse_status}" = "need-reboot"; then \
+                   env set fuse_status success; \
+               fi; \
+           fi || true
+
+read_fuses=if test -n "${fuse_num}"; then \
+               for num in ${fuse_num}; do \
+                   if env exists fuse_val_${num}; then \
+                       env set temp fuse cmp \\$fuse_bank_word_$num 0x\\$fuse_val_$num; \
+                       run temp; \
+                   else \
+                       false; \
+                   fi; \
+                   if test $? != "0"; then \
+                       env set temp fuse readm \\$fuse_bank_word_$num ${loadaddr}; \
+                       run temp; \
+                       setexpr.l fuse_val_${num} "*${loadaddr}"; \
+                       env set save_vars 1; \
+                   fi; \
+               done; \
+               tdx_is_closed; \
+               if test $? != "0"; then \
+                   if test "${fuse_val_close}" != "0"; then \
+                       env set save_vars 1; \
+                   fi; \
+                   env set fuse_val_close 0; \
+               else \
+                   if test "${fuse_val_close}" != "1"; then \
+                       env set save_vars 1; \
+                   fi; \
+                   env set fuse_val_close 1; \
+               fi; \
+           fi || true
+
+set_vars=if test "${save_vars}" = "1"; then \
+             for var in ${vars_to_del}; do \
+                 env set temp saved_$var=\\$$var; \
+                 run temp; \
+                 env delete ${var}; \
+             done; \
+             env delete save_vars; \
+             env save; \
+             for var in ${saved_vars_to_del}; do \
+                 env set temp "env set $var \\"\\$saved_${var}\\""; \
+                 run temp; \
+             done; \
+         fi || true
+
+reset_dev=if test "${fuse_status}" = "need-reboot"; then \
+              reset; \
+          fi || true
+
+# Ensure "prog_fuses", "read_fuses", "set_vars", and "reset_dev" are ran first here.
+bootcmd_run=run prog_fuses && run read_fuses && run set_vars && run reset_dev && \
+            run board_fixups && run check_rollback_needed && run set_bootargs && run set_fdt_path && \
             run bootcmd_dtb && run bootcmd_args && run set_bootargs_custom && run set_kernel_load_addr && \
             run bootcmd_load_k && run bootcmd_unzip_k && run bootcmd_load_r && run bootcmd_boot

--- a/recipes-bsp/u-boot/u-boot-fuse.inc
+++ b/recipes-bsp/u-boot/u-boot-fuse.inc
@@ -1,0 +1,27 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/u-boot-fuse:"
+
+# TODO: This patch heavily reuses code from the hardening feature from meta-tordadex-security.
+# Consider reconciling the two, to avoid too much code duplication.
+TDX_UBOOT_FUSE_PATCHES_COMMON = " \
+    file://0001-toradex-add-new-command-to-determine-HAB-AHAB-closed.patch \
+"
+
+TDX_UBOOT_FUSE_PATCHES_UPSTREAM = " \
+    ${TDX_UBOOT_FUSE_PATCHES_COMMON} \
+    file://0001-toradex-adjust-hab_status-exit-code-behavior.patch \
+"
+
+TDX_UBOOT_FUSE_PATCHES_DOWNSTREAM = " \
+    ${TDX_UBOOT_FUSE_PATCHES_COMMON} \
+    file://0001-toradex-adjust-ahab_status-exit-code-behavior.patch \
+"
+
+TDX_UBOOT_FUSE_PATCHES = "${TDX_UBOOT_FUSE_PATCHES_UPSTREAM}"
+TDX_UBOOT_FUSE_PATCHES:apalis-imx8 = "${TDX_UBOOT_FUSE_PATCHES_DOWNSTREAM}"
+TDX_UBOOT_FUSE_PATCHES:colibri-imx8x = "${TDX_UBOOT_FUSE_PATCHES_DOWNSTREAM}"
+TDX_UBOOT_FUSE_PATCHES:verdin-am62 = ""
+TDX_UBOOT_FUSE_PATCHES:verdin-am62-k3r5 = ""
+
+SRC_URI:append = " \
+    ${TDX_UBOOT_FUSE_PATCHES} \
+"

--- a/recipes-bsp/u-boot/u-boot-fuse/0001-toradex-add-new-command-to-determine-HAB-AHAB-closed.patch
+++ b/recipes-bsp/u-boot/u-boot-fuse/0001-toradex-add-new-command-to-determine-HAB-AHAB-closed.patch
@@ -1,0 +1,173 @@
+From 32ff2e8d260876fc26d7c4bae4f2907f0ddc0fad Mon Sep 17 00:00:00 2001
+From: Jeremias Cordoba <js.cordoba8321@gmail.com>
+Date: Thu, 5 Dec 2024 15:07:03 -0800
+Subject: [PATCH 1/2] toradex: add new command to determine HAB/AHAB closed
+ status
+
+Also add auxiliary function to detect a known HAB event on i.MX6.
+
+Upstream-Status: Inappropriate [Torizon OS specific]
+
+Signed-off-by: Jeremias Cordoba <jeremias.cordoba@toradex.com>
+---
+ common/Makefile         |   3 ++
+ common/tdx-hab-utils.c  | 112 ++++++++++++++++++++++++++++++++++++++++
+ include/tdx-hab-utils.h |  13 +++++
+ 3 files changed, 128 insertions(+)
+ create mode 100644 common/tdx-hab-utils.c
+ create mode 100644 include/tdx-hab-utils.h
+
+diff --git a/common/Makefile b/common/Makefile
+index e983547342..15f38f902b 100644
+--- a/common/Makefile
++++ b/common/Makefile
+@@ -30,6 +30,9 @@ obj-$(CONFIG_USB_GADGET) += usb.o
+ obj-$(CONFIG_USB_STORAGE) += usb_storage.o
+ obj-$(CONFIG_USB_ONBOARD_HUB) += usb_onboard_hub.o
+ 
++obj-$(CONFIG_IMX_HAB) += tdx-hab-utils.o
++obj-$(CONFIG_AHAB_BOOT) += tdx-hab-utils.o
++
+ # others
+ obj-$(CONFIG_CONSOLE_MUX) += iomux.o
+ obj-$(CONFIG_MTD_NOR_FLASH) += flash.o
+diff --git a/common/tdx-hab-utils.c b/common/tdx-hab-utils.c
+new file mode 100644
+index 0000000000..3183c21c05
+--- /dev/null
++++ b/common/tdx-hab-utils.c
+@@ -0,0 +1,112 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright 2024 Toradex
++ */
++
++#include <common.h>
++#include <command.h>
++#include <tdx-hab-utils.h>
++
++#if defined(CONFIG_IMX_HAB)
++#include <asm/mach-imx/hab.h>
++#elif defined(CONFIG_AHAB_BOOT)
++#include <firmware/imx/sci/sci.h>
++#endif
++
++#ifdef IGNORE_KNOWN_HAB_EVENTS
++static uint8_t known_rng_fail_event[][RNG_FAIL_EVENT_SIZE] = {
++        { 0xdb, 0x00, 0x24, 0x42,  0x69, 0x30, 0xe1, 0x1d,
++          0x00, 0x04, 0x00, 0x02,  0x40, 0x00, 0x36, 0x06,
++          0x55, 0x55, 0x00, 0x03,  0x00, 0x00, 0x00, 0x00,
++          0x00, 0x00, 0x00, 0x00,  0x00, 0x00, 0x00, 0x00,
++          0x00, 0x00, 0x00, 0x01 },
++};
++
++bool is_known_fail_event(const uint8_t *data, size_t len)
++{
++        int i;
++
++        for (i = 0; i < ARRAY_SIZE(known_rng_fail_event); i++) {
++                if (memcmp(data, known_rng_fail_event[i],
++                           min_t(size_t, len, RNG_FAIL_EVENT_SIZE)) == 0) {
++                        return true;
++                }
++        }
++
++        return false;
++}
++#endif
++
++/* Determines whether the device has been closed for HAB/AHAB.
++ * Returns a 0 if device is closed, 1 if it is open.
++ */
++static int tdx_secboot_dev_is_open(void)
++{
++#if defined(CONFIG_IMX_HAB)
++	if (imx_hab_is_enabled()) {
++		/* Device is closed (OR some error occurred). */
++		/* Notice that imx_hab_is_enabled() returns bool as per its
++		 * prototype but checking its code it can return a negative
++		 * value in case of fuse read errors. */
++		/* TODO: Evaluate if this is the best we can do here. */
++		return 0;
++	}
++#elif defined(CONFIG_AHAB_BOOT)
++	u16 lc;
++	if (sc_seco_chip_info(-1, &lc, NULL, NULL, NULL)) {
++		/* Some error occurred. */
++		return 0;
++	}
++	switch (lc) {
++	case 0x1:	/* Pristine */
++	case 0x2:	/* Fab */
++	case 0x8:	/* Open */
++		debug("Device is in a pre NXP-closed state!\n");
++		break;
++	case 0x20:	/* NXP closed */
++		debug("Device is in a NXP-closed state!\n");
++		break;
++	case 0x80:	/* OEM closed */
++		debug("Device is in OEM-closed state!\n");
++		return 0;
++	case 0x100:	/* Partial field return */
++	case 0x200:	/* Full field return */
++	case 0x400:	/* No return */
++		debug("Device is in some 'return' state!\n");
++		return 1;
++	default:	/* Unknown */
++		break;
++	}
++#else
++#error Neither CONFIG_IMX_HAB nor CONFIG_AHAB_BOOT is set
++#endif
++
++	/* Device is (assumed to be) open. */
++	return 1;
++}
++
++/* Returns 0 if device is closed, 1 if it is open or on error.
++ */
++static int do_tdx_is_closed(struct cmd_tbl *cmdtp, int flag, int argc,
++			    char *const argv[])
++{
++	int retval;
++
++	if (argc != 1) {
++		cmd_usage(cmdtp);
++		return 1;
++	}	
++
++	retval = tdx_secboot_dev_is_open();
++
++	if (retval) {
++		printf("Device is open.\n");
++	} else {
++		printf("Device is closed.\n");
++	}
++
++	return retval;
++}
++
++U_BOOT_CMD(tdx_is_closed, CONFIG_SYS_MAXARGS, 1, do_tdx_is_closed,
++	   "Checks whether device has been closed for HAB/AHAB","");
+diff --git a/include/tdx-hab-utils.h b/include/tdx-hab-utils.h
+new file mode 100644
+index 0000000000..316a0a61c3
+--- /dev/null
++++ b/include/tdx-hab-utils.h
+@@ -0,0 +1,13 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright 2024 Toradex
++ */
++
++#if (defined(CONFIG_MX6Q) || defined(CONFIG_MX6DL) || defined(CONFIG_MX6QDL))
++#define IGNORE_KNOWN_HAB_EVENTS 1
++#endif
++
++#ifdef IGNORE_KNOWN_HAB_EVENTS
++#define RNG_FAIL_EVENT_SIZE 36
++bool is_known_fail_event(const uint8_t *data, size_t len);
++#endif
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-fuse/0001-toradex-adjust-ahab_status-exit-code-behavior.patch
+++ b/recipes-bsp/u-boot/u-boot-fuse/0001-toradex-adjust-ahab_status-exit-code-behavior.patch
@@ -1,0 +1,45 @@
+From 9cd7e9c280888356f9a40e84264a4ba4a851416e Mon Sep 17 00:00:00 2001
+From: Jeremias Cordoba <js.cordoba8321@gmail.com>
+Date: Wed, 20 Nov 2024 16:16:24 -0800
+Subject: [PATCH] toradex: adjust ahab_status exit code behavior
+
+Adjust exit code behavior to return a 1 if there are any
+SECO events.
+
+Upstream-status; Inappropriate [Torizon OS specific]
+
+Signed-off-by: Jeremias Cordoba <jeremias.cordoba@toradex.com>
+---
+ arch/arm/mach-imx/imx8/ahab.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/mach-imx/imx8/ahab.c b/arch/arm/mach-imx/imx8/ahab.c
+index eb3916a7229..800b6d5b554 100644
+--- a/arch/arm/mach-imx/imx8/ahab.c
++++ b/arch/arm/mach-imx/imx8/ahab.c
+@@ -318,6 +318,7 @@ static int do_ahab_status(struct cmd_tbl *cmdtp, int flag, int argc,
+ 	u8 idx = 0U;
+ 	u32 event;
+ 	u16 lc;
++	int retval = 1;
+ 
+ 	err = sc_seco_chip_info(-1, &lc, NULL, NULL, NULL);
+ 	if (err) {
+@@ -336,10 +337,12 @@ static int do_ahab_status(struct cmd_tbl *cmdtp, int flag, int argc,
+ 		err = sc_seco_get_event(-1, idx, &event);
+ 	}
+ 
+-	if (idx == 0)
++	if (idx == 0) {
+ 		printf("No SECO Events Found!\n\n");
++		retval = 0;
++	}
+ 
+-	return 0;
++	return retval;
+ }
+ 
+ int ahab_close(void)
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-fuse/0001-toradex-adjust-hab_status-exit-code-behavior.patch
+++ b/recipes-bsp/u-boot/u-boot-fuse/0001-toradex-adjust-hab_status-exit-code-behavior.patch
@@ -1,0 +1,83 @@
+From 7a92e348ba88aeb1686538ef6376506cd9fe1d44 Mon Sep 17 00:00:00 2001
+From: Jeremias Cordoba <js.cordoba8321@gmail.com>
+Date: Thu, 5 Dec 2024 15:09:24 -0800
+Subject: [PATCH 2/2] toradex: adjust hab_status exit code behavior
+
+Adjust exit code behavior to return a 1 if there are any HAB events.
+An exception is made for a known HAB event on i.MX6 SoCs.
+
+Upstream-status; Inappropriate [Torizon OS specific]
+
+Signed-off-by: Jeremias Cordoba <jeremias.cordoba@toradex.com>
+---
+ arch/arm/mach-imx/hab.c | 17 ++++++++++++++---
+ 1 file changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/mach-imx/hab.c b/arch/arm/mach-imx/hab.c
+index 27e053ef70..42c9787c42 100644
+--- a/arch/arm/mach-imx/hab.c
++++ b/arch/arm/mach-imx/hab.c
+@@ -18,6 +18,8 @@
+ #include <asm/mach-imx/hab.h>
+ #include <linux/arm-smccc.h>
+ 
++#include<tdx-hab-utils.h>
++
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+ #define ALIGN_SIZE		0x1000
+@@ -454,6 +456,7 @@ static int get_hab_status(void)
+ 	size_t bytes = sizeof(event_data); /* Event size in bytes */
+ 	enum hab_config config = 0;
+ 	enum hab_state state = 0;
++	int retval = 0;
+ 
+ 	if (imx_hab_is_enabled())
+ 		puts("\nSecure boot enabled\n");
+@@ -476,6 +479,13 @@ static int get_hab_status(void)
+ 			puts("\n");
+ 			bytes = sizeof(event_data);
+ 			index++;
++#ifdef IGNORE_KNOWN_HAB_EVENTS
++                        if(!is_known_fail_event(event_data, bytes)) {
++				retval = 1;
++			}
++#else
++			retval = 1;
++#endif
+ 		}
+ 	}
+ 	/* Display message if no HAB events are found */
+@@ -484,7 +494,7 @@ static int get_hab_status(void)
+ 		       config, state);
+ 		puts("No HAB Events Found!\n\n");
+ 	}
+-	return 0;
++	return retval;
+ }
+ 
+ #ifdef CONFIG_MX7ULP
+@@ -562,6 +572,7 @@ static int get_hab_status_m4(void)
+ static int do_hab_status(struct cmd_tbl *cmdtp, int flag, int argc,
+ 			 char *const argv[])
+ {
++	int retval;
+ #ifdef CONFIG_MX7ULP
+ 	if ((argc > 2)) {
+ 		cmd_usage(cmdtp);
+@@ -578,10 +589,10 @@ static int do_hab_status(struct cmd_tbl *cmdtp, int flag, int argc,
+ 		return 1;
+ 	}
+ 
+-	get_hab_status();
++	retval = get_hab_status();
+ #endif
+ 
+-	return 0;
++	return retval;
+ }
+ 
+ static ulong get_image_ivt_offset(ulong img_addr)
+-- 
+2.30.2
+

--- a/recipes-bsp/u-boot/u-boot-toradex_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-toradex_%.bbappend
@@ -1,4 +1,5 @@
 require u-boot-ota.inc
+require u-boot-fuse.inc
 
 deploy_uboot_with_spl () {
     #Deploy u-boot-with-spl.imx

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,1 +1,2 @@
 require u-boot-ota.inc
+require u-boot-fuse.inc


### PR DESCRIPTION
…X only)

This mechanism allows the programming of HAB/AHAB fuses via u-boot variables. The following u-boot variables can be set for this mechanism to work:

* fuse_prog_list: An ordered, space separated list of hex values to be programmed into the fuses.

* fuse_prog_close: A boolean 1 or 0 for whether the device should be closed for HAB/AHAB. This variable is optional and if it does not exist it's the same as if it was 0.

* fuse_dry_run: Boolean 1 or 0. Causes the logic to do a dry run of the actions without actually programming any fuses.

As feedback this mechanism will set the following environment variables.

* fuse_val_N: This contains the hex value currently programmed in the Nth HAB/AHAB fuse on this device.

* fuse_fail: This will be set to 1 if any errors are detected in the process of programming the fuses on this device.

Related-to: TOR-3634