### PR TITLE
linux-toradex-kmeta: bump SRCREV to latest

### DIFF
--- a/recipes-kernel/linux/linux-toradex-kmeta.inc
+++ b/recipes-kernel/linux/linux-toradex-kmeta.inc
@@ -1,4 +1,4 @@
-SRCREV_torizon-meta = "c2a03f712aebec0547c82fe384ac197c789896ee"
+SRCREV_torizon-meta = "264e5f1c6f904361cca96ebdbda2e3e2533c28a8"
 SRCREV_torizon-meta:use-head-next = "${AUTOREV}"
 
 KMETABRANCH = "scarthgap-7.x.y"


### PR DESCRIPTION
Bumping linux-toradex-kmeta so that we get the TOR-3733 fix into our release build.

Related-to: TOR-3733