### PR TITLE
get_layer_revision_information: reducing parsing time from 10min to 30s

### DIFF
--- a/classes/ostree_layer_revision_info.bbclass
+++ b/classes/ostree_layer_revision_info.bbclass
@@ -1,0 +1,53 @@
+# NOTE: 
+#
+# This code was originally located in torizon_base_image_type.inc, which is included 
+# by the class image_type_torizon.bbclass. As the class is added to IMAGE_CLASSES, it is
+# parsed by every image recipe several times. There are 100+ image recipes in the layers
+# used by the torizon distro. When building the torizon-minimal image, the function get_layer_revision_information
+# was executed 350+ times in the step "Parsing recipes". Parsing took 10 minutes longer than normal.
+#
+# The function get_layer_revision_information executes the same information for every image
+# recipe. For every layer repository, it calculates the commit sha. The commit sha's don't 
+# change during a bitbake run. In short, get_layer_revision_information must only be executed
+# once for every build.
+#
+# By inheriting ostree_layer_revision_info (this class) in torizon-base.inc, which is required 
+# by the torizon image, the function get_layer_revision_information is executed exactly once.
+#
+# See also https://community.toradex.com/t/parsing-recipes-takes-10-minutes-longer-due-to-get-layer-revision-information/28529
+
+# Get git hashes from all layers and print it as GLib g_variant_parse() string
+# inspiration taken from image-buildinfo
+def get_layer_revision_information(d):
+    import bb.process
+    import subprocess
+    try:
+        layers = []
+        paths = (d.getVar("BBLAYERS" or "")).split()
+
+        for path in paths:
+            # Use relative path from ${OEROOT}/layers/ as layer name
+            name = os.path.relpath(path, os.path.join(d.getVar('OEROOT'), "layers"))
+            rev, _ = bb.process.run('export PSEUDO_UNLOAD=1; git rev-parse HEAD', cwd=path)
+            branch, _ = bb.process.run('export PSEUDO_UNLOAD=1; git rev-parse --abbrev-ref HEAD', cwd=path)
+            try:
+                subprocess.check_output("""cd %s; export PSEUDO_UNLOAD=1; set -e;
+                                        git diff --quiet --no-ext-diff
+                                        git diff --quiet --no-ext-diff --cached""" % path,
+                                        shell=True,
+                                        stderr=subprocess.STDOUT)
+                modified = ""
+            except subprocess.CalledProcessError as ex:
+                modified = ":modified"
+            # Key/value pair per layer
+            layers.append("'{}': '{}:{}{}'".format(name, branch.strip(), rev.strip(), modified))
+
+        # Create GLib dictionary
+        return "{" + ",".join(layers) + "}"
+    except:
+        e = sys.exc_info()[0]
+        bb.warn("Failed to get layers information. Caused by layer at {}. Exception: {}".format(path, e))
+
+# Use immediate expansion here to avoid calling a somewhat costly function whenever
+# EXTRA_OSTREE_COMMIT is expanded.
+OSTREE_LAYER_REVISION_INFO := "${@get_layer_revision_information(d)}"

--- a/classes/torizon_base_image_type.inc
+++ b/classes/torizon_base_image_type.inc
@@ -40,42 +40,6 @@ OSTREE_CREATE_DIFF = "1"
 OSTREE_COMMIT_SUBJECT = "${DISTRO_VERSION}"
 OSTREE_COMMIT_SUBJECT[vardepsexclude] = "DISTRO_VERSION"
 
-# Get git hashes from all layers and print it as GLib g_variant_parse() string
-# inspiration taken from image-buildinfo
-def get_layer_revision_information(d):
-    import bb.process
-    import subprocess
-    try:
-        layers = []
-        paths = (d.getVar("BBLAYERS" or "")).split()
-
-        for path in paths:
-            # Use relative path from ${OEROOT}/layers/ as layer name
-            name = os.path.relpath(path, os.path.join(d.getVar('OEROOT'), "layers"))
-            rev, _ = bb.process.run('export PSEUDO_UNLOAD=1; git rev-parse HEAD', cwd=path)
-            branch, _ = bb.process.run('export PSEUDO_UNLOAD=1; git rev-parse --abbrev-ref HEAD', cwd=path)
-            try:
-                subprocess.check_output("""cd %s; export PSEUDO_UNLOAD=1; set -e;
-                                        git diff --quiet --no-ext-diff
-                                        git diff --quiet --no-ext-diff --cached""" % path,
-                                        shell=True,
-                                        stderr=subprocess.STDOUT)
-                modified = ""
-            except subprocess.CalledProcessError as ex:
-                modified = ":modified"
-            # Key/value pair per layer
-            layers.append("'{}': '{}:{}{}'".format(name, branch.strip(), rev.strip(), modified))
-
-        # Create GLib dictionary
-        return "{" + ",".join(layers) + "}"
-    except:
-        e = sys.exc_info()[0]
-        bb.warn("Failed to get layers information. Caused by layer at {}. Exception: {}".format(path, e))
-
-# Use immediate expansion here to avoid calling a somewhat costly function whenever
-# EXTRA_OSTREE_COMMIT is expanded.
-OSTREE_LAYER_REVISION_INFO := "${@get_layer_revision_information(d)}"
-
 EXTRA_OSTREE_COMMIT[vardepsexclude] = "OSTREE_KERNEL_SOURCE_META_DATA"
 EXTRA_OSTREE_COMMIT = " \
     --add-metadata-string=oe.machine="${MACHINE}" \

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -10,6 +10,7 @@ IMAGE_FEATURES += "ssh-server-openssh bash-completion-pkgs"
 # Enough free space for a full image update
 IMAGE_OVERHEAD_FACTOR = "2.3"
 
+inherit ostree_layer_revision_info
 inherit core-image
 
 do_rootfs[cleandirs] += "${IMAGE_ROOTFS}"


### PR DESCRIPTION
The function get_layer_revision_information is executed 350+ times, as its encompassing class image_type_torizon is added to IMAGE_CLASSES. However, it calculates exactly the same layer revision info for every image in the same build. The commit sha's of the layer repositories don't change during a build. In short, the function must be executed only once. We achieve this by moving the function into its own class ostree_layer_revision_info and inheriting it via torizon-base.inc in the single image recipe requiring the layer revision info (e.g., torizon-minimal or torizon-docker). The time for parsing recipes drops from over 10 minutes to roughly 30 seconds.