### PR TITLE
Add support for upgrading from BCoT to ECoT

### DIFF
--- a/recipes-core/initramfs-framework/files/composefs
+++ b/recipes-core/initramfs-framework/files/composefs
@@ -2,6 +2,12 @@
 # Copyright (C) 2023 Toradex AG.
 # Licensed on MIT
 
+# Enable additions to allow upgrades from legacy to composefs-based storage (OSTree).
+CFS_UPGRADE_ENABLE="${CFS_UPGRADE_ENABLE:-@@CFS_UPGRADE_ENABLE@@}"
+
+# Force enabling fsverity (mostly for debugging purposes).
+CFS_ALWAYS_ENABLE="${CFS_ALWAYS_ENABLE:-0}"
+
 SYSROOT_DIR="/sysroot"
 COMPOSEFS_NAME=".ostree.cfs"
 PREPARE_ROOT_CFG="/usr/lib/ostree/prepare-root.conf"
@@ -10,24 +16,25 @@ composefs_enabled() {
 	return 0
 }
 
-composefs_error() {
-	fatal "$@"
+composefs_warn() {
+	msg "## WARNING: $*"
 }
 
 composefs_enable_fsverity_fs() {
 	root_dev=$(mount | sed -ne "\#${ROOTFS_DIR}# {s# *\(/dev/[^ ]*\) .*#\1#p}")
 	if [ ! -b "${root_dev}" ]; then
-		msg "Could not determine root device!"
+		composefs_warn "Could not determine root device!"
 		return 1
 	fi
+
 	if tune2fs -l "${root_dev}" 2>/dev/null | \
-	   grep -i 'filesystem features:.*\bverity\b' >/dev/null; then
+	   grep -q -i 'filesystem features:.*\bverity\b'; then
 		debug 'Feature "verity" is already enabled on the filesystem.'
 	else
 		if tune2fs -O verity "${root_dev}"; then
 			msg 'Enabling "verity" feature on the filesystem succeeded.'
 		else
-			msg 'Enabling "verity" feature on the filesystem FAILED.'
+			composefs_warn 'Enabling "verity" feature on the filesystem FAILED.'
 			return 1
 		fi
 	fi
@@ -55,10 +62,10 @@ composefs_progress() {
 	bar_len="50"
 	bar_done="$((bar_len * bar_cur / bar_tot))"
 	bar_todo="$((bar_len - bar_done))"
-	bar_str1="$(printf "%*s" ${bar_done} | tr ' ' '=')"
-	bar_str2="$(printf "%*s" ${bar_todo} | tr ' ' '.')"
-	bar_str3="$(printf "%d" ${bar_cur})"
-	bar_str4="$(printf "%d" ${bar_tot})"
+	bar_str1="$(printf "%*s" "${bar_done}" '' | tr ' ' '=')"
+	bar_str2="$(printf "%*s" "${bar_todo}" '' | tr ' ' '.')"
+	bar_str3="$(printf "%d" "${bar_cur}")"
+	bar_str4="$(printf "%d" "${bar_tot}")"
 
 	bar_str="$(printf "\rProgress: [%s%s] (%5s/%5s)" "${bar_str1}" "${bar_str2}" "${bar_str3}" "${bar_str4}")"
 
@@ -75,22 +82,40 @@ composefs_progress() {
 # "findutils" and "fsverity-utils".
 #
 composefs_enable_fsverity_files() {
-	nfiles="$(find "${SYSROOT_DIR}/ostree/repo/objects" \! -type d | wc -l)"
+	nfiles="$(find "${SYSROOT_DIR}/ostree/repo/objects" -type f | wc -l)"
 	count="0"
+	tmpf="$(mktemp)"
 
-	# Enable verity in all repository objects.
-	find "${SYSROOT_DIR}/ostree/repo/objects" \! -type d | while read fname; do
+	# Enable verity on all repository files.
+	find "${SYSROOT_DIR}/ostree/repo/objects" -type f | while read -r fname; do
 		composefs_progress "${count}" "${nfiles}"
-		fsverity enable "${fname}" 2>/dev/null
+		{ fsverity enable "${fname}" || fsverity measure "${fname}"; } >/dev/null 2>/dev/null
+		# shellcheck disable=SC2181
+		if [ "$?" -ne 0 ]; then
+			echo "ERROR: Could not enable fsverity on '${fname}'." >>"${tmpf}"
+		fi
 		count=$((count + 1))
 	done
 
 	composefs_progress "${nfiles}" "${nfiles}" "1"
+	msg ""
 
 	# And also on the composefs file of every deployment.
-	for cfsfile_ in "${SYSROOT_DIR}/ostree/deploy"/*/deploy/*/"${COMPOSEFS_NAME}"; do
-		fsverity enable "${cfsfile_}" 2>/dev/null
+	for fname in $(ls -1 "${SYSROOT_DIR}/ostree/deploy"/*/deploy/*/"${COMPOSEFS_NAME}" 2>/dev/null); do
+		{ fsverity enable "${fname}" || fsverity measure "${fname}"; } >/dev/null 2>/dev/null
+		# shellcheck disable=SC2181
+		if [ "$?" -ne 0 ]; then
+			echo "ERROR: Could not enable fsverity on '${fname}'." >>"${tmpf}"
+		fi
 	done
+
+	nerrors=$(grep -c 'ERROR:' "${tmpf}")
+	if [ "${nerrors}" -ne 0 ]; then
+		msg "Could not enable fsverity on ${nerrors} files (out of ${nfiles})."
+		return 1
+	fi
+
+	return 0
 }
 
 composefs_ensure_fsverity() {
@@ -103,7 +128,7 @@ composefs_ensure_fsverity() {
 	# Allow setting composefs.enabled config via kernel cmdline;
 	# "cfs.enabled" could be set to false|true|signed or any other value accepted
 	# by "ostree-prepare-root".
-	if [ "${bootparam_cfs_enabled}" ]; then
+	if [ -n "${bootparam_cfs_enabled}" ]; then
 		debug "Overriding composefs.enabled: setting to ${bootparam_cfs_enabled}"
 		sed -i -e "/^\[composefs\]/,/^\[.*\]/ {s/^enabled[[:space:]]*=.*\$/enabled = ${bootparam_cfs_enabled}/}" "${PREPARE_ROOT_CFG}"
 	fi
@@ -113,39 +138,70 @@ composefs_ensure_fsverity() {
 	enabled="${enabled:-no}"
 	debug "composefs.enabled=${enabled}"
 
-	if [ "${enabled}" != "no" ]; then
-		# Enable fsverity at the filesystem level; errors here would be detected upon
-		# ostree deployment generation as well so we don't make them fatal here.
-		composefs_enable_fsverity_fs
+	if [ "${enabled}" = "no" ]; then
+		debug "composefs is not enabled in ${PREPARE_ROOT_CFG}"
+		return 0
 	fi
 
-	if [ "${enabled}" != "signed" ]; then
-		debug "composefs signing is not enabled in ${PREPARE_ROOT_CFG}"
-		return 0
+	# Enable fsverity at the filesystem level.
+	if ! composefs_enable_fsverity_fs; then
+		debug "Could not enable fsverity on the fs - avoid enabling it on individual files"
+		return 1
 	fi
 
 	if [ -z "${bootparam_ostree}" ]; then
-		debug "ostree= parameter not passed in kernel cmdline"
-		return 0
+		debug "Parameter ostree= not passed in kernel cmdline"
+		return 1
 	fi
 
 	# Determine deployment being booted from kernel cmdline:
 	deployment="$(realpath -e "${SYSROOT_DIR}${bootparam_ostree}" 2>/dev/null)"
-	cfsfile="${deployment}/${COMPOSEFS_NAME}"
-	lockfile="${cfsfile}.rdlock"
-
 	if [ -z "${deployment}" ]; then
 		debug "Could not determine current deployment (ostree=${bootparam_ostree})"
 		return 1
 	fi
 
-	# We want to enable fsverity in the following cases:
+	cfsfile="${deployment}/${COMPOSEFS_NAME}"
+	lockfile="${SYSROOT_DIR}/ostree/repo/enable-verity.lock"
+
+	if [ ! -f "${cfsfile}" ]; then
+		debug "File '${cfsfile}' does not exist"
+	fi
+
+	# Handle the case where fsverity is partially enabled on the repository; this would normally
+	# happen when transitioning from legacy to composefs-backed installations.
+	enable_verity_on_upgrade="0"
+	if [ "${CFS_UPGRADE_ENABLE}" = "1" ]; then
+		# Use the /usr/etc/os-release file to figure out if fsverity is not enabled in some
+		# of the deployments.
+		osrfiles=$(ls -1 ${SYSROOT_DIR}/ostree/deploy/torizon/deploy/*/usr/etc/os-release 2>/dev/null)
+		for fn in ${osrfiles}; do
+			if ! fsverity measure "${fn}" >/dev/null 2>/dev/null; then
+				enable_verity_on_upgrade="1"
+				break
+			fi
+		done
+	fi
+
+	# We want to enable fsverity in any of the following cases:
 	#
-	# - If the lockfile exists (fsverity enabling operation may have been interrupted).
-	# - If fsverity is not enabled on the .cfs file.
+	# - If the lockfile exists; fsverity enabling operation may have been interrupted.
+	# - If fsverity is not enabled on the .cfs file; this would be the case after an OS
+	#   installation with e.g. Toradex Easy Installer (or any installer that unpacks a
+	#   tarball with the rootfs).
+	# - If we are upgrading from a legacy system and composefs is not enabled on some
+	#   files (this is optional and enabled by setting CFS_UPGRADE_ENABLE="1").
 	#
-	if [ ! -f "${lockfile}" ] && fsverity measure "${cfsfile}" >/dev/null 2>/dev/null; then
-		debug "fsverity is already enabled in storage"
+	if [ -f "${lockfile}" ]; then
+		debug "Lockfile exists - continue fsverity enabling"
+	elif [ -f "${cfsfile}" ] && ! fsverity measure "${cfsfile}" >/dev/null 2>/dev/null; then
+		debug "File '${cfsfile}' does not have fsverity info - start fsverity enabling"
+	elif [ "${enable_verity_on_upgrade}" = "1" ]; then
+		debug "Some deployment does not have fsverity info - start fsverity enabling"
+	elif [ "${CFS_ALWAYS_ENABLE}" = "1" ]; then
+		debug "CFS_ALWAYS_ENABLE is set - start fsverity enabling"
+	else
+		debug "Enabling fsverity on repository is not needed"
 		return 0
 	fi
 
@@ -159,18 +215,18 @@ composefs_ensure_fsverity() {
 
 	t0="$(date '+%s')"
 	composefs_enable_fsverity_files
+	composefs_enable_status="$?"
 	t1="$(date '+%s')"
 
 	# ---
 	rm "${lockfile}"
 
-	# Final result comes from measuring the composefs file (again):
-	if fsverity measure "${cfsfile}" >/dev/null 2>/dev/null; then
-		msg ""
-		msg "Enabling fsverity succeeded (after $((t1 - t0)) seconds)."
-	else
-		msg ""
-		msg "Enabling fsverity failed (system will not boot)."
+	msg "Enabling fsverity took $((t1 - t0)) seconds."
+
+	if [ "${composefs_enable_status}" -ne 0 ]; then
+		# TODO: Consider rebooting or forcing a rollback.
+		# TODO: Consider copying the file holding the errors somewhere.
+		composefs_warn "Enabling fsverity failed - system may not boot."
 		return 1
 	fi
 
@@ -188,5 +244,6 @@ composefs_run() {
 		composefs_ensure_fsverity
 	else
 		debug "No rootfs has been set"
+		return 1
 	fi
 }

--- a/recipes-core/initramfs-framework/files/composefs
+++ b/recipes-core/initramfs-framework/files/composefs
@@ -29,7 +29,7 @@ composefs_enable_fsverity_fs() {
 
 	if tune2fs -l "${root_dev}" 2>/dev/null | \
 	   grep -q -i 'filesystem features:.*\bverity\b'; then
-		debug 'Feature "verity" is already enabled on the filesystem.'
+		info 'Feature "verity" is already enabled on the filesystem.'
 	else
 		if tune2fs -O verity "${root_dev}"; then
 			msg 'Enabling "verity" feature on the filesystem succeeded.'
@@ -121,7 +121,7 @@ composefs_enable_fsverity_files() {
 composefs_ensure_fsverity() {
 	# Do we need fsverity?
 	if [ ! -f "${PREPARE_ROOT_CFG}" ]; then
-		debug "No ${PREPARE_ROOT_CFG} found - assuming fsverity is not needed"
+		info "No ${PREPARE_ROOT_CFG} found - assuming fsverity is not needed"
 		return 0
 	fi
 
@@ -129,7 +129,7 @@ composefs_ensure_fsverity() {
 	# "cfs.enabled" could be set to false|true|signed or any other value accepted
 	# by "ostree-prepare-root".
 	if [ -n "${bootparam_cfs_enabled}" ]; then
-		debug "Overriding composefs.enabled: setting to ${bootparam_cfs_enabled}"
+		info "Overriding composefs.enabled: setting to ${bootparam_cfs_enabled}"
 		sed -i -e "/^\[composefs\]/,/^\[.*\]/ {s/^enabled[[:space:]]*=.*\$/enabled = ${bootparam_cfs_enabled}/}" "${PREPARE_ROOT_CFG}"
 	fi
 
@@ -139,25 +139,25 @@ composefs_ensure_fsverity() {
 	debug "composefs.enabled=${enabled}"
 
 	if [ "${enabled}" = "no" ]; then
-		debug "composefs is not enabled in ${PREPARE_ROOT_CFG}"
+		info "composefs is not enabled in ${PREPARE_ROOT_CFG}"
 		return 0
 	fi
 
 	# Enable fsverity at the filesystem level.
 	if ! composefs_enable_fsverity_fs; then
-		debug "Could not enable fsverity on the fs - avoid enabling it on individual files"
+		info "Could not enable fsverity on the fs - avoid enabling it on individual files"
 		return 1
 	fi
 
 	if [ -z "${bootparam_ostree}" ]; then
-		debug "Parameter ostree= not passed in kernel cmdline"
+		info "Parameter ostree= not passed in kernel cmdline"
 		return 1
 	fi
 
 	# Determine deployment being booted from kernel cmdline:
 	deployment="$(realpath -e "${SYSROOT_DIR}${bootparam_ostree}" 2>/dev/null)"
 	if [ -z "${deployment}" ]; then
-		debug "Could not determine current deployment (ostree=${bootparam_ostree})"
+		info "Could not determine current deployment (ostree=${bootparam_ostree})"
 		return 1
 	fi
 
@@ -165,7 +165,7 @@ composefs_ensure_fsverity() {
 	lockfile="${SYSROOT_DIR}/ostree/repo/enable-verity.lock"
 
 	if [ ! -f "${cfsfile}" ]; then
-		debug "File '${cfsfile}' does not exist"
+		info "File '${cfsfile}' does not exist"
 	fi
 
 	# Handle the case where fsverity is partially enabled on the repository; this would normally
@@ -193,15 +193,15 @@ composefs_ensure_fsverity() {
 	#   files (this is optional and enabled by setting CFS_UPGRADE_ENABLE="1").
 	#
 	if [ -f "${lockfile}" ]; then
-		debug "Lockfile exists - continue fsverity enabling"
+		info "Lockfile exists - continue fsverity enabling"
 	elif [ -f "${cfsfile}" ] && ! fsverity measure "${cfsfile}" >/dev/null 2>/dev/null; then
-		debug "File '${cfsfile}' does not have fsverity info - start fsverity enabling"
+		info "File '${cfsfile}' does not have fsverity info - start fsverity enabling"
 	elif [ "${enable_verity_on_upgrade}" = "1" ]; then
-		debug "Some deployment does not have fsverity info - start fsverity enabling"
+		info "Some deployment does not have fsverity info - start fsverity enabling"
 	elif [ "${CFS_ALWAYS_ENABLE}" = "1" ]; then
-		debug "CFS_ALWAYS_ENABLE is set - start fsverity enabling"
+		info "CFS_ALWAYS_ENABLE is set - start fsverity enabling"
 	else
-		debug "Enabling fsverity on repository is not needed"
+		info "Enabling fsverity on repository is not needed"
 		return 0
 	fi
 
@@ -234,7 +234,7 @@ composefs_ensure_fsverity() {
 }
 
 composefs_run() {
-	debug "Running composefs script..."
+	info "Running composefs script..."
 
 	if [ -d "${ROOTFS_DIR}" ]; then
 		# When built with composefs support ostree-prepare-root will
@@ -243,7 +243,7 @@ composefs_run() {
 		ln -sf "${ROOTFS_DIR}" "${SYSROOT_DIR}"
 		composefs_ensure_fsverity
 	else
-		debug "No rootfs has been set"
+		info "No rootfs has been set"
 		return 1
 	fi
 }

--- a/recipes-core/initramfs-framework/files/composefs
+++ b/recipes-core/initramfs-framework/files/composefs
@@ -14,6 +14,27 @@ composefs_error() {
 	fatal "$@"
 }
 
+composefs_enable_fsverity_fs() {
+	root_dev=$(mount | sed -ne "\#${ROOTFS_DIR}# {s# *\(/dev/[^ ]*\) .*#\1#p}")
+	if [ ! -b "${root_dev}" ]; then
+		msg "Could not determine root device!"
+		return 1
+	fi
+	if tune2fs -l "${root_dev}" 2>/dev/null | \
+	   grep -i 'filesystem features:.*\bverity\b' >/dev/null; then
+		debug 'Feature "verity" is already enabled on the filesystem.'
+	else
+		if tune2fs -O verity "${root_dev}"; then
+			msg 'Enabling "verity" feature on the filesystem succeeded.'
+		else
+			msg 'Enabling "verity" feature on the filesystem FAILED.'
+			return 1
+		fi
+	fi
+
+	return 0
+}
+
 # $1: number of currently processed items
 # $2: total number of items to process
 # $3: (optional) when set to "1", a newline is added at the end
@@ -53,7 +74,7 @@ composefs_progress() {
 # which doesn't look like a good idea. Instead, here we depend only on
 # "findutils" and "fsverity-utils".
 #
-composefs_enable_fsverity_all() {
+composefs_enable_fsverity_files() {
 	nfiles="$(find "${SYSROOT_DIR}/ostree/repo/objects" \! -type d | wc -l)"
 	count="0"
 
@@ -87,9 +108,17 @@ composefs_ensure_fsverity() {
 		sed -i -e "/^\[composefs\]/,/^\[.*\]/ {s/^enabled[[:space:]]*=.*\$/enabled = ${bootparam_cfs_enabled}/}" "${PREPARE_ROOT_CFG}"
 	fi
 
-	# Check configuration key composefs.enabled; this could be set to true|false|signed.
+	# Check configuration key composefs.enabled; this could be set to no|maybe|yes|signed.
 	enabled="$(sed -n -e '/^\[composefs\]/,/^\[.*\]/ {s/^enabled[[:space:]]*=[[:space:]]*\([^[:space:]]*\)/\1/p}' "${PREPARE_ROOT_CFG}")"
+	enabled="${enabled:-no}"
 	debug "composefs.enabled=${enabled}"
+
+	if [ "${enabled}" != "no" ]; then
+		# Enable fsverity at the filesystem level; errors here would be detected upon
+		# ostree deployment generation as well so we don't make them fatal here.
+		composefs_enable_fsverity_fs
+	fi
+
 	if [ "${enabled}" != "signed" ]; then
 		debug "composefs signing is not enabled in ${PREPARE_ROOT_CFG}"
 		return 0
@@ -129,7 +158,7 @@ composefs_ensure_fsverity() {
 	msg ""
 
 	t0="$(date '+%s')"
-	composefs_enable_fsverity_all
+	composefs_enable_fsverity_files
 	t1="$(date '+%s')"
 
 	# ---

--- a/recipes-core/initramfs-framework/files/rootfs
+++ b/recipes-core/initramfs-framework/files/rootfs
@@ -39,24 +39,13 @@ rootfs_run() {
 			if [ "`echo ${bootparam_root} | cut -c1-5`" = "UUID=" ]; then
 				root_uuid=`echo $bootparam_root | cut -c6-`
 				bootparam_root="/dev/disk/by-uuid/$root_uuid"
-			fi
-
-			if [ "`echo ${bootparam_root} | cut -c1-9`" = "PARTUUID=" ]; then
+			elif [ "`echo ${bootparam_root} | cut -c1-9`" = "PARTUUID=" ]; then
 				root_partuuid=`echo $bootparam_root | cut -c10-`
 				bootparam_root="/dev/disk/by-partuuid/$root_partuuid"
-			fi
-
-			if [ "`echo ${bootparam_root} | cut -c1-10`" = "PARTLABEL=" ]; then
+			elif [ "`echo ${bootparam_root} | cut -c1-10`" = "PARTLABEL=" ]; then
 				root_partlabel=`echo $bootparam_root | cut -c11-`
 				bootparam_root="/dev/disk/by-partlabel/$root_partlabel"
-			fi
-
-			if [ "`echo ${bootparam_root} | cut -c1-10`" = "PARTLABEL=" ]; then
-				root_partlabel=`echo $bootparam_root | cut -c11-`
-				bootparam_root="/dev/disk/by-partlabel/$root_partlabel"
-			fi
-
-			if [ "`echo ${bootparam_root} | cut -c1-6`" = "LABEL=" ]; then
+			elif [ "`echo ${bootparam_root} | cut -c1-6`" = "LABEL=" ]; then
 				root_label=`echo $bootparam_root | cut -c7-`
 				bootparam_root="/dev/disk/by-label/$root_label"
 			fi
@@ -83,10 +72,10 @@ rootfs_run() {
 					# It is unlikely to change, but keep trying anyway.
 					# Perhaps we pick a different device next time.
 					umount $ROOTFS_DIR
-					fi
 				fi
+			fi
 		fi
-		debug "Sleeping for $delay second(s) to wait root to settle..."
+		debug "Sleeping for $delay second(s) to wait for root to settle..."
 		sleep $delay
 		C=$(( $C + 1 ))
 	done

--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -58,6 +58,8 @@ do_install:append() {
 
 require recipes-extended/ostree/ostree-prepare-root.inc
 
+CFS_UPGRADE_ENABLE ?= "0"
+
 do_install:append:cfs-support() {
     # Bundled into initramfs-module-kmod package:
     install -d ${D}/etc/modules-load.d/
@@ -65,6 +67,8 @@ do_install:append:cfs-support() {
 
     # Bundled into initramfs-module-composefs package:
     install -m 0755 ${WORKDIR}/composefs ${D}/init.d/94-composefs
+    sed -i -e 's/@@CFS_UPGRADE_ENABLE@@/${CFS_UPGRADE_ENABLE}/g' ${D}/init.d/94-composefs
+
     install -d ${D}${nonarch_libdir}/ostree/
     install -m 0644 /dev/null ${D}${nonarch_libdir}/ostree/prepare-root.conf
     write_prepare_root_config ${D}${nonarch_libdir}/ostree/prepare-root.conf

--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -33,7 +33,7 @@ FILES:initramfs-module-ostree = "/init.d/95-ostree"
 
 SUMMARY:initramfs-module-composefs = "initramfs support for booting composefs images"
 RDEPENDS:initramfs-module-composefs = "${PN}-base"
-RDEPENDS:initramfs-module-composefs:append:cfs-signed = " fsverity-utils"
+RDEPENDS:initramfs-module-composefs:append:cfs-signed = " fsverity-utils e2fsprogs-tune2fs"
 RRECOMMENDS:initramfs-module-composefs = "kernel-module-erofs kernel-module-overlay"
 FILES:initramfs-module-composefs = "\
     /init.d/94-composefs \

--- a/recipes-extended/ostree/files/ostree-repo-config.service
+++ b/recipes-extended/ostree/files/ostree-repo-config.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Update static OSTree repository configuration
+Before=aktualizr.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/sysroot
+ExecStart=/usr/sbin/ostree-repo-config.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-extended/ostree/files/ostree-repo-config.sh
+++ b/recipes-extended/ostree/files/ostree-repo-config.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+CFG_COMPOSEFS=${OSTREE_REPO_CFG_COMPOSEFS:-@@OSTREE_REPO_CFG_COMPOSEFS@@}
+CFG_FSVERITY=${OSTREE_REPO_CFG_FSVERITY:-@@OSTREE_REPO_CFG_FSVERITY@@}
+
+ostree_cfg_set() {
+    local key=${1?key required}
+    local val=${2}
+    local cur=$(ostree config get "${key}" 2>/dev/null)
+
+    if [ "$val" != "$cur" ]; then
+	# Avoid writing to the file if the value is already set as expected.
+	if [ -n "${val}" ]; then
+	    echo "setting ostree config '${key}' to '${val}'"
+	    ostree config set "${key}" "${val}"
+	else
+	    echo "clearing ostree config '${key}'"
+	    ostree config unset "${key}"
+	fi
+    else
+	echo "ostree config '${key}' is already set to '${val}'"
+    fi
+}
+
+ostree_cfg_set "ex-integrity.composefs" "${CFG_COMPOSEFS}"
+ostree_cfg_set "ex-integrity.fsverity" "${CFG_FSVERITY}"

--- a/recipes-extended/ostree/ostree-prepare-root.inc
+++ b/recipes-extended/ostree/ostree-prepare-root.inc
@@ -4,9 +4,10 @@
 # - PREP_ROOT_CFS_ENABLED: enabling of composefs ("yes", "no", "maybe" or "signed")
 #
 PREP_ROOT_ETC_TRANSIENT ?= "true"
-PREP_ROOT_CFS_ENABLED ?= "no"
-PREP_ROOT_CFS_ENABLED:cfs-support ?= "yes"
-PREP_ROOT_CFS_ENABLED:cfs-signed ?= "signed"
+PREP_ROOT_CFS_ENABLED_DEFAULT = "no"
+PREP_ROOT_CFS_ENABLED_DEFAULT:cfs-support = "yes"
+PREP_ROOT_CFS_ENABLED_DEFAULT:cfs-signed = "signed"
+PREP_ROOT_CFS_ENABLED ?= "${PREP_ROOT_CFS_ENABLED_DEFAULT}"
 
 write_prepare_root_config() {
     local outfile="${1?Output file name required}"

--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -12,6 +12,8 @@ SRC_URI:append = " \
     file://0002-mount-Allow-building-when-macro-LOOP_CONFIGURE-is-no.patch \
     file://ostree-pending-reboot.service \
     file://ostree-pending-reboot.path \
+    file://ostree-repo-config.sh \
+    file://ostree-repo-config.service \
 "
 
 # TODO: Upstream this addition.
@@ -41,6 +43,25 @@ PACKAGECONFIG:append:cfs-support = " composefs"
 PACKAGECONFIG:append:cfs-signed = " ed25519-libsodium"
 
 SYSTEMD_SERVICE:${PN} += "ostree-pending-reboot.path ostree-pending-reboot.service"
+
+# OSTREE_REPO_CFG_...: configurations to be set by "ostree config set <key>"
+# executed on the sysroot of the running device - operation performed by the
+# service ostree-repo-config.
+#
+# OSTREE_REPO_CFG_COMPOSEFS: related to key=ex-integrity.composefs (no|yes|maybe).
+# OSTREE_REPO_CFG_FSVERITY: related to key=ex-integrity.fsverity (no|yes|maybe).
+#
+OSTREE_REPO_CFG_COMPOSEFS_DEFAULT = ""
+OSTREE_REPO_CFG_COMPOSEFS_DEFAULT:cfs-support = "yes"
+OSTREE_REPO_CFG_COMPOSEFS_DEFAULT:cfs-signed = "yes"
+OSTREE_REPO_CFG_COMPOSEFS ?= "${OSTREE_REPO_CFG_COMPOSEFS_DEFAULT}"
+
+OSTREE_REPO_CFG_FSVERITY_DEFAULT = ""
+OSTREE_REPO_CFG_FSVERITY_DEFAULT:cfs-support = "maybe"
+OSTREE_REPO_CFG_FSVERITY_DEFAULT:cfs-signed = "yes"
+OSTREE_REPO_CFG_FSVERITY ?= "${OSTREE_REPO_CFG_FSVERITY_DEFAULT}"
+
+SYSTEMD_SERVICE:${PN}:append:cfs-support = " ostree-repo-config.service"
 
 def is_ti(d):
     overrides = d.getVar('OVERRIDES')
@@ -78,4 +99,11 @@ require ostree-prepare-root.inc
 do_install:append:cfs-support() {
     install -m 0644 /dev/null ${D}${nonarch_libdir}/ostree/prepare-root.conf
     write_prepare_root_config ${D}${nonarch_libdir}/ostree/prepare-root.conf
+
+    install -m 0644 ${WORKDIR}/ostree-repo-config.service ${D}${systemd_system_unitdir}
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/ostree-repo-config.sh ${D}${sbindir}
+    sed -e 's/@@OSTREE_REPO_CFG_COMPOSEFS@@/${OSTREE_REPO_CFG_COMPOSEFS}/' \
+        -e 's/@@OSTREE_REPO_CFG_FSVERITY@@/${OSTREE_REPO_CFG_FSVERITY}/' \
+        -i ${D}${sbindir}/ostree-repo-config.sh
 }


### PR DESCRIPTION
The main difference between BCoT (basic chain of trust) and ECoT (extended chain of trust) is the addition of the root filesystem protections to ensure integrity and authenticity, both of which achieved by the use of composefs.

In this PR we add a the capability of upgrading a legacy OSTree installation (based on hard links) to one backed by composefs. Overall, the upgrade method introduced here involves:

- Implementation inside the initial ramdisk to enable fsverity on the filesystem and on the individual files in the OSTree repository.
- A systemd service responsible for changing the OSTree repository configuration (which is itself kept outside of OSTree) to enable both composefs and fsverity on the OSTree/libostree side.

For further details, please refer to the commit messages.

**NOTE**: The actual upgrade will require very specific steps which will be documented later.
