### PR TITLE
imx95: install mali firmware (mali_csffw.bin) in the rootfs

### DIFF
--- a/dynamic-layers/meta-imx-bsp/recipes-graphics/mali/mali-imx_%.bbappend
+++ b/dynamic-layers/meta-imx-bsp/recipes-graphics/mali/mali-imx_%.bbappend
@@ -1,0 +1,7 @@
+DEPENDS = ""
+
+do_install () {
+    install -d ${D}${nonarch_base_libdir}/firmware
+    cp -r ${S}/usr/lib/firmware/* ${D}${nonarch_base_libdir}/firmware
+}
+

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -80,6 +80,11 @@ CORE_IMAGE_BASE_INSTALL:append:sota = " \
     tzn-mqtt \
 "
 
+# Packages that install firmwares/kernel modules that must be present
+# in the rootfs. Firmware blobs, generally speaking, cannot be loaded
+# from containers as their kernel module counterparts generally expect
+# the files to be in an specific directory (generally /lib/firmware)
+
 CORE_IMAGE_BASE_INSTALL:append:mx8-nxp-bsp = " \
     kernel-module-imx-gpu-viv \
 "
@@ -90,6 +95,10 @@ CORE_IMAGE_BASE_INSTALL:append:am62xx = " \
 
 CORE_IMAGE_BASE_INSTALL:append:mx8mp-nxp-bsp = " \
     kernel-module-isp-vvcam \
+"
+
+CORE_IMAGE_BASE_INSTALL:append:mx95-nxp-bsp = " \
+    mali-imx \
 "
 
 nss_altfiles_set_users_groups () {


### PR DESCRIPTION
We need the firmware as the kernel module expects it in specific places of the
root filesystem, so it cannot be dynamically deployed from containers as the
rest of the graphical stack is.
    
On the imx8 and am62 for example the firmware is installed via 'driver' recipes
(kernel-module-imx-gpu-viv and ti-img-rogue-installer), on the imx95, however,
it comes from userspace portion, thus we need the bbappend to only install the
firmware, nothing else (no libEGL, libGLES etc...).
    
This follows the same logic as commits a7ec4b08 and b40b9114.

Note that I haven't 100% tested this commit besides a build as I need to actually build the graphical userspace to trigger the kernel module to load the firmware, but having it in `lib/firmware` is, from my understanding, enough.

Of course, the rest of the graphical stack belongs inside one of these: https://github.com/torizon/torizon-containers.