### PR TITLE
Scarthgap maintenance 

### DIFF
--- a/recipes-devtools/fastfetch/fastfetch_git.bb
+++ b/recipes-devtools/fastfetch/fastfetch_git.bb
@@ -11,12 +11,12 @@ HOMEPAGE = "https://github.com/fastfetch-cli/fastfetch"
 BUGTRACKER = "https://github.com/fastfetch-cli/fastfetch/issues"
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=23e30b4a719e5645c9663669760d6601"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=83d9effb45945153bc98303441b5c03f"
 
-PV = "2.29.0+git${SRCPV}"
+PV = "2.38.0+git${SRCPV}"
 SRC_URI = "git://github.com/fastfetch-cli/fastfetch.git;protocol=https;branch=master"
 
-SRCREV = "9be70a73d3315c3ce1772700585af17923a4b953"
+SRCREV = "1b219a9d5c2a6f96b06b723152e43fed7b220cbf"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-extended/fluentbit/files/0001-lib-Do-not-use-private-makefile-targets-in-CMakelist.patch
+++ b/recipes-extended/fluentbit/files/0001-lib-Do-not-use-private-makefile-targets-in-CMakelist.patch
@@ -1,4 +1,4 @@
-From 940a4e270bb8879a78c0eac4daf997cb77e25b4b Mon Sep 17 00:00:00 2001
+From 7e6295f14ea057562a235fbf6762d867e739a181 Mon Sep 17 00:00:00 2001
 From: Niko Mauno <niko.mauno@vaisala.com>
 Date: Sun, 29 Sep 2024 12:00:00 +0000
 Subject: [PATCH] lib: Do not use private makefile targets in CMakelists.txt
