### PR TITLE
[Kirkstone] sudo: upgrade 1.9.15p5 -> 1.9.17p1

### DIFF
--- a/recipes-extended/sudo/sudo.inc
+++ b/recipes-extended/sudo/sudo.inc
@@ -1,0 +1,48 @@
+SUMMARY = "Provide limited super user privileges to specific users"
+DESCRIPTION = "Sudo (superuser do) allows a system administrator to give certain users (or groups of users) the ability to run some (or all) commands as root while logging all commands and arguments."
+HOMEPAGE = "http://www.sudo.ws"
+BUGTRACKER = "http://www.sudo.ws/bugs/"
+SECTION = "admin"
+LICENSE = "ISC & BSD-3-Clause & BSD-2-Clause & Zlib"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=2841c822e587db145364ca95e9be2ffa \
+                    file://plugins/sudoers/redblack.c;beginline=1;endline=46;md5=03e35317699ba00b496251e0dfe9f109 \
+                    file://lib/util/reallocarray.c;beginline=3;endline=15;md5=397dd45c7683e90b9f8bf24638cf03bf \
+                    file://lib/util/fnmatch.c;beginline=3;endline=27;md5=004d7d2866ba1f5b41174906849d2e0f \
+                    file://lib/util/glob.c;beginline=2;endline=31;md5=2852f68687544e3eb8a0a61665506f0e \
+                    file://lib/util/snprintf.c;beginline=3;endline=33;md5=b70df6179969e38fcf68da91b53b8029 \
+                    file://include/sudo_queue.h;beginline=2;endline=27;md5=ad578e9664d17a010b63e4bc0576ee8d \
+                    file://lib/util/inet_pton.c;beginline=3;endline=17;md5=27785c9f5835093eda42aa0816a2d0b4 \
+                    file://lib/util/arc4random.c;beginline=3;endline=20;md5=ced8636ecefa2ba907cfe390bc3bd964 \
+                    file://lib/util/arc4random_uniform.c;beginline=3;endline=17;md5=e30c2b777cdc00cfcaf7c445a10b262f \
+                    file://lib/util/getentropy.c;beginline=1;endline=19;md5=a0f58be3d60b6dcd898ec5fe0866d36f \
+                    "
+
+inherit autotools
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[zlib] = "--enable-zlib,--disable-zlib,zlib"
+PACKAGECONFIG[pam-wheel] = ",,,pam-plugin-wheel"
+
+EXTRA_OECONF = "--with-editor=${base_bindir}/vi --with-env-editor"
+
+EXTRA_OECONF:append:libc-musl = " --disable-hardening "
+
+do_compile:prepend () {
+       # Remove build host references from config.h
+       sed -i  \
+           -e 's,--with-libtool-sysroot=${STAGING_DIR_TARGET},,g' \
+           -e 's,--build=${BUILD_SYS},,g' \
+           -e 's,--host=${HOST_SYS},,g' \
+	   ${B}/config.h
+}
+
+# Explicitly create ${localstatedir}/lib before do_install to ensure
+# the directory is accessible by all users. Otherwise the mkinstalldirs
+# script (from sudo) will recursively create ${localstatedir}/lib/sudo
+# and then chmod each directory with 0700 permissions, which isn't what
+# we want (i.e, users would not be able to access /var/lib).
+do_install:prepend (){
+	mkdir -p ${D}/${localstatedir}/lib
+}
+
+CVE_VERSION_SUFFIX = "patch"

