### PR TITLE
[Master] setup-environment-toradex: fix distro selection for imx95

### DIFF
--- a/scripts/lib/setup-devices/setup-environment-toradex
+++ b/scripts/lib/setup-devices/setup-environment-toradex
@@ -29,9 +29,9 @@ elif [ -n "$BASH_VERSION" ]; then
     set +o noclobber
 fi
 
-# DISTRO defaults to 'torizon' for am62/imx8/qemuarm64/genericx86-64 machines
+# DISTRO defaults to 'torizon' for am62(p)/imx8(m|p|SMARC)/imx95/am69/qemuarm64/genericx86-64 machines
 # DISTRO defaults to 'torizon-upstream' for other machines
-_TDX_DISTRO_DEFAULT="torizon-upstream" && echo "$MACHINE" | grep -E -q '(imx8|am62|am69|qemuarm64|genericx86-64)' && _TDX_DISTRO_DEFAULT="torizon"
+_TDX_DISTRO_DEFAULT="torizon-upstream" && echo "$MACHINE" | grep -E -q '(imx8|imx95|am62|am69|qemuarm64|genericx86-64)' && _TDX_DISTRO_DEFAULT="torizon"
 DISTRO=${DISTRO:-$_TDX_DISTRO_DEFAULT}
 
 if [ -z "${SDKMACHINE}" ]; then


### PR DESCRIPTION
For the new devices (SMARC imx8mp/95 and Verdin am62p), imx8 and am62p distro selection were already covered, but imx95 was missing.

Now we add it to the rule so we select the downstream distro.

Related-to: TOR-3898


(cherry picked from commit a8854d337ce4544ed37973d1563da958797c6f31)