### PR TITLE
u-boot-distro-boot: fix 'get_bank_word_internal' with empty strings

### DIFF
--- a/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
@@ -147,7 +147,6 @@ def get_bank_word_internal(d):
 BANK_WORD_INTERNAL = "${@get_bank_word_internal(d)}"
 
 do_compile:append () {
-    bbwarn "internal ${BANK_WORD_INTERNAL}"
     bbdebug 1 "Building uEnv.txt..."
     sed -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
         -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \

--- a/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
@@ -134,7 +134,11 @@ UENV_VARS_TO_DEL_EXTRA ?= "kernel_image \
 "
 
 def get_bank_word_internal(d):
-    bank_word_in=list(eval(d.getVar("BANK_WORD")))
+    bank_word_var = d.getVar("BANK_WORD")
+    if not bank_word_var:
+        return ""
+
+    bank_word_in=list(eval(bank_word_var))
     bank_word=""
     for i, bw in enumerate(bank_word_in, start=1):
         bank_word+="fuse_bank_word_{}={} {};\\n".format(i, bw[0], bw[1])


### PR DESCRIPTION
For unsupported machines, BANK_WORD is an empty string and since this was not being handled on this function we had an exception in this function that caused the build to fail.

Now if BANK_WORD is empty, we return early with "" as well.

Related-to: TOR-3664