--- a/recipes-extended/sudo/sudo/0001-sudo.conf.in-fix-conflict-with-multilib.patch
+++ b/recipes-extended/sudo/sudo/0001-sudo.conf.in-fix-conflict-with-multilib.patch
@@ -1,0 +1,61 @@
+From 8c69192754ba73dd6e3273728a21aa73988f4bfb Mon Sep 17 00:00:00 2001
+From: Kai Kang <kai.kang@windriver.com>
+Date: Tue, 17 Nov 2020 11:13:40 +0800
+Subject: [PATCH] sudo.conf.in: fix conflict with multilib
+
+When pass ${libdir} to --libexecdir of sudo, it fails to install sudo
+and lib32-sudo at same time:
+
+| Error: Transaction test error:
+|  file /etc/sudo.conf conflicts between attempted installs of
+     sudo-1.9.3p1-r0.core2_64 and lib32-sudo-1.9.3p1-r0.core2_32
+
+Update the comments in sudo.conf.in to avoid the conflict.
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+
+Upstream-Status: Inappropriate [OE configuration specific]
+---
+ examples/sudo.conf.in | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/examples/sudo.conf.in b/examples/sudo.conf.in
+index bdd676c..094341c 100644
+--- a/examples/sudo.conf.in
++++ b/examples/sudo.conf.in
+@@ -4,7 +4,7 @@
+ # Sudo plugins:
+ #   Plugin plugin_name plugin_path plugin_options ...
+ #
+-# The plugin_path is relative to @plugindir@ unless
++# The plugin_path is relative to $plugindir such as /usr/lib/sudo unless
+ #   fully qualified.
+ # The plugin_name corresponds to a global symbol in the plugin
+ #   that contains the plugin interface structure.
+@@ -51,7 +51,7 @@
+ # The compiled-in value is usually sufficient and should only be changed
+ # if you rename or move the sudo_intercept.so file.
+ #
+-#Path intercept @intercept_file@
++#Path intercept $intercept_file
+ 
+ #
+ # Sudo noexec:
+@@ -65,7 +65,7 @@
+ # The compiled-in value is usually sufficient and should only be changed
+ # if you rename or move the sudo_noexec.so file.
+ #
+-#Path noexec @noexec_file@
++#Path noexec $noexec_file
+ 
+ #
+ # Sudo plugin directory:
+@@ -74,7 +74,7 @@
+ # The default directory to use when searching for plugins that are
+ # specified without a fully-qualified path name.
+ #
+-#Path plugin_dir @plugindir@
++#Path plugin_dir $plugindir
+ 
+ #
+ # Core dumps:

--- a/recipes-extended/sudo/sudo/sudo.pam
+++ b/recipes-extended/sudo/sudo/sudo.pam
@@ -1,0 +1,6 @@
+#%PAM-1.0
+auth       include      common-auth
+account    include      common-account
+password   include      common-password
+session    optional     pam_keyinit.so revoke
+session    required     pam_limits.so

