### PR TITLE
docs: Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,29 +15,29 @@ https://developer.toradex.com/knowledge-base/build-torizoncore
 
 Building Common Torizon OS
 ========
-To build Common Torizon you'll need to first download the desired BSP, and then download `meta-toradex-torizon`'s layer on top of that, along with its dependencies (if not already present).
-If you want to build Common Torizon on the `scarthgap` branch:
+Download the BSP layers for your machine, the `meta-toradex-torizon` layer, and other layers that are required to build Common Torizon.
+To build Common Torizon on the `scarthgap` branch:
 ```bash
 $ git clone https://github.com/torizon/meta-toradex-torizon.git -b scarthgap-7.x.y
 $ git clone https://github.com/uptane/meta-updater.git -b scarthgap
 $ git clone https://git.yoctoproject.org/git/meta-virtualization -b scarthgap
 ```
 
-Once that's in place, you'll need to source whatever script your BSP uses to setup the build environment and edit your `conf/bblayers.conf` to add `meta-toradex-torizon` layer and its dependencies (and any other that might be missing).
+Then, source whatever script your BSP uses to setup the build environment and edit your `conf/bblayers.conf` to add `meta-toradex-torizon` layer and its dependencies (and any other that might be missing).
 
-After that you'll need to edit your `conf/local.conf` file to set the MACHINE you want to build (if not set already), and you'll need to change the DISTRO to `DISTRO='common-torizon'`.
+After that, edit your `conf/local.conf` file to set the MACHINE you want to build (if not set already), and change the DISTRO to `DISTRO='common-torizon'`.
 
-Now you should be ready to start building one of the available Torizon images:
+Start building one of the available Torizon images:
 * torizon-docker
 * torizon-minimal
 * torizon-podman (**experimental**)
 
 Below you'll find documentation for some devices to which Common Torizon was already ported, with more details on how to fetch, setup and build them.
 
-* [AM62x SK EVM](./docs/README-ti.md)
-* [iMX95](./docs/README-imx95.md)
-* [RZ/V2L](./docs/README-rzv2l.md)
-* [x86](./docs/README-x86.md)
+* [Texas Instruments AM62x SK EVM](./docs/README-ti.md)
+* [Toradex i.MX95 Verdin EVK](./docs/README-imx95.md)
+* [Renesas RZ/V2L EVKIT](./docs/README-rzv2l.md)
+* [Intel x86](./docs/README-x86.md)
 
 Reporting Issues
 ================

--- a/docs/README-imx95.md
+++ b/docs/README-imx95.md
@@ -1,4 +1,4 @@
-Sync
+Setup
 ======
 1. Create the project folder:
 ```bash
@@ -37,7 +37,7 @@ $ bitbake torizon-docker
 
 All artifacts should be inside `build-imx95/deploy/images/imx95-19x19-verdin`, including the `.wic` file.
 
-Flashing the device
+Flash the Device
 ======
 1. Change board boot switch to `ON OFF OFF ON` (CM33 Serial Download)
 2. Download [uuu](https://github.com/nxp-imx/mfgtools/releases/tag/uuu_1.5.201) or build it from [source](https://github.com/nxp-imx/mfgtools)

--- a/docs/README-rzv2l.md
+++ b/docs/README-rzv2l.md
@@ -1,4 +1,4 @@
-Sync
+Setup
 ======
 1. Clone Renesas BSP layer:
 ```
@@ -30,7 +30,7 @@ $ bitbake torizon-docker
 
 All artifacts should be inside `build/deploy/images/smarc-rzv2l`
 
-Flashing the device
+Flash the Device
 ======
 1. With `SW11` set to `OFF ON OFF ON`, run (assuming ttyUSB0)
 ```
@@ -68,7 +68,7 @@ Have the SD card in a single partition and run (assuming SD card is `sdc`)
 $ sudo dd if=torizon-docker-smarc-rzv2l-7.0.0-devel-20250127163415+build.0.ota-ext4 of=/dev/sdc1 oflag=direct bs=4M status=progress conv=fsync
 ```
 
