### PR TITLE
u-boot-toradex-ti: add U-Boot fragments to enable fallback

### DIFF
--- a/recipes-bsp/u-boot/u-boot-toradex-ti_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-toradex-ti_%.bbappend
@@ -1,1 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/u-boot-ota:"
 
+SRC_URI:append = " \
+    file://bootcommand.cfg \
+    file://bootcount.cfg \
+    file://bootlimit.cfg \
+"


### PR DESCRIPTION
'require u-boot-ota.inc' was removed from this bbappend due to some build errors:
```
ERROR: u-boot-toradex-ti-1_2024.04+git-r0 do_deploy: Recipe u-boot-toradex-ti is trying to install files into a shared area when those files already exist. The files and the manifests listing them are:
  /workdir/torizon-7.x.y-integration/build-torizon/deploy/images/verdin-am62/u-boot-initial-env.raw
    (not matched to any task)
  /workdir/torizon-7.x.y-integration/build-torizon/deploy/images/verdin-am62/u-boot-version.json
    (not matched to any task)
Please adjust the recipes so only one recipe provides a given file.
```

Because 'u-boot-ota.inc' is appending to all 'do_deploy' tasks, we end up installing those filles more than once (since for TI, it is a multiarch build). And since we can't just add an ':k3r5' override to the task append (due to the .inc file being generic), I've opted to exclude the whole .inc file for now (bootloader updates are not supported on TI devices) and manually add the U-Boot cfg fragmentes necessary to enable the fallback logic, and having the 'bootlimit=3' variable in its environment.

Related-to: TOR-3728