### PR TITLE
imx95: add torizon.cfg fragment to NXP's Kernel

### DIFF
--- a/dynamic-layers/meta-imx-bsp/recipes-kernel/linux/linux-imx_%.bbappend
+++ b/dynamic-layers/meta-imx-bsp/recipes-kernel/linux/linux-imx_%.bbappend
@@ -1,1 +1,5 @@
 require recipes-kernel/linux/linux-torizon.inc
+
+# NXP's Kernel recipe uses this variable to manually append fragments
+# to the generated .config.
+DELTA_KERNEL_DEFCONFIG:append = "torizon.cfg"

--- a/recipes-kernel/linux/linux-torizon.inc
+++ b/recipes-kernel/linux/linux-torizon.inc
@@ -4,6 +4,12 @@ SRC_URI:append:common-torizon = " \
     file://torizon.scc \
 "
 
+# NXP's Kernel recipe needs the cfg fragment in order to merge with
+# with the generated .config. Otherwise the fragments won't apply.
+SRC_URI:append:common-torizon:imx95-19x19-verdin = "\
+    file://torizon.cfg \
+"
+
 SRC_URI:append:cfs-support = "\
     file://composefs.scc \
 "


### PR DESCRIPTION
To apply a Kernel fragment to NXP's Kernel, we need to add it to 'DELTA_KERNEL_DEFCONFIG', so that it can be manually applied to the generated .config file.

Related-to: TOR-3754