### PR TITLE
initramfs-framework: add irq_imx_irqsteer module to iMX8 initramfs

### DIFF
--- a/recipes-core/initramfs-framework/files/50-imx8-graphics.conf
+++ b/recipes-core/initramfs-framework/files/50-imx8-graphics.conf
@@ -1,3 +1,4 @@
+irq_imx_irqsteer
 sec_dsim
 display_connector
 sec_mipi_dsim_imx

--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -113,6 +113,7 @@ do_install:append:cfs-signed() {
 # Adding modules so plymouth can show the splash screen during boot
 SRC_URI:append:mx8-nxp-bsp = " file://50-imx8-graphics.conf"
 RDEPENDS:initramfs-module-kmod:append:mx8-nxp-bsp = " \
+    kernel-module-irq-imx-irqsteer \
     kernel-module-display-connector \
     kernel-module-lontium-lt8912b \
     kernel-module-sec-dsim \


### PR DESCRIPTION
Due to BSP's change on linux-toradex-kconfig [1], a regression was introduced on Torizon OS where the splash screen was no longer appearing during boot on iMX8 devices (Colibri and Verdin).

This was due to the config CONFIG_IMX_IRQSTEER now being set to module, so it would be missing during splash initialization, on initramfs.

Now we add the module to our initramfs for it to be inserted before initializing plymouth.

[1] https://git.toradex.com/cgit/linux-toradex-kconfig.git/commit/?h=main&id=2bbba4e35cc4ac9f5ee0a6a44b5a6aa2a60324ba

Related-to: TOR-3803, TOR-3807, TOR-3837