--- a/recipes-extended/sudo/sudo_1.9.17p1.bb
+++ b/recipes-extended/sudo/sudo_1.9.17p1.bb
@@ -1,0 +1,113 @@
+# FIXME: the LIC_FILES_CHKSUM values have been updated by 'devtool upgrade'.
+# The following is the difference between the old and the new license text.
+# Please update the LICENSE value if needed, and summarize the changes in
+# the commit message via 'License-Update:' tag.
+# (example: 'License-Update: copyright years updated.')
+#
+# The changes:
+#
+# --- LICENSE.md
+# +++ LICENSE.md
+# @@ -1,6 +1,6 @@
+#  Sudo is distributed under the following license:
+#
+# -    Copyright (c) 1994-1996, 1998-2023
+# +    Copyright (c) 1994-1996, 1998-2025
+#          Todd C. Miller <Todd.Miller@sudo.ws>
+#
+#      Permission to use, copy, modify, and distribute this software for any
+# @@ -247,9 +247,9 @@
+#
+#  The file arc4random.c bears the following license:
+#
+# -    Copyright (c) 1996, David Mazieres <dm@uun.org>
+# -    Copyright (c) 2008, Damien Miller <djm@openbsd.org>
+# -    Copyright (c) 2013, Markus Friedl <markus@openbsd.org>
+# +    Copyright (c) 1996, David Mazieres <dm@uun.org>
+# +    Copyright (c) 2008, Damien Miller <djm@openbsd.org>
+# +    Copyright (c) 2013, Markus Friedl <markus@openbsd.org>
+#      Copyright (c) 2014, Theo de Raadt <deraadt@openbsd.org>
+#
+#      Permission to use, copy, modify, and distribute this software for any
+# @@ -282,7 +282,7 @@
+#
+#  The file getentropy.c bears the following license:
+#
+# -    Copyright (c) 2014 Theo de Raadt <deraadt@openbsd.org>
+# +    Copyright (c) 2014 Theo de Raadt <deraadt@openbsd.org>
+#      Copyright (c) 2014 Bob Beck <beck@obtuse.com>
+#
+#      Permission to use, copy, modify, and distribute this software for any
+# @@ -299,7 +299,7 @@
+#
+#  The embedded copy of zlib bears the following license:
+#
+# -    Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler
+# +    Copyright (C) 1995-2024 Jean-loup Gailly and Mark Adler
+#
+#      This software is provided 'as-is', without any express or implied
+#      warranty.  In no event will the authors be held liable for any damages
+#
+#
+
+require sudo.inc
+
+SRC_URI = "https://www.sudo.ws/dist/sudo-${PV}.tar.gz \
+           ${@bb.utils.contains('DISTRO_FEATURES', 'pam', '${PAM_SRC_URI}', '', d)} \
+           file://0001-sudo.conf.in-fix-conflict-with-multilib.patch \
+           "
+
+PAM_SRC_URI = "file://sudo.pam"
+
+SRC_URI[sha256sum] = "ff607ea717072197738a78f778692cd6df9a7e3e404565f51de063ca27455d32"
+
+DEPENDS += " virtual/crypt ${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'libpam', '', d)}"
+RDEPENDS:${PN} += " ${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'pam-plugin-limits pam-plugin-keyinit', '', d)}"
+
+CACHED_CONFIGUREVARS = " \
+        ac_cv_type_rsize_t=no \
+        ac_cv_path_MVPROG=${base_bindir}/mv \
+        ac_cv_path_BSHELLPROG=${base_bindir}/sh \
+        ac_cv_path_SENDMAILPROG=${sbindir}/sendmail \
+        ac_cv_path_VIPROG=${base_bindir}/vi \
+        "
+
+EXTRA_OECONF += " \
+             ${@bb.utils.contains('DISTRO_FEATURES', 'pam', '--with-pam', '--without-pam', d)} \
+             ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '--enable-tmpfiles.d=${nonarch_libdir}/tmpfiles.d', '--disable-tmpfiles.d', d)} \
+             --with-rundir=/run/sudo \
+             --with-vardir=/var/lib/sudo \
+             --libexecdir=${libdir} \
+             "
+
+do_install:append () {
+	if [ "${@bb.utils.filter('DISTRO_FEATURES', 'pam', d)}" ]; then
+		install -D -m 644 ${WORKDIR}/sudo.pam ${D}/${sysconfdir}/pam.d/sudo
+		if ${@bb.utils.contains('PACKAGECONFIG', 'pam-wheel', 'true', 'false', d)} ; then
+			echo 'auth       required     pam_wheel.so use_uid' >>${D}${sysconfdir}/pam.d/sudo
+			sed -i 's/# \(%wheel ALL=(ALL) ALL\)/\1/' ${D}${sysconfdir}/sudoers
+		fi
+	fi
+
+	chmod 4111 ${D}${bindir}/sudo
+	chmod 0440 ${D}${sysconfdir}/sudoers
+
+	# Explicitly remove the /sudo directory to avoid QA error
+	rmdir -p --ignore-fail-on-non-empty ${D}/run/sudo
+}
+
+FILES:${PN}-dev += "${libdir}/${BPN}/lib*${SOLIBSDEV} ${libdir}/${BPN}/*.la \
+                    ${libdir}/lib*${SOLIBSDEV} ${libdir}/*.la"
+
+CONFFILES:${PN}-lib = "${sysconfdir}/sudoers"
+
+SUDO_PACKAGES = "${PN}-sudo\
+                 ${PN}-lib"
+
+PACKAGE_BEFORE_PN = "${SUDO_PACKAGES}"
+
+RDEPENDS:${PN}-sudo = "${PN}-lib"
+RDEPENDS:${PN} += "${SUDO_PACKAGES}"
+
+FILES:${PN}-sudo = "${bindir}/sudo ${bindir}/sudoedit"
+FILES:${PN}-lib = "${localstatedir} ${libexecdir} ${sysconfdir} ${libdir} ${nonarch_libdir}"


### PR DESCRIPTION
    In order to fix sudo CVE's, we've ported the 'openembedded-cores' recipe
    to Torizon, while we internally bump our manifest.
    The sudo recipes were taken as is from openembedded-core kirkstone
    branch.

    Fixed CVE's:
    * Fixed CVE-2025-32462.  Sudo's -h (--host) option could be specified when running a command or editing a file.  This could enable a local privilege escalation attack if the sudoers file allows the user to run commands on a different host.

    * Fixed CVE-2025-32463.  An attacker can leverage sudo's -R (--chroot) option to run arbitrary commands as root, even if they are not listed in the sudoers file.  The chroot support has been deprecated an will be removed entirely in a future release.

Related-to: TOR-3913