### PR TITLE
Add support for TI's AM62L EVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Start building one of the available Torizon images:
 
 Below you'll find documentation for some devices to which Common Torizon was already ported, with more details on how to fetch, setup and build them.
 
-* [Texas Instruments AM62x/AM62P SK EVM](./docs/README-ti.md)
+* [Texas Instruments AM62x/AM62L/AM62P SK EVM](./docs/README-ti.md)
 * [Toradex i.MX95 Verdin EVK](./docs/README-imx95.md)
 * [Renesas RZ/V2L EVKIT](./docs/README-rzv2l.md)
 * [Intel x86](./docs/README-x86.md)

--- a/conf/distro/include/common-torizon.inc
+++ b/conf/distro/include/common-torizon.inc
@@ -14,6 +14,8 @@ BBMASK += " \
 
 OSTREE_DEPLOY_DEVICETREE = "0"
 
+hostname:pn-base-files ?= "${MACHINE}"
+
 require conf/distro/include/versioning.inc
 
 SDK_VENDOR = "-tznsdk"

--- a/conf/machine/include/am62lxx-evm.inc
+++ b/conf/machine/include/am62lxx-evm.inc
@@ -1,0 +1,15 @@
+require am62xx.inc
+
+TORIZON_TTY_DEVICE = "ttyS0,115200"
+
+UENV_EXTRA_CONFIGS = "if test "${board_name}" = "am62lx" -a "${fdtfile}" = "ti/k3-am62l3-evm.dtb"; then env set fdtfile k3-am62l3-evm.dtb; fi"
+
+OSTREE_DEVICETREE = "\
+    ti/k3-am62l3-evm.dtb \
+    ti/k3-am62l3-evm-lpmdemo.dtb \
+    ti/k3-am62l3-evm-m2-cc3351.dtbo \
+    ti/k3-am62l3-evm-pwm.dtbo \
+    ti/k3-am62l3-evm-dsi-rpi-7inch-panel.dtbo \
+"
+
+IMAGE_BOOT_FILES:append = " tiboot3-am62lx-hs-fs-evm.bin"

--- a/conf/machine/include/am62pxx-evm.inc
+++ b/conf/machine/include/am62pxx-evm.inc
@@ -1,11 +1,7 @@
-WKS_FILE:sota:am62pxx-evm = "torizon-am62xx-sota.wks"
-
-OSTREE_KERNEL_ARGS:sota:am62pxx-evm = "quiet logo.nologo vt.global_cursor_default=0 plymouth.ignore-serial-consoles splash fbcon=map:10 console=ttyS2,115200 root=LABEL=otaroot rootfstype=ext4"
+require am62xx.inc
 
 CORE_IMAGE_BASE_INSTALL:append:am62pxx = " ti-img-rogue-driver"
 
-UBOOT_BOOT_PARTITION_NUMBER:am62pxx-evm = "2"
-OTAROOT_PARTITION_NUMBER:am62pxx-evm = "2"
 UENV_EXTRA_CONFIGS:am62pxx-evm = "if test "${board_name}" = "am62px" -a "${fdtfile}" = "ti/k3-am62p5-sk.dtb"; then env set fdtfile k3-am62p5-sk.dtb; echo DONE; fi"
 
 # If there are any DT overlays in KERNEL_DEVICETREE that should be automatically applied during