-Booting
+Boot
 ======
 With both steps above finished, just move `sw11` to `OFF OFF OFF ON`, insert the SD card into `CN10` and power on the device.  
 Press `Enter` on keyboard so you land on u-boot shell, and then run

--- a/docs/README-ti.md
+++ b/docs/README-ti.md
@@ -1,4 +1,48 @@
-Sync
+Setup
+======
+1. If you don't have the `repo` tool installed, please refer to [Build Torizon OS From Source with Yocto Project](https://developer.toradex.com/torizon/in-depth/build-torizoncore-from-source-with-yocto-projectopenembedded/#download-metadata).
+2. Initialize and sync the repo manifest for Texas Instruments:
+```bash
+$ mkdir common-torizon; cd common-torizon
+$ repo init -u git://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/ti/default.xml
+$ repo sync -j 10
+```
+We **strongly recommend** using the `default.xml` manifest. The `integration.xml` and `next.xml` are development manifests used internally and they might be unstable.
+`default.xml` is the manifest used for our releases, so they are reliable.  
+> [!IMPORTANT]  
+> Common Torizon OS is only available on branches `scarthgap-7.x.y` or newer!
+
+Alternatively, you can manually clone all layers one by one. Refer to the section _Manual Setup_ at the end of this document to learn how.
+
+Build
+======
+1. Source `setup-environment`, specifying the machine to build with the MACHINE variable e.g.:
+```bash
+$ MACHINE=am62xx-evm . setup-environment <build-directory>
+```
+If a build directory is not given, the script will create one named `build-ti-${DISTRO}`, where all build artifacts will be stored. By default `DISTRO` is automatically set to `common-torizon` with the TI boards.
+
+2. Inside the build directory, start the build e.g.:
+```bash
+$ bitbake torizon-docker
+```
+All artifacts should be inside `<build-directory>/deploy/images/${MACHINE}`, including the `.wic` file.
+
+Boot the Image from an SD Card
+======
+1. Flash the generated .wic artifact file to a micro SD card and insert it into the board. For example, if using `dd` to flash the image, double-check the device name of the SD card with `lsblk`, make sure it's unmounted, then run the command below:
+```bash
+$ sudo dd if=<image-name>.wic of=/dev/<sdcard-device-name> bs=4M status=progress
+```
+2. Configure the board for SD card boot and connect the UART interface to the host PC. For example, for the AM62x SK EVM you can follow the instructions on the [TI Resource Explorer website](https://dev.ti.com/tirex/explore/node?node=A__AZatcAgHClq18snt16Hmfg__PROCESSORS-DEVTOOLS__FUz-xrs__LATEST).
+3. Establish a serial connection with the board e.g. using `picocom`:
+```bash
+$ picocom -b 115200 /dev/ttyUSB0
+```
+
+---
+
+Manual Setup
 ======
 1. Create the directory structure for the Yocto layers e.g.:
 ```bash
@@ -35,45 +79,4 @@ $ git clone https://github.com/openembedded/meta-openembedded -b scarthgap
   * Create a symlink to our `setup-environment`:
 ```bash
 $ ln -s sources/meta-toradex-torizon/scripts/setup-environment setup-environment
-```
-
-Repo Sync
-======
-Instead of manually creating the directory structure and cloning each layer like instructed above, it's possible to use the `repo` tool to look for our remote manifest files and automatically download all the necessary Yocto layers with a few commands.
-1. If you don't have `repo` installed, please refer to this [link](https://developer.toradex.com/torizon/in-depth/build-torizoncore-from-source-with-yocto-projectopenembedded/#download-metadata).
-2. Start syncing the manifest:
-```bash
-$ repo init -u git://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/ti/default.xml
-$ repo sync -j 10
-```
-We **strongly recommend** using the `default.xml` manifest. We also have there `integration.xml` and `next.xml`, but these are development manifests used internally and they might be unstable.
-`default.xml` is the manifest used for our releases, so they are reliable.  
-Since we're now using the manifest, the `setup-environment` symlink will be automatically created for you on your top folder.
-> [!IMPORTANT]  
-> Common Torizon OS is only available on branches `scarthgap-7.x.y` or newer!
-
-Build
-======
-1. Source `setup-environment` to setup build, specifying the machine to build with the MACHINE variable e.g.:
-```bash
-$ MACHINE=am62xx-evm . setup-environment <build-directory>
-```
-If a build directory is not given, the script will create one named `build-ti-${DISTRO}`, where all build artifacts will be stored. By default `DISTRO` is automatically set to `common-torizon` with the TI boards.
-
-2. Inside the build directory, start the build e.g.:
-```bash
-$ bitbake torizon-docker
-```
-All artifacts should be inside `<build-directory>/deploy/images/${MACHINE}`, including the `.wic` file.
-
-Booting the image from an SD card
-======
-1. Flash the generated .wic artifact file to a micro SD card and insert it into the board. For example, if using `dd` to flash the image, double-check the device name of the SD card with `lsblk`, make sure it's unmounted, then run the command below:
-```bash
-$ sudo dd if=<image-name>.wic of=/dev/<sdcard-device-name> bs=4M status=progress
-```
-2. Configure the board for SD card boot and connect the UART interface to the host PC. For example, for the AM62x SK EVM you can follow the instructions on the [TI Resource Explorer website](https://dev.ti.com/tirex/explore/node?node=A__AZatcAgHClq18snt16Hmfg__PROCESSORS-DEVTOOLS__FUz-xrs__LATEST).
-3. Establish a serial connection with the board e.g. using `picocom`:
-```bash
-$ picocom -b 115200 /dev/ttyUSB0
 ```

--- a/docs/README-x86.md
+++ b/docs/README-x86.md
@@ -1,4 +1,66 @@
-Sync
+Setup
+======
+1. If you don't have the `repo` tool installed, please refer to [Build Torizon OS From Source with Yocto Project](https://developer.toradex.com/torizon/in-depth/build-torizoncore-from-source-with-yocto-projectopenembedded/#download-metadata).
+2. Initialize and sync the repo manifest for x86:
+```bash
+$ mkdir common-torizon; cd common-torizon
+$ repo init -u git://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/x86/default.xml
+$ repo sync -j 10
+```
+We **strongly recommend** using the `default.xml` manifest. The `integration.xml` and `next.xml` are development manifests used internally and they might be unstable.
+`default.xml` is the manifest used for our releases, so they are reliable.  
+> [!IMPORTANT]  
+> Common Torizon OS is only available on branches `scarthgap-7.x.y` or newer!
+
+Alternatively, you can manually clone all layers one by one. Refer to the section _Manual Setup_ at the end of this document to learn how.
+
+Build
+======
+1. Source `setup-environment`:
+```bash
+$ MACHINE=intel-corei7-64 . setup-environment build-corei7-64
+```
+This will create a build folder named `build-corei7-64`, where all build artifacts will be stored.
+
+2. Inside the build directory, start the build e.g.:
+```bash
+$ bitbake torizon-docker
+```
+
+All artifacts should be inside `build-corei7-64/deploy/images/intel-corei7-64`, including the `.wic` file.
+
+Test on Virtual Box
+======
+Setup a virtual machine to test the image built, using the generated `.wic.vdi` or `.wic.vmdk`.
+
+Below is a script for setting up a virtual machine inside Virtual Box, called `Common-Torizon`:
+```bash
+# Setup new machine Common-Torizon
+VBoxManage createvm --name Common-Torizon --ostype "Linux_64" --register --basefolder "$HOME/CommonTorizonVBoxVM"
+VBoxManage modifyvm Common-Torizon --firmware efi64
+# Attempt at serial connection (cant communicate but can inspect serial logs via 'tail -f /tmp/serial')
+VBoxManage modifyvm Common-Torizon --cpus 2 --memory 2048 --vram 256 --graphicscontroller vmsvga --uart1 0x3F8 4 --uartmode1 file /tmp/serial
+
+VBoxManage storagectl Common-Torizon --name "SATA Controller" --add sata --bootable on
+VBoxManage storageattach Common-Torizon --storagectl "SATA Controller" --port 0 --device 0 --type hdd --medium "torizon-docker-intel-corei7-64.wic.vdi"
+# Port forwarding for SSH on port 2222
+VBoxManage modifyvm Common-Torizon --nat-pf1=ssh,tcp,,2222,,3791 --nat-pf1=ssh_tor,tcp,,2223,,22
+
+VBoxManage startvm Common-Torizon
+```
+
+Test on QEMU
+======
+
+Run using QEMU:
+
+```bash
+$ qemu-system-x86_64 -drive if=virtio,file=torizon-docker-intel-corei7-64.wic,format=raw -no-reboot -cpu host -nic user,hostfwd=tcp::2222-:22 -machine pc -vga virtio -m 4096 -bios /usr/share/ovmf/OVMF.fd -enable-kvm -serial pty
+```
+
+---
+
+Manual Setup
 ======
 1. Create your build folder structure. Something like:
 ```bash
@@ -30,55 +92,3 @@ $ git clone https://github.com/openembedded/meta-openembedded -b scarthgap
 $ ln -s layers/meta-toradex-torizon/scripts/setup-environment setup-environment
 ```
 
-Repo Sync
-======
-1. If you dont have `repo` tool installed, please refer to this [link](https://developer.toradex.com/torizon/in-depth/build-torizoncore-from-source-with-yocto-projectopenembedded/#download-metadata).
-2. Start syncing the manifest
-```bash
-$ repo init -u git://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/x86/default.xml
-$ repo sync -j 10
-```
-We **strongly recommend** using the `default.xml` manifest. We also have there `integration.xml` and `next.xml`, but these are development manifests used internally and they might be unstable.
-`default.xml` is the manifest used for our releases, so they are reliable.  
-Since we're now using the manifest, Common Torizon `setup-script` link will be automatically created for you on your top folder.
-> [!IMPORTANT]  
-> Common Torizon OS is only available on branches `scarthgap-7.x.y` or newer!
-
-Build
-======
-1. Source `setup-environment` to setup build:
-```bash
-$ MACHINE=intel-corei7-64 . setup-environment build-corei7-64
-```
-This will create a build folder named `build-corei7-64`, where all build artifacts will be stored.
-2. Start Common Torizon build:
-```bash
-$ bitbake torizon-docker
-```
-
-All artifacts should be inside `build-corei7-64/deploy/images/intel-corei7-64`, including the `.wic` file.
-
-Testing on Virtual Box
-======
-You could easily setup a virtual machine to test the image built, using the generated `.wic.vdi` or `.wic.vmdk`.
-
-Below is a script for setting up a virtual machine inside Virtual Box, called `Common-Torizon`:
-```bash
-# Setup new machine Common-Torizon
-VBoxManage createvm --name Common-Torizon --ostype "Linux_64" --register --basefolder "$HOME/CommonTorizonVBoxVM"
-VBoxManage modifyvm Common-Torizon --firmware efi64
-# Attempt at serial connection (cant communicate but can inspect serial logs via 'tail -f /tmp/serial')
-VBoxManage modifyvm Common-Torizon --cpus 2 --memory 2048 --vram 256 --graphicscontroller vmsvga --uart1 0x3F8 4 --uartmode1 file /tmp/serial
-
-VBoxManage storagectl Common-Torizon --name "SATA Controller" --add sata --bootable on
-VBoxManage storageattach Common-Torizon --storagectl "SATA Controller" --port 0 --device 0 --type hdd --medium "torizon-docker-intel-corei7-64.wic.vdi"
-# Port forwarding for SSH on port 2222
-VBoxManage modifyvm Common-Torizon --nat-pf1=ssh,tcp,,2222,,3791 --nat-pf1=ssh_tor,tcp,,2223,,22
-
-VBoxManage startvm Common-Torizon
-```
-
-Or you could run using QEmu:
-```bash
-$ qemu-system-x86_64 -drive if=virtio,file=torizon-docker-intel-corei7-64.wic,format=raw -no-reboot -cpu host -nic user,hostfwd=tcp::2222-:22 -machine pc -vga virtio -m 4096 -bios /usr/share/ovmf/OVMF.fd -enable-kvm -serial pty
-```


### PR DESCRIPTION
Overall update docs. Highlights:

* Move manual setup to the end of articles, and make setup via repo Manifest the default.
* Update some sentences to imperative, to shorten sentences.