### PR TITLE
common: standardize hostnames

### DIFF
--- a/docs/README-ti.md
+++ b/docs/README-ti.md
@@ -4,11 +4,15 @@ Setup
 2. Initialize and sync the repo manifest for Texas Instruments:
 ```bash
 $ mkdir common-torizon; cd common-torizon
-$ repo init -u git://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/ti/default.xml
+$ repo init -u git://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/ti/integration.xml
 $ repo sync -j 10
 ```
-We **strongly recommend** using the `default.xml` manifest. The `integration.xml` and `next.xml` are development manifests used internally and they might be unstable.
-`default.xml` is the manifest used for our releases, so they are reliable.  
+
+> [!IMPORTANT]
+> Until an official release of Common Torizon OS, only the `integration.xml` manifest is suitable for end-users to build. After an official release, users will be able to use the `default.xml` manifest.
+
+Note that `integration.xml` is a development manifest used internally and they might containg development features and thus be considered unstable.
+
 > [!IMPORTANT]  
 > Common Torizon OS is only available on branches `scarthgap-7.x.y` or newer!
 


### PR DESCRIPTION
Hostnames should closely reflect the machine names. One of the main reasons is clarity not only within Yocto but also due to the device fields that are filled up in Torizon Cloud using the hostname as base.

This MR sets a precedent for new common machines hostnames, with the following format: <machine-name>-<optional-qualifier>.

Note that <machine-name> itself might be a specific format with short dashes and optional qualifiers.

This approach is taxonomically similar to the hostnames used in Toradex SoMs, which is always the machine name (that as in the latest paragraph also has the format of <family>-<soc>, such as verdin-am62.

With this approach, the differences between hostnames, device ids and Yocto machines is unequivocal and clear.