### PR TITLE
scripts: fix setup-environment-ti syntax error

### DIFF
--- a/scripts/lib/setup-devices/setup-environment-ti
+++ b/scripts/lib/setup-devices/setup-environment-ti
@@ -78,6 +78,7 @@ if [ "${MACHINE}" = "beagley-ai" ]; then
     cat <<EOF >>conf/bblayers.conf
 BBLAYERS += "\${OEROOT}/sources/meta-ti/meta-beagle"
 EOF
+  fi
 fi
 
 if ! grep -q "# Torizon" conf/local.conf; then


### PR DESCRIPTION
Quick fix to properly close an 'if' statement in the script. My previous PR caused this issue, sorry about the mess.