### PR TITLE
Bump SRCREV to latest for Torizon OS 7.2.0 quarterly release

### DIFF
--- a/recipes-kernel/linux/linux-toradex-kmeta.inc
+++ b/recipes-kernel/linux/linux-toradex-kmeta.inc
@@ -1,4 +1,4 @@
-SRCREV_torizon-meta = "1e293f75e7e5569f0d86d752fbf4180dd3fac6eb"
+SRCREV_torizon-meta = "7ccf29a1cb46a8aa18946ada445a2616c5526740"
 SRCREV_torizon-meta:use-head-next = "${AUTOREV}"
 
 KMETABRANCH = "scarthgap-7.x.y"

--- a/recipes-sota/rac/rac_git.bb
+++ b/recipes-sota/rac/rac_git.bb
@@ -15,7 +15,7 @@ SRC_URI = " \
 SRCREV_FORMAT = "rac_tough"
 
 SRCREV_rac = "3200bfc68a5b8fa645f54e8c715f32d313df925a"
-SRCREV_tough = "9316c096b32196df75ba17a8a5502b19baffe24e"
+SRCREV_tough = "69e51d241b950951907b439a9996692967a9e82b"
 
 # Disable AUTOREV, it does not guarantee work, since the crate dependencies
 # listed below in the SRC_URI might also need to be updated.


### PR DESCRIPTION
Related-to: TOR-3647