### PR TITLE
Improvements and bug fix to the fusing feature

### DIFF
--- a/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
@@ -10,6 +10,19 @@ SRC_URI:append = " \
 # representing device-tree overlays) to be used when booting.
 FITCONF_FDT_OVERLAYS ??= ""
 
+# Fusing support inside uEnv.txt:
+#
+# - FUSE_SUPPORT_SIGNED_BUILD: internal usage (automatically set to "1" on tdx-signed builds).
+# - FUSE_SUPPORT_DEFAULT: internal usage (default value of FUSE_SUPPORT)
+# - FUSE_SUPPORT: whether or not to add support for fusing in uEnv.txt.
+# - FUSE_SUPPORT_TYPE: type of support to add (allowed value: "NXP").
+#
+FUSE_SUPPORT_SIGNED_BUILD = "0"
+FUSE_SUPPORT_SIGNED_BUILD:tdx-signed = "1"
+FUSE_SUPPORT_DEFAULT = "0"
+FUSE_SUPPORT ?= "${FUSE_SUPPORT_DEFAULT}"
+FUSE_SUPPORT_TYPE = ""
+
 # Machine specific values related to HAB/AHAB fusing (i.MX specific)
 BANK_WORD = ""
 FUSE_NUM = ""
@@ -52,26 +65,36 @@ BANK_WORD:mx6ull-generic-bsp = "${IMX6_COMMON_BANK_WORD}"
 FUSE_NUM:mx6ull-generic-bsp = "${FUSE_NUM_8}"
 STATUS_CMD:mx6ull-generic-bsp = "${HAB_STATUS_CMD}"
 CLOSE_CMD:mx6ull-generic-bsp = "${IMX6_COMMON_CLOSE_CMD}"
+FUSE_SUPPORT_DEFAULT:mx6ull-generic-bsp = "${FUSE_SUPPORT_SIGNED_BUILD}"
+FUSE_SUPPORT_TYPE:mx6ull-generic-bsp = "NXP"
 
 BANK_WORD:mx6q-generic-bsp = "${IMX6_COMMON_BANK_WORD}"
 FUSE_NUM:mx6q-generic-bsp = "${FUSE_NUM_8}"
 STATUS_CMD:mx6q-generic-bsp = "${HAB_STATUS_CMD}"
 CLOSE_CMD:mx6q-generic-bsp = "${IMX6_COMMON_CLOSE_CMD}"
+FUSE_SUPPORT_DEFAULT:mx6q-generic-bsp = "${FUSE_SUPPORT_SIGNED_BUILD}"
+FUSE_SUPPORT_TYPE:mx6q-generic-bsp = "NXP"
 
 BANK_WORD:mx6dl-generic-bsp = "${IMX6_COMMON_BANK_WORD}"
 FUSE_NUM:mx6dl-generic-bsp = "${FUSE_NUM_8}"
 STATUS_CMD:mx6dl-generic-bsp = "${HAB_STATUS_CMD}"
 CLOSE_CMD:mx6dl-generic-bsp = "${IMX6_COMMON_CLOSE_CMD}"
+FUSE_SUPPORT_DEFAULT:mx6dl-generic-bsp = "${FUSE_SUPPORT_SIGNED_BUILD}"
+FUSE_SUPPORT_TYPE:mx6dl-generic-bsp = "NXP"
 
 BANK_WORD:mx7-generic-bsp = "${IMX7_IMX8M_COMMON_BANK_WORD}"
 FUSE_NUM:mx7-generic-bsp = "${FUSE_NUM_8}"
 STATUS_CMD:mx7-generic-bsp = "${HAB_STATUS_CMD}"
 CLOSE_CMD:mx7-generic-bsp = "${IMX7_IMX8M_COMMON_CLOSE_CMD}"
