### PR TITLE
iMX95: fix some build issues

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,6 +12,8 @@ LAYERDEPENDS_meta-toradex-torizon = "sota virtualization-layer"
 LAYERSERIES_COMPAT_meta-toradex-torizon = "scarthgap"
 
 BBFILES_DYNAMIC += "\
+    fsl-bsp-release:${LAYERDIR}/dynamic-layers/meta-imx-bsp/*/*/*.bb \
+    fsl-bsp-release:${LAYERDIR}/dynamic-layers/meta-imx-bsp/*/*/*.bbappend \
     intel:${LAYERDIR}/dynamic-layers/meta-intel/*/*/*.bb \
     intel:${LAYERDIR}/dynamic-layers/meta-intel/*/*/*.bbappend \
     meta-ti-bsp:${LAYERDIR}/dynamic-layers/meta-ti-bsp/*/*/*.bb \

--- a/conf/machine/include/imx95-19x19-verdin.inc
+++ b/conf/machine/include/imx95-19x19-verdin.inc
@@ -7,4 +7,4 @@ BBMASK += "\
 "
 
 PREFERRED_PROVIDER_virtual/dtb = ""
-OSTREE_DEPLOY_DEVICETREE:forcevariable = "0"
+PREFERRED_PROVIDER_u-boot-default-script = "u-boot-distro-boot"

--- a/dynamic-layers/meta-imx-bsp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/dynamic-layers/meta-imx-bsp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -1,0 +1,1 @@
+require recipes-bsp/u-boot/u-boot-rollback.inc


### PR DESCRIPTION
iMX95 was not booting properly, because the uEnv.txt present in the image was not the one properly for Common Torizon.

Also fixed the bootloader, adding the fragments to enable rollback and re-enabled 'OSTREE_DEPLOY_DEVICETREE' for iMX95, so that it's dtb and dtbo's are deployed into the device.

Related-to: TOR-3752