### PR TITLE
Fix for OS rollback not working when kernel image type changes on update

### DIFF
--- a/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
+++ b/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
@@ -57,6 +57,7 @@ check_rollback_needed=if test -n "${kernel_image2}" && test "${rollback}" = "1";
     env set fdtdir ${fdtdir2}; \
     env set fdt_file ${fdt_file2}; \
     env set fdtfile ${fdtfile2}; \
+    test -n "${kernel_image_type2}" && env set kernel_image_type ${kernel_image_type2}; \
 fi || true
 
 set_fdt_path=if test -n "${fdtdir}"; then \

--- a/recipes-extended/ostree/files/0002-Add-support-for-the-fdtfile-variable-in-uEnv.txt.patch
+++ b/recipes-extended/ostree/files/0002-Add-support-for-the-fdtfile-variable-in-uEnv.txt.patch
@@ -1,7 +1,9 @@
-From 7a5048cc44966363a23c70ac15ad13d43d26e78d Mon Sep 17 00:00:00 2001
+From 2081a996bc941ff892fb6b76d23b1cc6bac00770 Mon Sep 17 00:00:00 2001
 From: Sergio Prado <sergio.prado@toradex.com>
 Date: Wed, 13 Jul 2022 14:52:33 -0300
-Subject: [PATCH 2/3] Add support for the fdtfile variable in uEnv.txt
+Subject: [PATCH 1/2] Add support for the fdtfile variable in uEnv.txt
+
+Comments for v1:
 
 When TorizonCore Builder applies a device tree to a TorizonCore
 image, the variable fdtfile is defined in uEnv.txt, instead of
@@ -11,65 +13,82 @@ This patch adds support in ostree to this variable, to make sure its
 rollback variant (fdtfile2) is created in an update, and used in a
 rollback situation.
 
-Upstream-Status: Inappropriate [TorizonCore specific]
-
 Signed-off-by: Sergio Prado <sergio.prado@toradex.com>
+
+Comments for v2:
+
+Fix memory leak and generalize the implementation to allow other fields
+to be searched in uEnv.txt.
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+
+Upstream-Status: Inappropriate [TorizonCore specific]
 ---
- src/libostree/ostree-bootloader-uboot.c | 34 +++++++++++++++++++++++++
- 1 file changed, 34 insertions(+)
+ src/libostree/ostree-bootloader-uboot.c | 44 +++++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
 
 diff --git a/src/libostree/ostree-bootloader-uboot.c b/src/libostree/ostree-bootloader-uboot.c
-index 41280cf1..6242781b 100644
+index 41280cf1..6eb41e4e 100644
 --- a/src/libostree/ostree-bootloader-uboot.c
 +++ b/src/libostree/ostree-bootloader-uboot.c
