### PR TITLE
systemd: Fix volatile logs (master)

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -43,7 +43,7 @@ pkg_postinst:${PN}:append () {
 do_install:append() {
     if ${@bb.utils.contains('FILESYSTEM_PERMS_TABLES', 'files/fs-perms-volatile-log.txt', 'true', 'false', d)}; then
         sed -i '/^d \/var\/log /d' ${D}${nonarch_libdir}/tmpfiles.d/var.conf
-        echo 'L+ /var/log - - - - /var/volatile/log' >> ${D}${sysconfdir}/tmpfiles.d/00-create-volatile.conf
+        echo 'L+ /var/log - - - - /var/volatile/log' >> ${D}${nonarch_libdir}/tmpfiles.d/00-create-volatile.conf
     else
         # Make sure /var/log is not a link to volatile (e.g. after system updates)
         sed -i '/\[Service\]/aExecStartPre=-/bin/rm -f /var/log' ${D}${systemd_system_unitdir}/systemd-journal-flush.service


### PR DESCRIPTION
With Scarthgap the install location of 00-create-volatile.conf was changed from /etc to /usr/lib.

Update our bbappend to point to this new install location.

Related-to: TOR-3838

Same as: https://github.com/torizon/meta-toradex-torizon/pull/278

But for the master branch.