### PR TITLE
systemd: re-enable networkd PACKAGECONFIG from systemd

### DIFF
--- a/recipes-core/systemd/systemd/0002-systemd-networkd-wait-online.service.in-use-any-by-d.patch
+++ b/recipes-core/systemd/systemd/0002-systemd-networkd-wait-online.service.in-use-any-by-d.patch
@@ -1,0 +1,36 @@
+From 7bae91fd94b6bcbcc43270a86f09b3d55147efcf Mon Sep 17 00:00:00 2001
+From: Eduardo Ferreira <eduardo.barbosa@toradex.com>
+Date: Mon, 29 Jan 2024 10:30:18 -0300
+Subject: [PATCH] systemd-networkd-wait-online.service.in: use --any by default
+
+Use --any by default when waiting for a network interface to be fully
+configured, otherwise it blocks until all the available interfaces are
+in the configured state.
+
+Obs.: Inherited from LmP.
+
+Upstream-Status: Inappropriate [TorizonCore specific]
+
+Signed-off-by: Sergio Prado <sergio.prado@toradex.com>
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+Signed-off-by: Eduardo Ferreira <eduardo.barbosa@toradex.com>
+---
+ units/systemd-networkd-wait-online.service.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/units/systemd-networkd-wait-online.service.in b/units/systemd-networkd-wait-online.service.in
+index 7768121f5f..7d26e04fe3 100644
+--- a/units/systemd-networkd-wait-online.service.in
++++ b/units/systemd-networkd-wait-online.service.in
+@@ -19,7 +19,7 @@ Before=network-online.target shutdown.target
+ 
+ [Service]
+ Type=oneshot
+-ExecStart={{LIBEXECDIR}}/systemd-networkd-wait-online
++ExecStart={{LIBEXECDIR}}/systemd-networkd-wait-online --any
+ RemainAfterExit=yes
+ 
+ [Install]
+-- 
+2.34.1
+

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -4,6 +4,7 @@ ALTERNATIVE_PRIORITY[resolv-conf] = "300"
 
 SRC_URI:append = " \
     file://0001-tmpfiles-tmp.conf-reduce-cleanup-age-to-half.patch \
+    file://0002-systemd-networkd-wait-online.service.in-use-any-by-d.patch \
     file://0003-emergency-rescue.service.in-Use-torizon-specific-scr.patch \
     file://systemd-timesyncd-update.service \
     file://torizon-recover \
@@ -11,8 +12,7 @@ SRC_URI:append = " \
 
 SRC_URI:append:genericx86-64 = " file://0001-rules-whitelist-hd-devices.patch"
 
-PACKAGECONFIG:append = " resolved"
-PACKAGECONFIG:remove = "networkd"
+PACKAGECONFIG:append = " resolved networkd"
 RRECOMMENDS:${PN}:remove = "os-release"
 
 # /var is expected to be rw, so drop volatile-binds service files
@@ -37,6 +37,10 @@ pkg_postinst:${PN}:append () {
 		fi
 		# Disable reboot when Ctrl+Alt+Del is pressed on a USB keyboard
 		systemctl $OPTS mask ctrl-alt-del.target
+
+		# Mask systemd-networkd-wait-online.service to avoid long boot times
+		# when networking is unplugged
+		systemctl $OPTS mask systemd-networkd-wait-online.service
 	fi
 }
 


### PR DESCRIPTION
networkd is needed to setup DHCP for the Access Point. As a faster solution to enable our release, we revert networkd, since this was an issue only on master branch, while we try to find a more permanent solution afterwards.

This reverts commit 4d0ebb190e6c15fd3f82c14aae4def2d4a6decec.

Related-to: TOR-3883