### PR TITLE
torizon.conf: Extending distro with formerly removed distro features

### DIFF
--- a/conf/distro/include/base-distro.inc
+++ b/conf/distro/include/base-distro.inc
@@ -41,7 +41,7 @@ IMAGE_BOOT_FILES_REMOVE:sota = "boot.scr-${MACHINE};boot.scr overlays.txt overla
 IMAGE_BOOT_FILES_REMOVE:append:apalis-imx8 = " hdmitxfw.bin dpfw.bin"
 
 DISTRO_FEATURES:append = " virtualization stateless-system"
-DISTRO_FEATURES:remove = "3g alsa irda pcmcia nfc ldconfig pulseaudio wayland x11 ptest multiarch vulkan"
+DISTRO_FEATURES:remove = "${DISTRO_FEATURES_REMOVE}"
 DISTRO_FEATURES:imx-generic-bsp:remove = "opengl"
 
 # No need for x11 even for native

--- a/conf/distro/include/base-distro.inc
+++ b/conf/distro/include/base-distro.inc
@@ -41,6 +41,7 @@ IMAGE_BOOT_FILES_REMOVE:sota = "boot.scr-${MACHINE};boot.scr overlays.txt overla
 IMAGE_BOOT_FILES_REMOVE:append:apalis-imx8 = " hdmitxfw.bin dpfw.bin"
 
 DISTRO_FEATURES:append = " virtualization stateless-system"
+DISTRO_FEATURES_REMOVE ?= "3g alsa irda pcmcia nfc ldconfig pulseaudio wayland x11 ptest multiarch vulkan"
 DISTRO_FEATURES:remove = "${DISTRO_FEATURES_REMOVE}"
 DISTRO_FEATURES:imx-generic-bsp:remove = "opengl"
 

--- a/conf/distro/include/torizon.inc
+++ b/conf/distro/include/torizon.inc
@@ -13,6 +13,8 @@ INHERIT += "toradex-sanity toradex-mirrors"
 # We do not need teziimg, ota-ext4 or wic images by default
 IMAGE_FSTYPES_REMOVE ?= "ota-ext4 wic wic.gz wic.bmap wic.xz"
 
+DISTRO_FEATURES_REMOVE ?= "3g alsa irda pcmcia nfc ldconfig pulseaudio wayland x11 ptest multiarch vulkan"
+
 # Compatibility with toradex layers
 BBMASK += " \
     /meta-toradex-bsp-common/recipes-core/systemd/systemd_%.bbappend \

--- a/conf/distro/include/torizon.inc
+++ b/conf/distro/include/torizon.inc
@@ -13,8 +13,6 @@ INHERIT += "toradex-sanity toradex-mirrors"
 # We do not need teziimg, ota-ext4 or wic images by default
 IMAGE_FSTYPES_REMOVE ?= "ota-ext4 wic wic.gz wic.bmap wic.xz"
 
-DISTRO_FEATURES_REMOVE ?= "3g alsa irda pcmcia nfc ldconfig pulseaudio wayland x11 ptest multiarch vulkan"
-
 # Compatibility with toradex layers
 BBMASK += " \
     /meta-toradex-bsp-common/recipes-core/systemd/systemd_%.bbappend \


### PR DESCRIPTION
base-distro.inc removes features like 3g, alsa, nfc, and wayland from DISTRO_FEATURES. It makes impossible adding these features in a distro extending torizon.conf. Once an item is removed from a BitBake variable, it can never be appended again.

The solution is to assign the removed features to a new variable DISTRO_FEATURES_REMOVE in torizon.inc and :remove its contents from DISTRO_FEATURES in base-distro.inc.

Client code can remove features from DISTRO_FEATURES_REMOVE and append the features to DISTRO_FEATURES. DISTRO_FEATURES_REMOVE is an extension point for torizon.conf similar to IMAGE_FSTYPES_REMOVE. Now, clients can extend the distro conf torizon.conf.