### PR TITLE
udev: toradex-net-rename: refactor rename script and rules for AM69

### DIFF
--- a/recipes-core/udev/files/10-toradex-net-rename.rules
+++ b/recipes-core/udev/files/10-toradex-net-rename.rules
@@ -1,2 +1,3 @@
 #Assign predictable names to Toradex net devices
-SUBSYSTEM=="net", ATTR{address}=="00:14:2d*", ACTION=="add", PROGRAM="/usr/bin/toradex-net-rename.sh %k", NAME="%c{1}"
+SUBSYSTEM=="net", ATTR{address}=="00:14:2d*", ACTION=="add", PROGRAM="/usr/bin/toradex-net-rename.sh 00:14:2d %k", NAME="%c{1}"
+SUBSYSTEM=="net", ATTR{address}=="8c:06:cb*", ACTION=="add", PROGRAM="/usr/bin/toradex-net-rename.sh 8c:06:cb %k", NAME="%c{1}"


### PR DESCRIPTION
Since the MAC address range we have is almost finished, Toradex has bought a new range of MAC addresses and is utilizing it with its new Aquila AM69.

For t his reason, we had to adapt our udev rule and refactor the script to accommodate this new range.

Related-to: TOR-3630