### PR TITLE
[Common] Use less disk space during builds

### DIFF
--- a/scripts/lib/setup-devices/setup-environment-imx
+++ b/scripts/lib/setup-devices/setup-environment-imx
@@ -28,6 +28,9 @@ TMPDIR = "${_TDX_BUILDDIR}/tmp"
 TI_COMMON_DEPLOY = "${_TDX_BUILDDIR}/deploy"
 DEPLOY_DIR = "\${TI_COMMON_DEPLOY}\${@'' if d.getVar('BB_CURRENT_MC') == 'default' else '/\${BB_CURRENT_MC}'}"
 
+# ease up disk space requirements
+INHERIT += "rm_work"
+
 # Torizon
 include conf/machine/include/\${MACHINE}.inc
 EOF

--- a/scripts/lib/setup-devices/setup-environment-intel
+++ b/scripts/lib/setup-devices/setup-environment-intel
@@ -25,6 +25,9 @@ DEPLOY_DIR = "\${TI_COMMON_DEPLOY}\${@'' if d.getVar('BB_CURRENT_MC') == 'defaul
 # Accept Synaptics FW license
 LICENSE_FLAGS_ACCEPTED = "synaptics-killswitch"
 
+# ease up disk space requirements
+INHERIT += "rm_work"
+
 # Torizon
 include conf/machine/include/\${MACHINE}.inc
 EOF

--- a/scripts/lib/setup-devices/setup-environment-renesas
+++ b/scripts/lib/setup-devices/setup-environment-renesas
@@ -17,6 +17,9 @@ TMPDIR = "/build/tmp"
 # Where to save the packages and images
 DEPLOY_DIR = "/build/deploy"
 
+# ease up disk space requirements
+INHERIT += "rm_work"
+
 # Torizon
 include conf/machine/include/\${MACHINE}.inc
 EOF

--- a/scripts/lib/setup-devices/setup-environment-ti
+++ b/scripts/lib/setup-devices/setup-environment-ti
@@ -86,7 +86,7 @@ if ! grep -q "# Torizon" conf/local.conf; then
   sed -i "/^TMPDIR .*/c\TMPDIR = \"\${TOPDIR}/tmp\"" conf/local.conf
   sed -i "/^PACKAGE_CLASSES .*/c\# PACKAGE_CLASSES = \"package_deb\"" conf/local.conf
   sed -i "/^EXTRA_IMAGE_FEATURES = \"debug-tweaks\"/c\# EXTRA_IMAGE_FEATURES = \"debug-tweaks\"" conf/local.conf
-  sed -i "/^SSTATE_DIR .*/c\SSTATE_DIR= \"\${TOPDIR}/sstate-cache\"" conf/local.conf
+  sed -i "/^SSTATE_DIR .*/c\SSTATE_DIR= \"\${TOPDIR}/../sstate-cache\"" conf/local.conf
 
   cat <<EOF >>conf/local.conf
 # Where to save the packages and images

--- a/scripts/lib/setup-devices/setup-environment-ti
+++ b/scripts/lib/setup-devices/setup-environment-ti
@@ -92,6 +92,9 @@ if ! grep -q "# Torizon" conf/local.conf; then
 # Where to save the packages and images
 TI_COMMON_DEPLOY = "\${TOPDIR}/deploy"
 
+# ease up disk space requirements
+INHERIT += "rm_work"
+
 # Torizon
 include conf/machine/include/\${MACHINE}.inc
 EOF


### PR DESCRIPTION
Builds were using a lot of disk space, and was affecting negatively our CI.
On this change I've fixed the sstate-cache directory for TI builds, placing it on root directory instead of inside the build folder.

Also I've added a line that inherits `rm_work` bbclass for our builds, so that we cleanup a bit afterwards and use less disk space.