@@ -17,8 +13,4 @@ UENV_EXTRA_CONFIGS:am62pxx-evm = "if test "${board_name}" = "am62px" -a "${fdtfi
 #     k3-am62x-sk-hdmi-audio.dtbo \
 # "
 
-IMAGE_FSTYPES:append = " wic"
-IMAGE_BOOT_FILES:append:am62pxx-evm = " tispl.bin u-boot.img tiboot3.bin tiboot3-am62px-hs-fs-evm.bin"
-
-PREFERRED_PROVIDER_virtual/dtb = ""
-hostname:pn-base-files = "am62pxx-evm"
+IMAGE_BOOT_FILES:append:am62pxx-evm = " tiboot3-am62px-hs-fs-evm.bin"

--- a/conf/machine/include/am62xx-evm.inc
+++ b/conf/machine/include/am62xx-evm.inc
@@ -1,12 +1,8 @@
-WKS_FILE:sota:am62xx-evm = "torizon-am62xx-sota.wks"
+require am62xx.inc
 
-OSTREE_KERNEL_ARGS:sota:am62xx-evm = "quiet logo.nologo vt.global_cursor_default=0 plymouth.ignore-serial-consoles splash fbcon=map:10 console=ttyS2,115200 root=LABEL=otaroot rootfstype=ext4"
+UENV_EXTRA_CONFIGS = "if test "${board_name}" = "am62b_p1_skevm" -a "${fdtfile}" = "ti/k3-am625-sk.dtb"; then env set fdtfile k3-am625-sk.dtb; fi"
 
-UBOOT_BOOT_PARTITION_NUMBER:am62xx-evm = "2"
-OTAROOT_PARTITION_NUMBER:am62xx-evm = "2"
-UENV_EXTRA_CONFIGS:am62xx-evm = "if test "${board_name}" = "am62b_p1_skevm"; then if test "${fdtfile}" = "ti/k3-am625-sk.dtb"; then env set fdtfile k3-am625-sk.dtb; fi; fi"
-
-KERNEL_DEVICETREE:am62xx-evm = " \
+KERNEL_DEVICETREE = " \
     ti/k3-am625-sk.dtb \
     ti/k3-am62x-sk-csi2-imx219.dtbo \
     ti/k3-am62x-sk-csi2-ov5640.dtbo \
@@ -14,15 +10,11 @@ KERNEL_DEVICETREE:am62xx-evm = " \
     ti/k3-am62x-sk-hdmi-audio.dtbo \
 "
 # Overlays in KERNEL_DEVICETREE to be applied during boot time
-KERNEL_DEVICETREE_OVERLAY_BOOT:am62xx-evm = " \
+KERNEL_DEVICETREE_OVERLAY_BOOT = " \
     k3-am62x-sk-csi2-imx219.dtbo \
     k3-am62x-sk-csi2-ov5640.dtbo \
     k3-am62x-sk-csi2-tevi-ov5640.dtbo \
     k3-am62x-sk-hdmi-audio.dtbo \
 "
 
-IMAGE_FSTYPES:append = " wic"
-IMAGE_BOOT_FILES:append:am62xx-evm = " tispl.bin u-boot.img tiboot3.bin tiboot3-am62x-hs-fs-evm.bin tiboot3-am62x-gp-evm.bin tiboot3-am62x-hs-evm.bin"
-
-PREFERRED_PROVIDER_virtual/dtb = ""
-hostname:pn-base-files = "am62xx-evm"
+IMAGE_BOOT_FILES:append = " tiboot3-am62x-hs-fs-evm.bin tiboot3-am62x-gp-evm.bin tiboot3-am62x-hs-evm.bin"

--- a/conf/machine/include/am62xx.inc
+++ b/conf/machine/include/am62xx.inc
@@ -1,0 +1,14 @@
+# Base configurations for TI's BSP AM62 devices
+
+WKS_FILE:sota = "torizon-am62xx-sota.wks"
+
+TORIZON_TTY_DEVICE ?= "ttyS2,115200"
+OSTREE_KERNEL_ARGS:sota = "quiet logo.nologo vt.global_cursor_default=0 plymouth.ignore-serial-consoles splash fbcon=map:10 console=${TORIZON_TTY_DEVICE} root=LABEL=otaroot rootfstype=ext4"
+
+UBOOT_BOOT_PARTITION_NUMBER = "2"
+OTAROOT_PARTITION_NUMBER = "2"
+
+IMAGE_FSTYPES:append = " wic"
+IMAGE_BOOT_FILES:append = " tispl.bin u-boot.img tiboot3.bin"
+
+PREFERRED_PROVIDER_virtual/dtb = ""

--- a/docs/README-ti.md
+++ b/docs/README-ti.md
@@ -40,6 +40,17 @@ $ sudo dd if=<image-name>.wic of=/dev/<sdcard-device-name> bs=4M status=progress
 $ picocom -b 115200 /dev/ttyUSB0
 ```
 
+Alternate way to flash the SD Card
+======
+With the generated `.wic` file, you could use bmaptool. If you don't have it installed, you could get it by running `sudo apt install bmap-tools`.
+But first, run `lsblk` and make sure that you SD Card is not mounted. If so, please unmount all partitions beforehand.
+```bash
+$ bmaptool create -o torizon.bmap torizon.wic
+$ sudo bmaptool copy --bmap torizon.bmap torizon.wic /dev/sdx
+
+```
+Where you should replace `/dev/sdx` with the SD Card you want to flash.
+
 ---
 
 Manual Setup

--- a/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/am62/bootcommand.cfg
+++ b/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/am62/bootcommand.cfg
@@ -1,3 +1,3 @@
 CONFIG_LEGACY_IMAGE_FORMAT=y
 CONFIG_USE_BOOTCOMMAND=y
-CONFIG_BOOTCOMMAND="setenv devtype mmc; setenv devnum 1; ext4load ${devtype} ${devnum}:2 ${loadaddr} /boot.scr && source"
+CONFIG_BOOTCOMMAND="setenv devtype mmc; setenv devnum 1; ext4load ${devtype} ${devnum}:2 ${loadaddr} /boot.scr && source ${loadaddr}"

--- a/recipes-bsp/u-boot/u-boot-rollback/qemuarm64/bootcommand.cfg
+++ b/recipes-bsp/u-boot/u-boot-rollback/qemuarm64/bootcommand.cfg
@@ -10,4 +10,4 @@ CONFIG_SYS_BOOTM_LEN=0x4000000
 # CONFIG_MTD is not set
 # CONFIG_MTD_NOR_FLASH is not set
 CONFIG_USE_BOOTCOMMAND=y
-CONFIG_BOOTCOMMAND="setenv devtype virtio; setenv devnum 0; ext4load ${devtype} ${devnum}:1 ${loadaddr} /boot.scr; source"
+CONFIG_BOOTCOMMAND="setenv devtype virtio; setenv devnum 0; ext4load ${devtype} ${devnum}:1 ${loadaddr} /boot.scr && source ${loadaddr}"

--- a/scripts/setup-environment
+++ b/scripts/setup-environment
@@ -63,8 +63,9 @@ _TDX_TORADEX_MACHINES=("apalis-imx6"          "meta-freescale-3rdparty" \
                   "verdin-imx8mm"        "meta-toradex-nxp" \
                   "verdin-imx8mp"        "meta-toradex")
 
-_TDX_COMMON_MACHINES=("am62pxx-evm"    "meta-ti-bsp" \
-                 "am62xx-evm"    "meta-ti-bsp" \
+_TDX_COMMON_MACHINES=("am62lxx-evm"   "meta-ti-bsp" \
+                 "am62pxx-evm"        "meta-ti-bsp" \
+                 "am62xx-evm"         "meta-ti-bsp" \
                  "intel-corei7-64"    "meta-intel" \
                  "imx95-19x19-verdin" "meta-imx" \
                  "smarc-rzv2l"        "rz-community-bsp")
@@ -140,7 +141,7 @@ if echo "${_TDX_TORADEX_MACHINES[@]}" | grep -q "$MACHINE"; then
 else
     # Common Torizon machines
     case "${MACHINE}" in
-        am62xx-evm|am62pxx-evm)
+        am62xx-evm|am62pxx-evm|am62lxx-evm)
             # for TI boards there's only common-torizon as possible DISTRO
             MACHINE="${MACHINE}" DISTRO="common-torizon" . ${_TDX_SCRIPTS_PATH}/setup-environment-ti $@
         ;;


### PR DESCRIPTION
Also a minor refactor on the AM62 machine includes, to avoid duplicating code, fix a potential issue on `bootcommand`, where we were assuming default addresses.
And added the AM62L entry in the README file, as well as an alternate flashing method.

Please check the commit messages for more info