@@ -25,8 +25,8 @@ Upstream-Status: Submitted [https://github.com/fluent/fluent-bit/pull/9450]
  lib/cfl/CMakeLists.txt      | 8 ++------
  lib/cmetrics/CMakeLists.txt | 8 ++------
  lib/ctraces/CMakeLists.txt  | 8 ++------
- lib/monkey/CMakeLists.txt   | 4 ----
- 4 files changed, 6 insertions(+), 22 deletions(-)
+ lib/monkey/CMakeLists.txt   | 4 +---
+ 4 files changed, 7 insertions(+), 21 deletions(-)
 
 diff --git a/lib/cfl/CMakeLists.txt b/lib/cfl/CMakeLists.txt
 index 2193cb29c..e2a5cba37 100644
@@ -48,7 +48,7 @@ index 2193cb29c..e2a5cba37 100644
  
  
 diff --git a/lib/cmetrics/CMakeLists.txt b/lib/cmetrics/CMakeLists.txt
-index 4f2989106..9c40dadf4 100644
+index 18582997d..8f7176dd6 100644
 --- a/lib/cmetrics/CMakeLists.txt
 +++ b/lib/cmetrics/CMakeLists.txt
 @@ -60,12 +60,8 @@ if(NOT MSVC)
@@ -67,11 +67,11 @@ index 4f2989106..9c40dadf4 100644
  # Configuration options
  option(CMT_DEV                       "Enable development mode"                   No)
 diff --git a/lib/ctraces/CMakeLists.txt b/lib/ctraces/CMakeLists.txt
-index e92834e06..5cebb3b73 100644
+index e47ba022d..0ddfd5f97 100644
 --- a/lib/ctraces/CMakeLists.txt
 +++ b/lib/ctraces/CMakeLists.txt
 @@ -30,12 +30,8 @@ set(CTR_VERSION_MINOR  5)
- set(CTR_VERSION_PATCH  6)
+ set(CTR_VERSION_PATCH  7)
  set(CTR_VERSION_STR "${CTR_VERSION_MAJOR}.${CTR_VERSION_MINOR}.${CTR_VERSION_PATCH}")
  
 -# Define __FILENAME__ consistently across Operating Systems
@@ -86,7 +86,7 @@ index e92834e06..5cebb3b73 100644
  # Configuration options
  option(CTR_DEV             "Enable development mode"                   No)
 diff --git a/lib/monkey/CMakeLists.txt b/lib/monkey/CMakeLists.txt
-index 95d8cc1e6..8c66887da 100644
+index 028240bcc..b386cb726 100644
 --- a/lib/monkey/CMakeLists.txt
 +++ b/lib/monkey/CMakeLists.txt
 @@ -15,10 +15,8 @@ include(GNUInstallDirs)
@@ -101,6 +101,3 @@ index 95d8cc1e6..8c66887da 100644
  
  # Monkey Version
  set(MK_VERSION_MAJOR  1)
--- 
-2.39.2
-

--- a/recipes-extended/fluentbit/files/0002-flb_info.h.in-Do-not-hardcode-compilation-directorie.patch
+++ b/recipes-extended/fluentbit/files/0002-flb_info.h.in-Do-not-hardcode-compilation-directorie.patch
@@ -1,4 +1,4 @@
-From 71dab751a27a2e582b711de22873065dd28f4b65 Mon Sep 17 00:00:00 2001
+From c8c9dd3aeb49ab2ec94c3ab081e2368736a5da20 Mon Sep 17 00:00:00 2001
 From: Paulo Neves <ptsneves@gmail.com>
 Date: Thu, 28 Jul 2022 11:42:31 +0200
 Subject: [PATCH] flb_info.h.in: Do not hardcode compilation directories
@@ -14,7 +14,7 @@ Upstream-Status: Pending
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/include/fluent-bit/flb_info.h.in b/include/fluent-bit/flb_info.h.in
-index a89485c..2579afc 100644
+index 3a08f8051..aa6a48f29 100644
 --- a/include/fluent-bit/flb_info.h.in
 +++ b/include/fluent-bit/flb_info.h.in
 @@ -23,7 +23,7 @@

--- a/recipes-extended/fluentbit/files/0003-CMakeLists.txt-Revise-init-manager-deduction.patch
+++ b/recipes-extended/fluentbit/files/0003-CMakeLists.txt-Revise-init-manager-deduction.patch
@@ -1,4 +1,4 @@
-From c9969cc46e5e4d58db28c89b22bebe42d9f96962 Mon Sep 17 00:00:00 2001
+From bf4e832544e8aa5866ef57859f95b71bd8811154 Mon Sep 17 00:00:00 2001
 From: Niko Mauno <niko.mauno@vaisala.com>
 Date: Mon, 21 Oct 2024 16:02:46 +0000
 Subject: [PATCH] CMakeLists.txt: Revise init manager deduction
@@ -15,10 +15,10 @@ Upstream-Status: Inappropriate [configuration]
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 084f2c57d..f0f35f00b 100644
+index 8404b65c1..0c7876058 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -532,7 +532,7 @@ if(FLB_BINARY)
+@@ -540,7 +540,7 @@ if(FLB_BINARY)
      set(SYSTEMD_UNITDIR  /lib/systemd/system)
    endif()
  
@@ -27,7 +27,7 @@ index 084f2c57d..f0f35f00b 100644
      set(FLB_SYSTEMD_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.service")
      configure_file(
        "${PROJECT_SOURCE_DIR}/init/systemd.in"
-@@ -540,7 +540,7 @@ if(FLB_BINARY)
+@@ -548,7 +548,7 @@ if(FLB_BINARY)
        )
      install(FILES ${FLB_SYSTEMD_SCRIPT} COMPONENT binary DESTINATION ${SYSTEMD_UNITDIR})
      install(DIRECTORY DESTINATION ${FLB_INSTALL_CONFDIR} COMPONENT binary)
@@ -36,6 +36,3 @@ index 084f2c57d..f0f35f00b 100644
      set(FLB_UPSTART_SCRIPT "${PROJECT_SOURCE_DIR}/init/${FLB_OUT_NAME}.conf")
      configure_file(
        "${PROJECT_SOURCE_DIR}/init/upstart.in"
--- 
-2.39.2
-

--- a/recipes-extended/fluentbit/files/0004-chunkio-Link-with-fts-library-with-musl.patch
+++ b/recipes-extended/fluentbit/files/0004-chunkio-Link-with-fts-library-with-musl.patch
@@ -1,4 +1,4 @@
-From 63dbbad5978e5f5b0e7d42614999cb6b4ebcce10 Mon Sep 17 00:00:00 2001
+From a07df56092e529627db0946c025cb4964567280c Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 10 Aug 2022 01:27:16 -0700
 Subject: [PATCH] chunkio: Link with fts library with musl
@@ -14,10 +14,10 @@ Upstream-Status: Pending
  1 file changed, 1 insertion(+)
 
 diff --git a/lib/chunkio/src/CMakeLists.txt b/lib/chunkio/src/CMakeLists.txt
-index a4fc2d3..4244eb8 100644
+index bb52273d4..524500919 100644
 --- a/lib/chunkio/src/CMakeLists.txt
 +++ b/lib/chunkio/src/CMakeLists.txt
-@@ -13,6 +13,7 @@ set(src
+@@ -14,6 +14,7 @@ set(src
    )
  
  set(libs cio-crc32)
@@ -25,5 +25,3 @@ index a4fc2d3..4244eb8 100644
  
  if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
    set(src
--- 
-2.37.1

--- a/recipes-extended/fluentbit/files/0004-wasm-avoid-cmake-try_run-when-cross-compiling.patch
+++ b/recipes-extended/fluentbit/files/0004-wasm-avoid-cmake-try_run-when-cross-compiling.patch
@@ -1,4 +1,4 @@
-From 5b6d274664f92a6c6083f4d27a1b1604a326f22c Mon Sep 17 00:00:00 2001
+From 5f3bfd51851c6700b4dfd2ac25e83e5306b923f8 Mon Sep 17 00:00:00 2001
 From: Patrick Wicki <patrick.wicki@siemens.com>
 Date: Sat, 5 Oct 2024 21:36:12 +0200
 Subject: [PATCH] wasm: avoid cmake try_run when cross-compiling for x86

--- a/recipes-extended/fluentbit/files/0005-Use-posix-strerror_r-with-musl.patch
+++ b/recipes-extended/fluentbit/files/0005-Use-posix-strerror_r-with-musl.patch
@@ -1,4 +1,4 @@
-From f645128082117a0152a95b3dccd869a184b7513f Mon Sep 17 00:00:00 2001
+From 0c4310483875509f464883fa345f54e0d3ae25a5 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Wed, 10 Aug 2022 01:23:48 -0700
 Subject: [PATCH] Use posix strerror_r with musl
@@ -12,12 +12,15 @@ Signed-off-by: Khem Raj <raj.khem@gmail.com>
 Resolved conflicts while upgrading recipe from v1.9.9 to v3.1.9.
 
 Signed-off-by: Niko Mauno <niko.mauno@vaisala.com>
+---
+ src/flb_network.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/flb_network.c b/src/flb_network.c
-index d183209fd..41e0281b5 100644
+index 8f8ca33f6..dd098a2ea 100644
 --- a/src/flb_network.c
 +++ b/src/flb_network.c
-@@ -553,7 +553,7 @@ static int net_connect_async(int fd,
+@@ -605,7 +605,7 @@ static int net_connect_async(int fd,
              /* Connection is broken, not much to do here */
  #if ((defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) ||    \
       (defined(_XOPEN_SOURCE) || _XOPEN_SOURCE - 0L >= 600L)) &&     \

--- a/recipes-extended/fluentbit/files/0005-cprof_encode_text.c-fix-wrong-pointer-assignment.patch
+++ b/recipes-extended/fluentbit/files/0005-cprof_encode_text.c-fix-wrong-pointer-assignment.patch
@@ -1,0 +1,56 @@
+From 2e39a3cea7d03721298e90fad70560c541b092a5 Mon Sep 17 00:00:00 2001
+From: Thomas Devoogdt <thomas@devoogdt.com>
+Date: Sat, 16 Nov 2024 20:55:37 +0100
+Subject: [PATCH] cprof_encode_text.c: fix wrong pointer assignment
+
+Fix cprofiles build.
+
+Upstream-Status: Submitted [https://github.com/fluent/cprofiles/pull/3]
+
+Signed-off-by: Thomas Devoogdt <thomas@devoogdt.com>
+Signed-off-by: Patrick Wicki <patrick.wicki@siemens.com>
+---
+ lib/cprofiles/src/cprof_encode_text.c | 6 +++---
+ lib/cprofiles/src/cprof_profile.c     | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/lib/cprofiles/src/cprof_encode_text.c b/lib/cprofiles/src/cprof_encode_text.c
+index 218a72b5b..ab2d6247d 100644
+--- a/lib/cprofiles/src/cprof_encode_text.c
++++ b/lib/cprofiles/src/cprof_encode_text.c
+@@ -1909,7 +1909,7 @@ static int encode_cprof_resource_profiles(
+                 struct cprof_resource_profiles *instance) {
+     int result;
+     struct cfl_list             *iterator;
+-    struct cprof_scope_profile *scope_profile;
++    struct cprof_scope_profiles *scope_profiles;
+ 
+     result = encode_string(context,
+                             CFL_TRUE,
+@@ -1958,11 +1958,11 @@ static int encode_cprof_resource_profiles(
+ 
+         cfl_list_foreach(iterator,
+                          &instance->scope_profiles) {
+-            scope_profile = cfl_list_entry(
++            scope_profiles = cfl_list_entry(
+                                 iterator,
+                                 struct cprof_scope_profiles, _head);
+ 
+-            result = encode_cprof_scope_profiles(context, scope_profile);
++            result = encode_cprof_scope_profiles(context, scope_profiles);
+ 
+             if (result != CPROF_ENCODE_TEXT_SUCCESS) {
+                 return result;
+diff --git a/lib/cprofiles/src/cprof_profile.c b/lib/cprofiles/src/cprof_profile.c
+index 66d62b361..d059d0376 100644
+--- a/lib/cprofiles/src/cprof_profile.c
++++ b/lib/cprofiles/src/cprof_profile.c
+@@ -98,7 +98,7 @@ void cprof_profile_destroy(struct cprof_profile *instance)
+     struct cfl_list             *iterator_backup;
+     struct cprof_attribute_unit *attribute_unit;
+     struct cprof_value_type     *value_type;
+-    struct cprof_mapping        *location;
++    struct cprof_location        *location;
+     struct cprof_function       *function;
+     struct cfl_list             *iterator;
+     struct cprof_mapping        *mapping;

--- a/recipes-extended/fluentbit/fluentbit_3.2.1.bb
+++ b/recipes-extended/fluentbit/fluentbit_3.2.1.bb
@@ -17,13 +17,14 @@ DEPENDS = "\
 "
 DEPENDS:append:libc-musl = " fts"
 
-SRCREV = "431fa79ae27edaef8d050a7af6f038f4400193a1"
+SRCREV = "600b5a955b5ef7b9d025e0c128432260d0c6a5f1"
 SRC_URI = "\
-    git://github.com/fluent/fluent-bit.git;branch=3.1;protocol=https \
+    git://github.com/fluent/fluent-bit.git;branch=master;protocol=https \
     file://0001-lib-Do-not-use-private-makefile-targets-in-CMakelist.patch \
     file://0002-flb_info.h.in-Do-not-hardcode-compilation-directorie.patch \
     file://0003-CMakeLists.txt-Revise-init-manager-deduction.patch \
     file://0004-wasm-avoid-cmake-try_run-when-cross-compiling.patch \
+    file://0005-cprof_encode_text.c-fix-wrong-pointer-assignment.patch \
 "
 SRC_URI:append:libc-musl = "\
     file://0004-chunkio-Link-with-fts-library-with-musl.patch \
@@ -42,6 +43,7 @@ PACKAGECONFIG ??= "\
     ipo \
     metrics \
     parser \
+    prefer-system-libs \
     proxy-go \
     record-accessor \
     regex \
@@ -54,6 +56,12 @@ PACKAGECONFIG ??= "\
 "
 # See https://github.com/fluent/fluent-bit/issues/7248#issuecomment-1631280496
 PACKAGECONFIG:remove:toolchain-clang = "ipo"
+
+# Use system libs
+PACKAGECONFIG[prefer-system-libs] = "-DFLB_PREFER_SYSTEM_LIBS=Yes,-DFLB_PREFER_SYSTEM_LIBS=No, nghttp2 c-ares"
+DEPENDS += " ${@bb.utils.contains('PACKAGECONFIG', 'prefer-system-libs backtrace', 'libbacktrace', '', d)}"
+DEPENDS += " ${@bb.utils.contains('PACKAGECONFIG', 'prefer-system-libs jemalloc', 'jemalloc', '', d)}"
+DEPENDS += " ${@bb.utils.contains('PACKAGECONFIG', 'prefer-system-libs luajit', 'luajit', '', d)}"
 
 PACKAGECONFIG[all] = "-DFLB_ALL=Yes,-DFLB_ALL=No"
 PACKAGECONFIG[arrow] = "-DFLB_ARROW=Yes,-DFLB_ARROW=No"
@@ -104,8 +112,8 @@ PACKAGECONFIG[windows-defaults] = "-DFLB_WINDOWS_DEFAULTS=Yes,-DFLB_WINDOWS_DEFA
 PACKAGECONFIG[minimal] = "-DFLB_MINIMAL=Yes,-DFLB_MINIMAL=No"
 
 # Without zstd dependency, kafka plugin build fails at link attempt against native libzstd.so
-PACKAGECONFIG[in-kafka] = "-DFLB_IN_KAFKA=ON,-DFLB_IN_KAFKA=OFF,librdkafka zstd"
-PACKAGECONFIG[out-kafka] = "-DFLB_OUT_KAFKA=ON,-DFLB_OUT_KAFKA=OFF,librdkafka zstd"
+PACKAGECONFIG[in-kafka] = "-DFLB_IN_KAFKA=ON,-DFLB_IN_KAFKA=OFF,librdkafka zstd curl"
+PACKAGECONFIG[out-kafka] = "-DFLB_OUT_KAFKA=ON,-DFLB_OUT_KAFKA=OFF,librdkafka zstd curl"
 
 SYSTEMD_SERVICE:${PN} = "fluent-bit.service"
 

--- a/recipes-sota/greenboot/greenboot_git.bb
+++ b/recipes-sota/greenboot/greenboot_git.bb
@@ -20,8 +20,8 @@ SRC_URI = "\
 
 S = "${WORKDIR}/git"
 
-SRCREV = "9f997198416415a426d0ac394e38a391dd9b2e0a"
-PV = "0.15.7+git${SRCPV}"
+SRCREV = "2552ba5584a96f1d7930c74f199b816c19e20129"
+PV = "0.15.8+git${SRCPV}"
 
 RDEPENDS:${PN} = "bash"
 

--- a/recipes-support/composefs/composefs_1.0.8.bb
+++ b/recipes-support/composefs/composefs_1.0.8.bb
@@ -3,17 +3,17 @@ DESCRIPTION = "The composefs project combines several underlying Linux \
 features to provide a very flexible mechanism to support read-only mountable \
 filesystem trees, stacking on top of an underlying "lower" Linux filesystem."
 HOMEPAGE = "https://github.com/containers/composefs"
-LICENSE = "GPL-3.0-or-later & LGPL-2.0-or-later & Apache-2.0"
+LICENSE = "GPL-2.0-only & GPL-2.0-or-later & LGPL-2.1-or-later & Apache-2.0"
 LIC_FILES_CHKSUM = "\
     file://BSD-2-Clause.txt;md5=121c8a0a8fa5961a26b7863034ebcce8 \
-    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
-    file://COPYING.LESSERv3;md5=6a6a8e020838b23406c81b19c1d46df6 \
-    file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c \
-    file://COPYINGv3;md5=d32239bcb673463ab874e80d47fae504 \
+    file://COPYING;md5=5cbca48090f7fe0169186a551a5bf78c \
+    file://COPYING.GPL-2.0-only;md5=94fa01670a2a8f2d3ab2de15004e0848 \
+    file://COPYING.GPL-2.0-or-later;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://COPYING.LGPL-2.1-or-later;md5=4fbd65380cdd255951079008b364516c \
     file://LICENSE.Apache-2.0;md5=3b83ef96387f14655fc854ddc3c6bd57 \
 "
 
-SRCREV = "098d985a1b9a15ac828d7b2382297a6955e31e40"
+SRCREV = "858ce1b38e1534c2602eb431124b5dca706bc746"
 SRC_URI = "git://github.com/containers/composefs.git;protocol=https;branch=main"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
fastfetch: v2.29.0 to v2.38.0 - changelog: https://github.com/fastfetch-cli/fastfetch/releases)
fluentbit: v3.1.9 to v3.2.1 (backported from meta-oe's master as is) - changelog: https://fluentbit.io/announcements/older-versions/
greenboot: v0.15.7 to v0.15.8 - changelog: https://github.com/fedora-iot/greenboot/releases/tag/v0.15.8
composefs: v1.0.5 to v1.0.8 - (backported from meta-oe's master as is) - changelog: https://github.com/composefs/composefs/releases/tag/v1.0.8

Related-to: TOR-3512
