### PR TITLE
Add support for TI AM62x Starter Kit EVM (SK-AM62B-P1) board on Common Torizon

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,6 +14,8 @@ LAYERSERIES_COMPAT_meta-toradex-torizon = "scarthgap"
 BBFILES_DYNAMIC += "\
     intel:${LAYERDIR}/dynamic-layers/meta-intel/*/*/*.bb \
     intel:${LAYERDIR}/dynamic-layers/meta-intel/*/*/*.bbappend \
+    meta-ti-bsp:${LAYERDIR}/dynamic-layers/meta-ti-bsp/*/*/*.bb \
+    meta-ti-bsp:${LAYERDIR}/dynamic-layers/meta-ti-bsp/*/*/*.bbappend \
     toradex-bsp-common-layer:${LAYERDIR}/dynamic-layers/meta-toradex-bsp-common/*/*/*.bb \
     toradex-bsp-common-layer:${LAYERDIR}/dynamic-layers/meta-toradex-bsp-common/*/*/*.bbappend \
     toradex-ti-layer:${LAYERDIR}/dynamic-layers/meta-toradex-ti/*/*/*.bb \

--- a/conf/machine/include/am62xx-evm.inc
+++ b/conf/machine/include/am62xx-evm.inc
@@ -1,0 +1,28 @@
+WKS_FILE:sota:am62xx-evm = "torizon-am62xx-sota.wks"
+
+OSTREE_KERNEL_ARGS:sota:am62xx-evm:append = "console=ttyS2,115200 earlycon root=LABEL=otaroot rootfstype=ext4"
+
+UBOOT_BOOT_PARTITION_NUMBER:am62xx-evm = "2"
+OTAROOT_PARTITION_NUMBER:am62xx-evm = "2"
+UENV_EXTRA_CONFIGS:am62xx-evm = "if test "${board_name}" = "am62b_p1_skevm"; then if test "${fdtfile}" = "ti/k3-am625-sk.dtb"; then env set fdtfile k3-am625-sk.dtb; fi; fi"
+
+KERNEL_DEVICETREE:am62xx-evm = " \
+    ti/k3-am625-sk.dtb \
+    ti/k3-am62x-sk-csi2-imx219.dtbo \
+    ti/k3-am62x-sk-csi2-ov5640.dtbo \
+    ti/k3-am62x-sk-csi2-tevi-ov5640.dtbo \
+    ti/k3-am62x-sk-hdmi-audio.dtbo \
+"
+# Overlays in KERNEL_DEVICETREE to be applied during boot time
+KERNEL_DEVICETREE_OVERLAY_BOOT:am62xx-evm = " \
+    k3-am62x-sk-csi2-imx219.dtbo \
+    k3-am62x-sk-csi2-ov5640.dtbo \
+    k3-am62x-sk-csi2-tevi-ov5640.dtbo \
+    k3-am62x-sk-hdmi-audio.dtbo \
+"
+
+IMAGE_FSTYPES:append = " wic"
+IMAGE_BOOT_FILES:append:am62xx-evm = " tispl.bin u-boot.img tiboot3.bin tiboot3-am62x-hs-fs-evm.bin tiboot3-am62x-gp-evm.bin tiboot3-am62x-hs-evm.bin"
+
+PREFERRED_PROVIDER_virtual/dtb = ""
+hostname:pn-base-files = "am62xx-evm"

--- a/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -1,0 +1,1 @@
+require recipes-bsp/u-boot/u-boot-rollback.inc

--- a/dynamic-layers/meta-ti-bsp/recipes-kernel/linux/linux-ti-staging%.bbappend
+++ b/dynamic-layers/meta-ti-bsp/recipes-kernel/linux/linux-ti-staging%.bbappend
@@ -1,0 +1,1 @@
+require recipes-kernel/linux/linux-torizon.inc

