### PR TITLE
rac: fix SRC_URI for tough

### DIFF
--- a/recipes-sota/rac/rac_git.bb
+++ b/recipes-sota/rac/rac_git.bb
@@ -7,7 +7,7 @@ inherit cargo systemd
 # Main source respository
 SRC_URI = " \
     git://github.com/torizon/rac.git;protocol=https;branch=main;name=rac \
-    git://github.com/toradex/tough;protocol=https;branch=rac;name=tough;destsuffix=tough \
+    git://github.com/toradex/tough.git;protocol=https;branch=rac;name=tough;destsuffix=tough \
     file://remote-access.service \
     file://client.toml \
 "


### PR DESCRIPTION
Some git environments are configured with safe.bareRepository=explicit [1], causing the do_fetch step to fail when attempting to git fetch the tough SRC_URI. Let's fix this by adding the missing .git suffix in the URI to ensure it is a bare repository.

```
$ bitbake rac
...
WARNING: rac-0.0+git-r0 do_fetch: Failed to fetch URL git://github.com/toradex/tough;protocol=https;branch=rac;name=tough;destsuffix=tough, attempting MIRRORS if available
ERROR: rac-0.0+git-r0 do_fetch: Fetcher failure: Fetch command export PSEUDO_DISABLED=1; export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/1000/bus"; ... LANG=C git -c gc.autoDetach=false -c core.pager=cat -c safe.bareRepository=all fetch -f --progress https://github.com/toradex/tough refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* failed with exit code 1, see logfile for output
ERROR: rac-0.0+git-r0 do_fetch: Bitbake Fetcher Error: FetchError('Unable to fetch URL from any source.', 'git://github.com/toradex/tough;protocol=https;branch=rac;name=tough;destsuffix=tough')
```

Link: https://git.kernel.org/pub/scm/git/git.git/tree/Documentation/config/safe.adoc [1]