### PR TITLE
[Master] am62l: fix missing bootloader binary

### DIFF
--- a/conf/machine/include/am62lxx-evm.inc
+++ b/conf/machine/include/am62lxx-evm.inc
@@ -12,4 +12,3 @@ OSTREE_DEVICETREE = "\
     ti/k3-am62l3-evm-dsi-rpi-7inch-panel.dtbo \
 "
 
-IMAGE_BOOT_FILES:append = " tiboot3-am62lx-hs-fs-evm.bin"


### PR DESCRIPTION
Cherry-picking #281 to master.


(cherry picked from commit 6d3e307f221958c8c3348177357d7de572df0fa4)