--- a/recipes-bsp/u-boot/u-boot-distro-boot.bb
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bb
@@ -219,8 +219,13 @@ keep_fusing_block() {
 
 inherit deploy
 
+UBOOT_BOOT_PARTITION_NUMBER ?= "1"
+OTAROOT_PARTITION_NUMBER ?= "1"
+UENV_EXTRA_CONFIGS ?= "true"
+
 do_compile() {
-    sed -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
+    sed -e 's/@@UBOOT_BOOT_PARTITION_NUMBER@@/${UBOOT_BOOT_PARTITION_NUMBER}/' \
+        -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
         -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
         -e 's/@@KERNEL_DTB_PREFIX@@/${DTB_PREFIX}/' \
         -e 's/@@APPEND@@/${APPEND}/' \
@@ -228,7 +233,9 @@ do_compile() {
         "${WORKDIR}/boot.cmd.in" > boot.cmd
 
     bbdebug 1 "Building uEnv.txt..."
-    sed -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
+    sed -e 's#@@UENV_EXTRA_CONFIGS@@#${UENV_EXTRA_CONFIGS}#' \
+        -e 's/@@OTAROOT_PARTITION_NUMBER@@/${OTAROOT_PARTITION_NUMBER}/' \
+        -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
         -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
         -e 's/@@KERNEL_DTB_PREFIX@@/${DTB_PREFIX}/' \
         -e 's/@@FITCONF_FDT_OVERLAYS@@/${FITCONF_FDT_OVERLAYS}/' \

--- a/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
+++ b/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
@@ -24,9 +24,9 @@ env set fdtfile2 "${fdtfile}"
 
 if test -n "${loadaddr}"
 then
-    ext4load ${devtype} ${devnum}:1 ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize}
+    ext4load ${devtype} ${devnum}:@@UBOOT_BOOT_PARTITION_NUMBER@@ ${loadaddr} /boot/loader/uEnv.txt; env import -t ${loadaddr} ${filesize}
 else
-    ext4load ${devtype} ${devnum}:1 ${scriptaddr} /boot/loader/uEnv.txt; env import -t ${scriptaddr} ${filesize}
+    ext4load ${devtype} ${devnum}:@@UBOOT_BOOT_PARTITION_NUMBER@@ ${scriptaddr} /boot/loader/uEnv.txt; env import -t ${scriptaddr} ${filesize}
 fi
 
 run bootcmd_run

--- a/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
+++ b/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
@@ -1,6 +1,6 @@
 kernel_image_type=@@KERNEL_IMAGETYPE@@
 overlays_file="overlays.txt"
-otaroot=1
+otaroot=@@OTAROOT_PARTITION_NUMBER@@
 fitconf_fdt_overlays="@@FITCONF_FDT_OVERLAYS@@"
 
 set_bootargs=env set bootcmd_args env set bootargs ${defargs} root=LABEL=otaroot rootfstype=ext4 ${bootargs} ${tdxargs}
@@ -227,8 +227,10 @@ set_vars=true
 reset_dev=true
 #+END_FUSING_BLOCK_DUMMY
 
+uenv_extra_configs=@@UENV_EXTRA_CONFIGS@@
+
 # Ensure "prog_fuses", "read_fuses", "set_vars", and "reset_dev" are ran first here.
 bootcmd_run=run prog_fuses && run read_fuses && run set_vars && run reset_dev && \
-            run board_fixups && run check_rollback_needed && run set_bootargs && run set_fdt_path && \
+            run board_fixups && run uenv_extra_configs && run check_rollback_needed && run set_bootargs && run set_fdt_path && \
             run bootcmd_dtb && run bootcmd_args && run set_bootargs_custom && run set_kernel_load_addr && \
             run bootcmd_load_k && run bootcmd_unzip_k && run bootcmd_load_r && run bootcmd_boot

--- a/recipes-bsp/u-boot/u-boot-rollback/am62xx-evm/bootcommand.cfg
+++ b/recipes-bsp/u-boot/u-boot-rollback/am62xx-evm/bootcommand.cfg
@@ -1,0 +1,3 @@
+CONFIG_LEGACY_IMAGE_FORMAT=y
+CONFIG_USE_BOOTCOMMAND=y
+CONFIG_BOOTCOMMAND="setenv devtype mmc; setenv devnum 1; ext4load ${devtype} ${devnum}:2 ${loadaddr} /boot.scr && source"

--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -75,7 +75,8 @@ def is_ti(d):
 
 def get_deps(d):
     if is_ti(d):  # TI
-        return 'u-boot-toradex-ti' if d.getVar('PREFERRED_PROVIDER_u-boot') else ''
+        preferred_provider_uboot = d.getVar('PREFERRED_PROVIDER_u-boot')
+        return preferred_provider_uboot if preferred_provider_uboot is not None else ''
     else:  # NXP/x86 generic/QEMU
         return 'u-boot-default-script' if d.getVar('PREFERRED_PROVIDER_u-boot-default-script') else ''
 

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -84,7 +84,7 @@ CORE_IMAGE_BASE_INSTALL:append:mx8-nxp-bsp = " \
     kernel-module-imx-gpu-viv \
 "
 
-CORE_IMAGE_BASE_INSTALL:append:verdin-am62 = " \
+CORE_IMAGE_BASE_INSTALL:append:am62xx = " \
     ti-img-rogue-driver \
 "
 

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -45,6 +45,7 @@ CORE_IMAGE_BASE_INSTALL:append = " \
     networkmanager \
     openssh-sftp-server \
     ostree-customize-plymouth \
+    ostree-devicetree-overlays \
     packagegroup-core-full-cmdline-multiuser \
     packagegroup-core-full-cmdline-utils \
     parted \
@@ -63,7 +64,6 @@ CORE_IMAGE_BASE_INSTALL:append = " \
 
 CORE_IMAGE_BASE_INSTALL:append:tdx = " \
     alsa-ucm-conf-tdx \
-    ostree-devicetree-overlays \
     set-hostname \
     tdx-info \
     udev-toradex-rules \

--- a/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_%.bbappend
+++ b/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_%.bbappend
@@ -2,13 +2,40 @@ PACKAGES:prepend = "ostree-devicetree-overlays "
 ALLOW_EMPTY:ostree-devicetree-overlays = "1"
 FILES:ostree-devicetree-overlays = "${nonarch_base_libdir}/modules/*/dtb/*.dtbo ${nonarch_base_libdir}/modules/*/dtb/overlays.txt"
 
+# Overlays in KERNEL_DEVICETREE to be applied during boot time
+KERNEL_DEVICETREE_OVERLAY_BOOT ?= ""
+
 do_install:append () {
     if [ ${@ oe.types.boolean('${OSTREE_DEPLOY_DEVICETREE}')} = True ]; then
         install -d $kerneldir/dtb/overlays
-        if [ ! -e ${DEPLOY_DIR_IMAGE}/overlays/none_deployed ]; then
-            install -m 0644 ${DEPLOY_DIR_IMAGE}/overlays/*.dtbo $kerneldir/dtb/overlays
-            install -m 0644 ${DEPLOY_DIR_IMAGE}/overlays.txt $kerneldir/dtb
+        if [ -d "${DEPLOY_DIR_IMAGE}/overlays" ]; then
+            if [ ! -e ${DEPLOY_DIR_IMAGE}/overlays/none_deployed ]; then
+                install -m 0644 ${DEPLOY_DIR_IMAGE}/overlays/*.dtbo $kerneldir/dtb/overlays
+                install -m 0644 ${DEPLOY_DIR_IMAGE}/overlays.txt $kerneldir/dtb
+            fi
         fi
+
+        kernel_overlays=""
+        if [ -n "$(find "$kerneldir/dtb/" -maxdepth 1 -type f -name "*.dtbo" | head -n1)" ]; then
+            for dtbo in ${KERNEL_DEVICETREE_OVERLAY_BOOT}; do
+                if [ ! -e "$kerneldir/dtb/$dtbo" ]; then
+                    bbfatal "$dtbo wasn't generated during the kernel build step, please make sure it's listed in KERNEL_DEVICETREE."
+                fi
+                kernel_overlays="$kernel_overlays $dtbo"
+            done
+
+            # Move overlays built during kernel compilation to the correct directory
+            mv $kerneldir/dtb/*.dtbo $kerneldir/dtb/overlays/
+        fi
+
+        if [ ! -f "$kerneldir/dtb/overlays.txt" ]; then
+            echo "fdt_overlays=$(echo $kernel_overlays)" > "${DEPLOY_DIR_IMAGE}/overlays.txt"
+            install -m 0644 ${DEPLOY_DIR_IMAGE}/overlays.txt $kerneldir/dtb
+        elif [ -n "$kernel_overlays" ]; then
+            bbwarn "overlays.txt already exists in the boot filesystem. Appending kernel overlays listed in KERNEL_DEVICETREE_OVERLAY_BOOT."
+            echo " $kernel_overlays" >> "$kerneldir/dtb/overlays.txt"
+        fi
+
     elif [ "${KERNEL_IMAGETYPE}" = "fitImage" ]; then
         if [ -e ${DEPLOY_DIR_IMAGE}/overlays.txt ]; then
             install -d $kerneldir/dtb

--- a/scripts/lib/wic/canned-wks/torizon-am62xx-sota.wks
+++ b/scripts/lib/wic/canned-wks/torizon-am62xx-sota.wks
@@ -1,0 +1,10 @@
+# short-description: Create OTA-enabled SD card image
+# long-description: Creates a partitioned SD card image with OSTree
+# physical sysroot as a payload. Boot files are located in the
+# first vfat partition.
+# Based on:
+# meta-ti/meta-ti-bsp/wic/sdimage-2part.wks
+# meta-updater/scripts/lib/wic/canned-wks/sdimage-sota.wks
+
+part --source bootimg-partition --fstype=vfat --label boot --active --align 1024 --use-uuid --fixed-size 128M
+part / --source otaimage --ondisk mmcblk --fstype=ext4 --align 1024


### PR DESCRIPTION
Add initial Torizon OS support for the AM62x Starter Kit Evaluation Module via Common Torizon distro, using the TI BSP. In addition to this layer (meta-toradex-torizon), the following Yocto layers are necessary in order to build the image:

- meta-virtualization
- meta-networking 
- meta-python
- meta-oe
- meta-filesystems
- meta-ti-extras
- meta-ti-bsp
- meta-arm 
- meta-arm-toolchain
- meta
- meta-poky
- meta-yocto-bsp
- meta-updater

`DISTRO` should be set to `common-torizon`
`MACHINE` should be set to `am62xx-evm`

In `conf/local.conf` append the following line at the end of the file:
```
include conf/machine/include/am62xx-evm.inc
```

Build the image with:
```
bitbake torizon-docker
```