### PR TITLE
am62xx: make bbappend changes only apply to TI's AM62 builds

### DIFF
--- a/conf/machine/include/common-am62xx.inc
+++ b/conf/machine/include/common-am62xx.inc
@@ -1,5 +1,8 @@
 # Base configurations for TI's BSP AM62 devices
 
+# Adding custom override to differentiate between Verdin AM62 and TI's AM62xx EVMs
+MACHINEOVERRIDES =. "common-ti:"
+
 WKS_FILE:sota = "torizon-am62xx-sota.wks"
 
 TORIZON_TTY_DEVICE ?= "ttyS2,115200"

--- a/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -1,10 +1,10 @@
-FILESEXTRAPATHS:prepend:ti-soc := "${THISDIR}/am62:"
+FILESEXTRAPATHS:prepend:common-ti := "${THISDIR}/am62:"
 
-SRC_URI:append:ti-soc = " file://fw_env.config"
+SRC_URI:append:common-ti = " file://fw_env.config"
 
-PACKAGE_ARCH = "${MACHINE_ARCH}"
+PACKAGE_ARCH:common-ti = "${MACHINE_ARCH}"
 
-do_install:append:ti-soc() {
+do_install:append:common-ti() {
     install -d ${D}/${sysconfdir}
     install -m 0644 ${WORKDIR}/fw_env.config ${D}/${sysconfdir}/
 }

--- a/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/dynamic-layers/meta-ti-bsp/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -1,8 +1,8 @@
 require recipes-bsp/u-boot/u-boot-rollback.inc
 
-FILESEXTRAPATHS:prepend := "${THISDIR}/am62:"
+FILESEXTRAPATHS:prepend:common-ti := "${THISDIR}/am62:"
 
-SRC_URI:append:ti-soc = " \
+SRC_URI:append:common-ti = " \
     file://env_mmc.cfg \
     file://bootcommand.cfg \
 "


### PR DESCRIPTION
We have some 'meta-ti-bsp' custom .bbappends on dynamic-layers, but the issue here is that Toradex's HW also uses this layer so we end up apllying those configurations as well.

In the end, it resulted in 'fw_printenv' not working properly, since the configuration file for TI is different from Toradex, which caused greenboot to not work properly and the OS rollback process to fail altogether.

Now we add a new override for TI's AM62 devices in our 'common-am62xx.inc' file, namely 'common-ti', since there's not unique override on TI's BSP, and 'ti-soc' that was used was common to both BSP's. So now, on TI's specific .bbappends, we use the 'common-ti' override, to make sure we're using Common Torizon distro and TI machine.

Related-to: TOR-3777