### PR TITLE
torizon.inc: remove duplicated assignments

### DIFF
--- a/conf/distro/include/torizon.inc
+++ b/conf/distro/include/torizon.inc
@@ -24,25 +24,3 @@ EXPERIMENTALOVERRIDES = ""
 # Currently Torizon does not support any experimental machines, in future such machines can be added like below:
 #EXPERIMENTALOVERRIDES:colibri-imx6ull = ":experimental"
 DISTROOVERRIDES .= "${EXPERIMENTALOVERRIDES}"
-
-# Use our variant of the aktualizr client instead of the
-# default from meta-updater
-PREFERRED_PROVIDER_aktualizr = "aktualizr-torizon"
-PREFERRED_PROVIDER_aktualizr-native = "aktualizr-torizon-native"
-PREFERRED_RPROVIDER_aktualizr = "aktualizr-torizon"
-PREFERRED_RPROVIDER_aktualizr-info = "aktualizr-torizon"
-PREFERRED_RPROVIDER_aktualizr-shared-prov = "aktualizr-torizon"
-
-# disable warning message from meta-security
-SKIP_META_SECURITY_SANITY_CHECK = "1"
-
-# Configure the "kernel command-line protection" for Torizon OS (relevant when
-# the tdx-signed class is in use).
-TOS_SECBOOT_REQUIRED_BOOTARGS_COMMON ?= "root=LABEL=otaroot rootfstype=ext4 ${OSTREE_KERNEL_ARGS}"
-TOS_SECBOOT_REQUIRED_BOOTARGS ?= "${TOS_SECBOOT_REQUIRED_BOOTARGS_COMMON}"
-TOS_SECBOOT_REQUIRED_BOOTARGS:apalis-imx6 ?= "enable_wait_mode=off vmalloc=400M ${TOS_SECBOOT_REQUIRED_BOOTARGS_COMMON}"
-TOS_SECBOOT_REQUIRED_BOOTARGS:colibri-imx6 ?= "enable_wait_mode=off galcore.contiguousSize=50331648 ${TOS_SECBOOT_REQUIRED_BOOTARGS_COMMON}"
-TOS_SECBOOT_REQUIRED_BOOTARGS:colibri-imx6ull-emmc ?= "user_debug=30 ${TOS_SECBOOT_REQUIRED_BOOTARGS_COMMON}"
-TOS_SECBOOT_REQUIRED_BOOTARGS:qemuarm64 ?= ""
-# Override BSP configuration:
-TDX_SECBOOT_REQUIRED_BOOTARGS:tdx-signed = "${TOS_SECBOOT_REQUIRED_BOOTARGS}"


### PR DESCRIPTION
When we did 86343936 (conf/distro: refactor torizon distro to support Common Torizon), we left behind some assignments in "torizon.inc" that were already present in "base-distro.inc" (included by the former). Here we fix this situation.

Related-to: TOR-3828

P.S.: I made this related to TOR-3828 ("Expected bootargs do not match actual args on signed images (apalis-imx6, colibri-imx6, colibri-imx6ull)") because my [previous PR](https://github.com/torizon/meta-toradex-torizon/pull/270) did not solve the issue with the boot arguments and the reason was these duplicated assignments (that I didn't notice were present).