### PR TITLE
image_type_torizon: improve warning for non-versioned layers

### DIFF
--- a/classes/image_type_torizon.bbclass
+++ b/classes/image_type_torizon.bbclass
@@ -98,8 +98,8 @@ def get_layer_revision_information(d):
         # Create GLib dictionary
         return "{" + ",".join(layers) + "}"
     except:
-        e = sys.exc_info()[0]
-        bb.warn("Failed to get layers information. Exception: {}".format(e))
+        e = sys.exc_info()[1]
+        bb.warn("Failed to get layers information. Caused by layer at {}. Exception: {}".format(path, e))
 
 # Use immediate expansion here to avoid calling a somewhat costly function whenever
 # EXTRA_OSTREE_COMMIT is expanded.


### PR DESCRIPTION
Currently, the warning for non-versioned layers involved in a build is not much helpful:

```
WARNING: Failed to get layers information. Exception: <class 'bb.process.ExecutionError'>
```

With this commit, the message will point which layer is causing it and what is the specific error that happened. E.g.:

```
WARNING: Failed to get layers information. Caused by layer at /workdir/torizon-7/layers/meta-iotedge-torizon. Exception: Execution of 'export PSEUDO_UNLOAD=1; git rev-parse HEAD' failed with exit code 128:
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```