+FUSE_SUPPORT_DEFAULT:mx7-generic-bsp = "${FUSE_SUPPORT_SIGNED_BUILD}"
+FUSE_SUPPORT_TYPE:mx7-generic-bsp = "NXP"
 
 BANK_WORD:mx8m-generic-bsp = "${IMX7_IMX8M_COMMON_BANK_WORD}"
 FUSE_NUM:mx8m-generic-bsp = "${FUSE_NUM_8}"
 STATUS_CMD:mx8m-generic-bsp = "${HAB_STATUS_CMD}"
 CLOSE_CMD:mx8m-generic-bsp = "${IMX7_IMX8M_COMMON_CLOSE_CMD}"
+FUSE_SUPPORT_DEFAULT:mx8m-generic-bsp = "${FUSE_SUPPORT_SIGNED_BUILD}"
+FUSE_SUPPORT_TYPE:mx8m-generic-bsp = "NXP"
 
 BANK_WORD:mx8qm-generic-bsp = "\
     (0, 722), \
@@ -94,6 +117,8 @@ BANK_WORD:mx8qm-generic-bsp = "\
 FUSE_NUM:mx8qm-generic-bsp = "${FUSE_NUM_16}"
 STATUS_CMD:mx8qm-generic-bsp = "${AHAB_STATUS_CMD}"
 CLOSE_CMD:mx8qm-generic-bsp = "${AHAB_CLOSE_CMD}"
+FUSE_SUPPORT_DEFAULT:mx8qm-generic-bsp = "${FUSE_SUPPORT_SIGNED_BUILD}"
+FUSE_SUPPORT_TYPE:mx8qm-generic-bsp = "NXP"
 
 BANK_WORD:mx8x-generic-bsp = "\
     (0, 730), \
@@ -116,6 +141,8 @@ BANK_WORD:mx8x-generic-bsp = "\
 FUSE_NUM:mx8x-generic-bsp = "${FUSE_NUM_16}"
 STATUS_CMD:mx8x-generic-bsp = "${AHAB_STATUS_CMD}"
 CLOSE_CMD:mx8x-generic-bsp = "${AHAB_CLOSE_CMD}"
+FUSE_SUPPORT_DEFAULT:mx8x-generic-bsp = "${FUSE_SUPPORT_SIGNED_BUILD}"
+FUSE_SUPPORT_TYPE:mx8x-generic-bsp = "NXP"
 
 UENV_VARS_TO_DEL ?= ""
 # List of uEnv.txt variables not present during initial generation
@@ -146,29 +173,79 @@ def get_bank_word_internal(d):
 
 BANK_WORD_INTERNAL = "${@get_bank_word_internal(d)}"
 
