### PR TITLE
aktualizr-torizon: bump SRCREV to latest

### DIFF
--- a/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
+++ b/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
@@ -15,7 +15,7 @@ SRC_URI = " \
   https://github.com/uptane/ota-tuf/releases/download/v${UPTANE_SIGN_PV}/cli-${UPTANE_SIGN_PV}.tgz;unpack=0;name=uptanesign \
 "
 
-SRCREV = "eff8ec84a3d6b5aae689ad7ca68f55842694743d"
+SRCREV = "29a7d4bd073f762d24cb0968b814dcb488a98847"
 SRCREV:use-head-next = "${AUTOREV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Bump the `aktualizr-torizon` version being used (just to synchronize with TorizonCore Builder).
