### PR TITLE
am62l: fix missing bootloader binary

### DIFF
--- a/conf/machine/include/am62lxx-evm.inc
+++ b/conf/machine/include/am62lxx-evm.inc
@@ -12,4 +12,3 @@ OSTREE_DEVICETREE = "\
     ti/k3-am62l3-evm-dsi-rpi-7inch-panel.dtbo \
 "
 
-IMAGE_BOOT_FILES:append = " tiboot3-am62lx-hs-fs-evm.bin"


### PR DESCRIPTION
Artifact 'am62lxx-evm/tiboot3-am62lx-hs-fs-evm.bin' has been removed on upstream [1], so we can just remove it.

[1] https://git.yoctoproject.org/meta-ti/commit/?h=scarthgap&id=342012483c9e05fd35689a9de0f16a9d4f123a19

Related-to: TOR-3847