### PR TITLE
[Master] systemd: fix usage of deprecated rootlibexecdir variable

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -60,5 +60,5 @@ do_install:append() {
     # The default SaveIntervalSec (60 secs) is too frequent, change to 1 hour
     sed -i -e "s/^.*SaveIntervalSec.*$/SaveIntervalSec=3600/" ${D}${sysconfdir}/systemd/timesyncd.conf
 
-    install -m 755 ${UNPACKDIR}/torizon-recover ${D}${rootlibexecdir}/systemd
+    install -m 755 ${UNPACKDIR}/torizon-recover ${D}${nonarch_libdir}/systemd
 }


### PR DESCRIPTION
This variable has been deprecated on version 255, in favor of 'nonarch_libdir', and removed from systemd's recipe.[1]

We caught this issue on our latest Jenkins build of master:
```
12-08:13:23:31  ERROR: systemd-1_256.8-r0 do_package: QA Issue: systemd: Files/directories were installed but not shipped in any package:
12-08:13:23:31    /systemd
```

[1] https://github.com/openembedded/openembedded-core/commit/c89b34401dfbe65de5a32bf8b4ef32902d868ce1