### PR TITLE
Fix torizon-signed generation with regards to the composefs keys

### DIFF
--- a/classes/torizon_base_image_type.inc
+++ b/classes/torizon_base_image_type.inc
@@ -119,6 +119,7 @@ CFS_OSTREECOMMIT_FILE_CHECKSUMS ?= "${@cfs_get_key_file_checksums(d)}"
 do_image_ostreecommit[prefuncs] += "${CFS_OSTREECOMMIT_PREFUNCS}"
 do_image_ostreecommit[depends] += "${CFS_OSTREECOMMIT_DEPENDS}"
 do_image_ostreecommit[file-checksums] += "${CFS_OSTREECOMMIT_FILE_CHECKSUMS}"
+do_image_ostreecommit[nostamp] = "1"
 
 EXTRA_OSTREE_COMMIT:append:cfs-signed = "\
     --generate-composefs-metadata \

--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -101,6 +101,7 @@ CFS_INSTALL_FILE_CHECKSUMS ?= "${@cfs_get_key_file_checksums(d)}"
 do_install[prefuncs] += "${CFS_INSTALL_PREFUNCS}"
 do_install[depends] += "${CFS_INSTALL_DEPENDS}"
 do_install[file-checksums] += "${CFS_INSTALL_FILE_CHECKSUMS}"
+do_install[nostamp] = "1"
 
 do_install:append:cfs-signed() {
     # Bundled into initramfs-module-composefs:


### PR DESCRIPTION
On some occasions, the `torizon-signed` image output by the build system won't boot showing an error message like this during boot:

```
ostree-prepare-root: No valid signatures found for public key
ERROR: There's no '/dev' on rootfs.
```

From what I could gather, the reason for this is a mismatch between the (private) key used for actually signing the composefs digest (that is stored as commit metadata in the OSTree repo) and the (public) key stored in the initial ramdisk. This situation can happen because the build system (Bitbake) keeps a stamp file associated with the tasks responsible for (a) signing the OSTree commit and (b) installing the public key into the ramdisk and those tasks don't necessarily run if the key files change (due to the stamp file).

The solution introduced here is simple: we add the "nostamp" flag to both of the said tasks causing the build system to consider them not up-to-date. Notice that doing this does not cause the image to be rebuilt whenever one runs `bitbake <image>` because the optimizations provided by the sstate still take place preventing the execution of the tasks in case the changes did not change.

To confirm the solution is working correctly I built and runtime tested the following cases:

- Full build with empty sstate & no keys.
- Full build with sstate previously populated & no keys.
- Full build with sstate previously populated & keys already present.
- Partial build where only the keys had been deleted.
- Partial build where the keys had been replaced.
