### PR TITLE
rac: enable RAC by default

### DIFF
--- a/recipes-sota/rac/rac_git.bb
+++ b/recipes-sota/rac/rac_git.bb
@@ -29,8 +29,6 @@ SRCREV_tough = "9316c096b32196df75ba17a8a5502b19baffe24e"
 S = "${WORKDIR}/git"
 
 SYSTEMD_SERVICE:${PN} = "remote-access.service"
-# Keep disabled by default for now
-SYSTEMD_AUTO_ENABLE:${PN} = "disable"
 
 PV = "0.0+git${SRCPV}"
 

--- a/recipes-sota/tzn-mqtt/tzn-mqtt_git.bb
+++ b/recipes-sota/tzn-mqtt/tzn-mqtt_git.bb
@@ -21,8 +21,6 @@ LIC_FILES_CHKSUM = " \
 "
 
 SYSTEMD_SERVICE:${PN} = "tzn-mqtt.service"
-# Keep disabled by default for now
-SYSTEMD_AUTO_ENABLE:${PN} = "disable"
 
 SRC_URI += " \
     crate://crates.io/addr2line/0.21.0 \


### PR DESCRIPTION
Now that it is using MQTT, data usage is more tolerable and we can have it enabled by default on Torizon OS builds.

Related-to: TOR-3750