-@@ -98,6 +98,36 @@ append_system_uenv (OstreeBootloaderUboot *self, const char *bootargs, GPtrArray
+@@ -98,6 +98,40 @@ append_system_uenv (OstreeBootloaderUboot *self, const char *bootargs, GPtrArray
    return TRUE;
  }
  
-+static gboolean
-+search_fdtfile (const char  *line,
-+                void        *data,
-+                GError     **error)
++struct uboot_config_get_params
 +{
++  const char *key; /* in */
++  const char *val; /* out */
++};
++
++static gboolean
++uboot_config_get_helper (const char *line, void *data, GError **error)
++{
++  struct uboot_config_get_params *params = data;
 +  g_auto(GStrv) vars = g_strsplit(line, "=", -1);
-+  if (!g_strcmp0 (vars[0], "fdtfile"))
++  if (!g_strcmp0 (vars[0], params->key))
 +    {
-+      gchar **val = data;
-+      *val = g_strdup (vars[1]);
++      params->val = g_strdup (vars[1]);
 +      return 0;
 +    }
 +  return 1;
 +}
 +
++/* The caller becomes the owner of the returned pointer. */
 +static const char *
-+uboot_config_get_fdtfile (GCancellable  *cancellable,
-+                          GError        **error)
++uboot_config_get (const char *key, GCancellable *cancellable, GError **error)
 +{
 +  const char *cfgfile = "/usr/lib/ostree-boot/uEnv.txt";
-+  const char *val = NULL;
++  struct uboot_config_get_params params = { .key = key, .val = NULL };
 +
-+  if (!g_file_test(cfgfile, G_FILE_TEST_EXISTS))
++  if (!g_file_test (cfgfile, G_FILE_TEST_EXISTS))
 +    return NULL;
 +
-+  ot_parse_file_by_line (cfgfile, search_fdtfile, &val, cancellable, error);
++  ot_parse_file_by_line (cfgfile, uboot_config_get_helper, &params, cancellable, error);
 +
-+  return val;
++  return params.val;
 +}
 +
  static gboolean
  create_config_from_boot_loader_entries (OstreeBootloaderUboot *self, int bootversion,
                                          GPtrArray *new_lines, GCancellable *cancellable,
-@@ -141,6 +171,10 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot *self, int bootver
+@@ -141,6 +175,16 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot *self, int bootver
        if (val)
          g_ptr_array_add (new_lines, g_strdup_printf ("fdtdir%s=/boot%s", index_suffix, val));
  
-+      val = uboot_config_get_fdtfile(cancellable, error);
-+      if (val && i)
-+        g_ptr_array_add (new_lines, g_strdup_printf ("fdtfile%s=%s", index_suffix, val));
++      if (i)
++        {
++          val = uboot_config_get ("fdtfile", cancellable, error);
++          if (val)
++            {
++              g_ptr_array_add (new_lines, g_strdup_printf ("fdtfile%s=%s", index_suffix, val));
++              g_free (val);
++            }
++        }
 +
        val = ostree_bootconfig_parser_get (config, "options");
        if (val)
          {
 -- 
-2.25.1
+2.34.1
 

--- a/recipes-extended/ostree/files/0005-Add-support-for-kernel_image_type-in-uEnv.txt.patch
+++ b/recipes-extended/ostree/files/0005-Add-support-for-kernel_image_type-in-uEnv.txt.patch
@@ -1,0 +1,44 @@
+From 4ba5b9e295e4dd5db69e10215859d68b5512da25 Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Tue, 3 Dec 2024 18:08:12 -0300
+Subject: [PATCH 2/2] Add support for kernel_image_type in uEnv.txt
+
+Save uEnv.txt variable "kernel_image_type" from the previous deployment
+to allow rollbacks to work when an OS update changes the kernel image
+type, which would be the case when upgrading from unsigned to signed
+images (or the reverse).
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Related-to: TOR-3563
+
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ src/libostree/ostree-bootloader-uboot.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/libostree/ostree-bootloader-uboot.c b/src/libostree/ostree-bootloader-uboot.c
+index 6eb41e4e..a566b997 100644
+--- a/src/libostree/ostree-bootloader-uboot.c
++++ b/src/libostree/ostree-bootloader-uboot.c
+@@ -193,6 +193,17 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot *self, int bootver
+             if (!append_system_uenv (self, val, new_lines, cancellable, error))
+               return FALSE;
+         }
++
++      if (i)
++        {
++          val = uboot_config_get ("kernel_image_type", cancellable, error);
++          if (val)
++            {
++              g_ptr_array_add (new_lines,
++                               g_strdup_printf ("kernel_image_type%s=%s", index_suffix, val));
++              g_free (val);
++            }
++        }
+     }
+ 
+   return TRUE;
+-- 
+2.34.1
+

--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -7,6 +7,7 @@ SRC_URI:append = " \
     file://0002-Add-support-for-the-fdtfile-variable-in-uEnv.txt.patch \
     file://0003-ostree-fetcher-curl-set-max-parallel-connections.patch \
     file://0004-curl-Make-socket-callback-during-cleanup-into-no-op.patch \
+    file://0005-Add-support-for-kernel_image_type-in-uEnv.txt.patch \
     file://0001-mount-Allow-building-when-macro-MOUNT_ATTR_IDMAP-is-.patch \
     file://0002-mount-Allow-building-when-macro-LOOP_CONFIGURE-is-no.patch \
     file://ostree-pending-reboot.service \


### PR DESCRIPTION
This fixes an issue with the rollback feature that happens when the kernel image type changes during an OS update; for example, when one switches from a standard (non secboot) to a secboot image.

See commit messages for further details.