+keep_fusing_block() {
+    local uenvfile="${1?uEnv.txt file must be specified}"
+    local suffix="${2?suffix must be specified}"
+    local bs="#+START_FUSING_BLOCK_"
+    local be="#+END_FUSING_BLOCK_"
+
+    # Find all blocks following the format:
+    # #+START_FUSING_BLOCK_<some-suffix>
+    # ...
+    # #+END_FUSING_BLOCK_<some-suffix>
+    #
+    suffixes=$(cat "${uenvfile}" | \
+               sed -n -e "s/^${bs}\([A-Z_]\+\).*$/\1/p" | \
+               sort | uniq)
+
+    bbdebug 1 "Identified the following fusing block suffixes:" ${suffixes}
+
+    for sf_ in ${suffixes}; do
+        if [ "${sf_}" = "${suffix}" ]; then
+            bbdebug 1 "Keeping fusing code block with suffix ${sf_} in uEnv.txt."
+            sed -e "/^${bs}${sf_}\([[:space:]].*$\|$\)/d" \
+                -e "/^${be}${sf_}\([[:space:]].*$\|$\)/d" \
+                -i "${uenvfile}"
+        else
+            bbdebug 1 "Removing fusing code block with suffix ${sf_} from uEnv.txt."
+            sed -e "/^${bs}${sf_}\([[:space:]].*$\|$\)/,/^${be}${sf_}\([[:space:]].*$\|$\)/d" \
+                -i "${uenvfile}"
+        fi
+    done
+}
+
 do_compile:append () {
     bbdebug 1 "Building uEnv.txt..."
     sed -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
         -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
         -e 's/@@KERNEL_DTB_PREFIX@@/${DTB_PREFIX}/' \
         -e 's/@@FITCONF_FDT_OVERLAYS@@/${FITCONF_FDT_OVERLAYS}/' \
-        -e "s/@@BANK_WORD@@/${BANK_WORD_INTERNAL}/" \
-        -e 's/@@FUSE_NUM@@/${FUSE_NUM}/' \
-        -e 's/@@STATUS_CMD@@/${STATUS_CMD}/' \
-        -e 's/@@CLOSE_CMD@@/${CLOSE_CMD}/' \
         ${WORKDIR}/uEnv.txt.in > ${WORKDIR}/uEnv.txt.temp
 
-    vars_to_del="${UENV_VARS_TO_DEL}"
-    if [ -z "${vars_to_del}" ]; then
-        vars_to_del="$(cat ${WORKDIR}/uEnv.txt.temp | \
-                       sed -n -e 's/^\([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/gp')"
-        # Needed to remove newlines from previous output
-        vars_to_del=$(echo ${vars_to_del})
+    if [ "${FUSE_SUPPORT}" = "1" ]; then
+        if [ "${FUSE_SUPPORT_TYPE}" = "NXP" ]; then
+            sed -e "s/@@BANK_WORD@@/${BANK_WORD_INTERNAL}/" \
+                -e 's/@@FUSE_NUM@@/${FUSE_NUM}/' \
+                -e 's/@@STATUS_CMD@@/${STATUS_CMD}/' \
+                -e 's/@@CLOSE_CMD@@/${CLOSE_CMD}/' \
+                -i ${WORKDIR}/uEnv.txt.temp
+            keep_fusing_block ${WORKDIR}/uEnv.txt.temp "NXP"
+        else
+            bbfatal "Unknown FUSE_SUPPORT_TYPE (${FUSE_SUPPORT_TYPE})."
+        fi
+    else
+        keep_fusing_block ${WORKDIR}/uEnv.txt.temp "DUMMY"
     fi
-    vars_to_del="${vars_to_del} ${UENV_VARS_TO_DEL_EXTRA}"
 
-    sed -e "s/@@VARS_TO_DEL@@/${vars_to_del}/" \
-        ${WORKDIR}/uEnv.txt.temp > uEnv.txt
+    if grep -q "@@VARS_TO_DEL@@" ${WORKDIR}/uEnv.txt.temp; then
+        vars_to_del="${UENV_VARS_TO_DEL}"
+        if [ -z "${vars_to_del}" ]; then
+            vars_to_del=$(sed -n -e 's/^\([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/gp' \
+	                      ${WORKDIR}/uEnv.txt.temp)
+        fi
+        vars_to_del="${vars_to_del} ${UENV_VARS_TO_DEL_EXTRA}"
+        vars_to_del=$(echo ${vars_to_del})
+        sed -e "s/@@VARS_TO_DEL@@/${vars_to_del}/" \
+            -i ${WORKDIR}/uEnv.txt.temp
+    fi
+
+    if grep -q "@@.*@@" ${WORKDIR}/uEnv.txt.temp; then
+        missing=$(sed -n -e 's/^.*\(@@[A-Z0-9_]\+@@\).*$/\1/p' ${WORKDIR}/uEnv.txt.temp)
+        missing=$(echo ${missing})
+        bbfatal "Some build-time variables have not been replaced in uEnv.txt: ${missing}."
+    fi
+
+    cp ${WORKDIR}/uEnv.txt.temp uEnv.txt
 }
 
 TDX_AMEND_BOOT_SCRIPT:torizon-distro = "0"

--- a/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bbappend
@@ -141,7 +141,7 @@ def get_bank_word_internal(d):
     bank_word_in=list(eval(bank_word_var))
     bank_word=""
     for i, bw in enumerate(bank_word_in, start=1):
