### PR TITLE
[Master] initramfs-module-kmod: add missing modules to enable native LVDS

### DIFF
--- a/recipes-core/initramfs-framework/files/50-imx8-graphics.conf
+++ b/recipes-core/initramfs-framework/files/50-imx8-graphics.conf
@@ -1,3 +1,6 @@
+fsl_imx_ldb
+imx8mp_ldb
+phy_fsl_imx8mp_lvds
 irq_imx_irqsteer
 sec_dsim
 display_connector

--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -112,6 +112,9 @@ do_install:append:cfs-signed() {
 # Adding modules so plymouth can show the splash screen during boot
 SRC_URI:append:mx8-nxp-bsp = " file://50-imx8-graphics.conf"
 RDEPENDS:initramfs-module-kmod:append:mx8-nxp-bsp = " \
+    kernel-module-fsl-imx-ldb \
+    kernel-module-imx8mp-ldb \
+    kernel-module-phy-fsl-imx8mp-lvds \
     kernel-module-irq-imx-irqsteer \
     kernel-module-display-connector \
     kernel-module-lontium-lt8912b \


### PR DESCRIPTION
Related-to: TOR-3863


(cherry picked from commit 898b81d901122cb59a8b080dcb2a5bec4312dd72)