### PR TITLE
hostapd: add custom hostapd.service for Aquila AM69

### DIFF
--- a/recipes-connectivity/hostapd/files/hostapd.service
+++ b/recipes-connectivity/hostapd/files/hostapd.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Hostapd IEEE 802.11 AP, IEEE 802.1X/WPA/WPA2/EAP/RADIUS Authenticator
+After=network.target
+
+[Service]
+Type=forking
+PIDFile=/run/hostapd.pid
+# Create virtual interface uap0 used for access point and make wlan0 down
+ExecStartPre=@SBINDIR@/iw dev wlan0 interface add uap0 type __ap
+ExecStartPre=@SBINDIR@/ip link set wlan0 down
+ExecStart=@SBINDIR@/hostapd @SYSCONFDIR@/hostapd.conf -P /run/hostapd.pid -B
+# Remove uap0 and bring wlan0 up after stopping
+ExecStopPost=@SBINDIR@/iw dev uap0 del
+ExecStopPost=@SBINDIR@/ip link set wlan0 up
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-connectivity/hostapd/hostapd_%.bbappend
+++ b/recipes-connectivity/hostapd/hostapd_%.bbappend
@@ -1,0 +1,2 @@
+# 
+FILESEXTRAPATHS:prepend:aquila-am69 := "${THISDIR}/files:"


### PR DESCRIPTION
Aquila AM69 is using the ath11k Linux driver, which does not support separate wireless interfaces for station mode and access point mode. So following the BSP changes [1], we add the necessary commands to hostapd.service to create the uap0 interface.

[1] https://git.toradex.com/cgit/meta-toradex-demos.git/commit/?h=scarthgap-7.x.y&id=de062b56b74134216934747e60760226e48997c9

Related-to: TOR-3801