### PR TITLE
Attempt to solve "Kernel modules not working correctly on preempt-rt images"

### DIFF
--- a/recipes-kernel/linux/linux-torizon.inc
+++ b/recipes-kernel/linux/linux-torizon.inc
@@ -10,6 +10,32 @@ SRC_URI:append:cfs-signed = "\
 
 KBUILD_BUILD_VERSION .= "-Torizon"
 
+do_patch:append:preempt-rt() {
+	# When the RT patches are applied via "git apply" by the kgit-s2q tool
+	# (part of yocto-kernel-tools) the author is set to "invalid_git config"
+	# which we validate here to ensure we'll amend the proper commit.
+	#
+	author0=$(git --git-dir="${S}/.git" log -1 --format='%an' HEAD)
+	author1=$(git --git-dir="${S}/.git" log -1 --format='%an' HEAD^)
+	if [ "${author0}" != "invalid_git config" ] || \
+	   [ "${author1}" = "invalid_git config" ]; then
+		bbfatal "Assumption for PREMPT_RT patches is no longer valid; task needs review!"
+	fi
+
+	# Reset the date of the commit introducing the RT patches to get a
+	# reproducible hash.
+	#
+	# This is basically a workaround for the fact that the RT patches are
+	# applied as a single patch file without author and commit date
+	# information which causes the generated commit to always have a
+	# different hash even with the exact same base kernel and RT patches.
+	#
+	GIT_COMMITTER_DATE='1970-01-01T00:00:00 +0000' \
+	git --git-dir="${S}/.git" commit \
+	    --amend --no-edit -m 'RT patches' \
+	    --date='1970-01-01T00:00:00 +0000'
+}
+
 # Print kernel URL and BRANCH to files to be used by ostree commit as metadata
 kernel_do_deploy:append() {
 	url=`git --git-dir=${S}/.git config --get remote.origin.url`


### PR DESCRIPTION
This is an attempt to solve an issue with the PREEMPT-RT builds where the build of the kernel (along with device-trees and overlays) does not match the build of the kernel modules. Specifically, what does not match is the string responsible for defining the kernel ABI version which in turn also defines the name of the directory containing the kernel and kernel modules.

To try and solve the issue, here we modify the do_patch task to make it forcefully set the commit date of the last commit which is supposed to be the commit applying the RT patches. Normally applying those patches produces different hashes every time because the said patches do not have date information in then leading the kgit-s2q tool to use the current date on the commit produced by the patching operation.

Related-to: TOR-3656

To clarify, here I say "attempt to solve" because I wasn't able to reproduce the problem with my builds. So this work must still be validated with the actual production CI/CD environment.
