### PR TITLE
Revert "setup-environment-toradex: change CycloneDX SBOM export direc…

### DIFF
--- a/scripts/lib/setup-devices/setup-environment-toradex
+++ b/scripts/lib/setup-devices/setup-environment-toradex
@@ -139,10 +139,6 @@ SDKMACHINE ?= "${SDKMACHINE}"
 
 # Extra options that can be changed by the user
 INHERIT += "rm_work cyclonedx-export"
-
-# FIXME: Dirty hack to have CycloneDX SBOMs uploaded to artifactory
-CYCLONEDX_EXPORT_SBOM = "${_TDX_BUILDDIR}/deploy/images/${MACHINE}/cyclonedx_sbom.json"
-CYCLONEDX_EXPORT_VEX = "${_TDX_BUILDDIR}/deploy/images/${MACHINE}/cyclonedx_vex.json"
 EOF
 else
     sed -i "s/^DISTRO ?= \"[^\"]*\"$/DISTRO ?= \"${DISTRO}\"/" conf/auto.conf


### PR DESCRIPTION
…tory"

Reverting since this is causing issues on our internal pipeline.

This reverts commit 8ea2d9f8ff9af75954cef88afab8484b7e5e8fae.