### PR TITLE
linux-torizon.inc: adapt RT patches check to upstream distro

### DIFF
--- a/recipes-kernel/linux/linux-torizon.inc
+++ b/recipes-kernel/linux/linux-torizon.inc
@@ -21,8 +21,15 @@ do_patch:append:preempt-rt() {
 	#
 	author0=$(git --git-dir="${S}/.git" log -1 --format='%an' HEAD)
 	author1=$(git --git-dir="${S}/.git" log -1 --format='%an' HEAD^)
-	if [ "${author0}" != "invalid_git config" ] || \
-	   [ "${author1}" = "invalid_git config" ]; then
+	if [ "${author0}" != "invalid_git config" ]; then
+		bbnote "Amendment of RT patches commit dates not required"
+		return 0
+	fi
+
+	# The assumption here is that only the latest commit has the invalid
+	# author while the previous one is valid (that is, all RT patches are
+	# concentrated in a single commit).
+	if [ "${author1}" = "invalid_git config" ]; then
 		bbfatal "Assumption for PREMPT_RT patches is no longer valid; task needs review!"
 	fi
 
@@ -34,6 +41,7 @@ do_patch:append:preempt-rt() {
 	# information which causes the generated commit to always have a
 	# different hash even with the exact same base kernel and RT patches.
 	#
+	bbnote "Amending dates of last commit (holding the RT patches)"
 	GIT_COMMITTER_DATE='1970-01-01T00:00:00 +0000' \
 	git --git-dir="${S}/.git" commit \
 	    --amend --no-edit -m 'RT patches' \


### PR DESCRIPTION
Turns out the logic to check if the RT patches dates are correctly set as introduced by commit "linux-torizon.inc: make preempt-rt commit dates deterministic" failed with upstream kernels. Here we amend the logic to deal with that.

Related-to: TOR-3656