-        bank_word+="fuse_bank_word_{}={} {};\\n".format(i, bw[0], bw[1])
+        bank_word+="fuse_bank_word_{}={} {}\\n".format(i, bw[0], bw[1])
     return bank_word
 
 BANK_WORD_INTERNAL = "${@get_bank_word_internal(d)}"

--- a/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
+++ b/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
@@ -2,9 +2,6 @@ kernel_image_type=@@KERNEL_IMAGETYPE@@
 overlays_file="overlays.txt"
 otaroot=1
 fitconf_fdt_overlays="@@FITCONF_FDT_OVERLAYS@@"
-@@BANK_WORD@@
-fuse_num=@@FUSE_NUM@@
-vars_to_del=@@VARS_TO_DEL@@
 
 set_bootargs=env set bootcmd_args env set bootargs ${defargs} root=LABEL=otaroot rootfstype=ext4 ${bootargs} ${tdxargs}
 
@@ -112,6 +109,11 @@ bootcmd_boot=if test ${bootscript_debug} != 1; then \
                  fi; \
              fi || true
 
+#+START_FUSING_BLOCK_NXP
+@@BANK_WORD@@
+fuse_num=@@FUSE_NUM@@
+vars_to_del=@@VARS_TO_DEL@@
+
 prog_fuses=if test -n "${fuse_prog_list}" && test "${fuse_status}" = "pending" || test "${fuse_status}" = "need-reboot"; then \
                if test "${fuse_status}" = "pending"; then \
                    env set index 1; \
@@ -211,6 +213,14 @@ set_vars=if test "${save_vars}" = "1"; then \
 reset_dev=if test "${fuse_status}" = "need-reboot"; then \
               reset; \
           fi || true
+#+END_FUSING_BLOCK_NXP
+#+START_FUSING_BLOCK_DUMMY
+# Dummy fuse functions:
+prog_fuses=true
+read_fuses=true
+set_vars=true
+reset_dev=true
+#+END_FUSING_BLOCK_DUMMY
 
 # Ensure "prog_fuses", "read_fuses", "set_vars", and "reset_dev" are ran first here.
 bootcmd_run=run prog_fuses && run read_fuses && run set_vars && run reset_dev && \

--- a/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
+++ b/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
@@ -170,15 +170,20 @@ prog_fuses=if test -n "${fuse_prog_list}" && test "${fuse_status}" = "pending" |
 read_fuses=if test -n "${fuse_num}"; then \
                for num in ${fuse_num}; do \
                    if env exists fuse_val_${num}; then \
-                       env set temp fuse cmp \\$fuse_bank_word_$num 0x\\$fuse_val_$num; \
+                       env set temp fuse cmp \\$fuse_bank_word_${num} \\$fuse_val_${num}; \
                        run temp; \
                    else \
                        false; \
                    fi; \
                    if test $? != "0"; then \
-                       env set temp fuse readm \\$fuse_bank_word_$num ${loadaddr}; \
-                       run temp; \
-                       setexpr.l fuse_val_${num} "*${loadaddr}"; \
+                       env set temp fuse readm \\$fuse_bank_word_${num} ${loadaddr}; \
+                       if run temp; then \
+                           setexpr.l fuse_val_${num} "*${loadaddr}"; \
+                           env set temp env set fuse_val_${num} 0x\\$fuse_val_${num}; \
+                           run temp; \
+                       else \
+                           env set fuse_val_${num} 0x0; \
+                       fi; \
                        env set save_vars 1; \
                    fi; \
                done; \


### PR DESCRIPTION
- Fix a bug in the format of variable `fuse_bank_word`.
- Make fuse additions conditional: now the additions will be present only on supported NXP machines when building a `tdx-signed` image.
- Store valid value in `fuse_val_N` in case of fuse read errors.

For details, please refer to the commit messages.
