### PR TITLE
meta-cyclonedx: enable generation of CycloneDX SBOM on Torizon builds

### DIFF
--- a/conf/template/bblayers.conf
+++ b/conf/template/bblayers.conf
@@ -16,6 +16,7 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-perl \
   ${OEROOT}/layers/meta-virtualization \
   ${OEROOT}/layers/meta-updater \
+  ${OEROOT}/layers/meta-cyclonedx \
 "
 
 # These layers hold machine specific content, aka Board Support Packages

--- a/scripts/lib/setup-devices/setup-environment-toradex
+++ b/scripts/lib/setup-devices/setup-environment-toradex
@@ -138,7 +138,7 @@ MACHINE ?= "${MACHINE}"
 SDKMACHINE ?= "${SDKMACHINE}"
 
 # Extra options that can be changed by the user
-INHERIT += "rm_work"
+INHERIT += "rm_work cyclonedx-export"
 EOF
 else
     sed -i "s/^DISTRO ?= \"[^\"]*\"$/DISTRO ?= \"${DISTRO}\"/" conf/auto.conf


### PR DESCRIPTION
Related-to: TOR-3899

Signed-off-by: Eduardo Ferreira <eduardo.barbosa@toradex.com>