### PR TITLE
initramfs-framework: fix torizon-signed SPDX build issue

### DIFF
--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -34,7 +34,6 @@ FILES:initramfs-module-ostree = "/init.d/95-ostree"
 SUMMARY:initramfs-module-composefs = "initramfs support for booting composefs images"
 RDEPENDS:initramfs-module-composefs = "${PN}-base"
 RDEPENDS:initramfs-module-composefs:append:cfs-signed = " fsverity-utils e2fsprogs-tune2fs"
-RRECOMMENDS:initramfs-module-composefs = "kernel-module-erofs kernel-module-overlay"
 FILES:initramfs-module-composefs = "\
     /init.d/94-composefs \
     ${nonarch_libdir}/ostree/prepare-root.conf \
@@ -60,15 +59,21 @@ require recipes-extended/ostree/ostree-prepare-root.inc
 
 CFS_UPGRADE_ENABLE ?= "0"
 
+RRECOMMENDS:initramfs-module-kmod:append:cfs-support = " \
+    kernel-module-erofs \
+    kernel-module-overlay \
+"
+
 do_install:append:cfs-support() {
-    # Bundled into initramfs-module-kmod package:
+    # Bundled into initramfs-module-kmod:
     install -d ${D}/etc/modules-load.d/
     install -m 0755 ${WORKDIR}/80-composefs.conf ${D}/etc/modules-load.d/80-composefs.conf
 
-    # Bundled into initramfs-module-composefs package:
+    # Bundled into initramfs-module-composefs:
     install -m 0755 ${WORKDIR}/composefs ${D}/init.d/94-composefs
     sed -i -e 's/@@CFS_UPGRADE_ENABLE@@/${CFS_UPGRADE_ENABLE}/g' ${D}/init.d/94-composefs
 
+    # Bundled into initramfs-module-composefs:
     install -d ${D}${nonarch_libdir}/ostree/
     install -m 0644 /dev/null ${D}${nonarch_libdir}/ostree/prepare-root.conf
     write_prepare_root_config ${D}${nonarch_libdir}/ostree/prepare-root.conf
@@ -98,7 +103,7 @@ do_install[depends] += "${CFS_INSTALL_DEPENDS}"
 do_install[file-checksums] += "${CFS_INSTALL_FILE_CHECKSUMS}"
 
 do_install:append:cfs-signed() {
-    # Bundled into initramfs-module-composefs package:
+    # Bundled into initramfs-module-composefs:
     install -d ${D}${sysconfdir}/ostree/
     install -m 0644 ${CFS_SIGN_KEYDIR}/${CFS_SIGN_KEYNAME}.pub \
     	            ${D}${sysconfdir}/ostree/initramfs-root-binding.key
@@ -133,3 +138,6 @@ do_install:append:ti-soc() {
     install -d ${D}/etc/modules-load.d/
     install -m 0755 ${WORKDIR}/50-am62-graphics.conf ${D}/etc/modules-load.d/50-am62-graphics.conf
 }
+
+# Required to ensure runtime SPDX data is updated when kernel modules change
+do_create_runtime_spdx[rdeptask] = "virtual/kernel:do_create_runtime_spdx"


### PR DESCRIPTION
This is expected to solve a build issue with torizon-signed images where the following error message is output in the build logs:

ERROR: initramfs-ostree-torizon-image-1.0-r0 do_rootfs: Cannot find any SPDX file for document
http://spdx.org/spdxdocs/kernel-module-display-connector-<version>-<sha>

The immediate cause for the problem comes from the initramfs-framework: do_create_runtime_spdx task not being executed even when initial ramdisk undergoes modifications between two builds. Unfortunately the root cause is still a mistery. However, a simple solution employed here is by making the initramfs-framework:do_create_runtime_spdx task "rdepend" on the corresponding task of the kernel.

Besides the above, also change how we set the dependencies to the required kernel modules when composefs is enabled. Initially the dependencies were set as initramfs-module-composefs -> kernel modules but now the dependency is set as initramfs-module-kmod -> kernel modules as done with all the other modules. Tests have shown that this wasn't the root cause of the SPDX issue though.

Related-to: TOR-3704