### PR TITLE
[Master] setup-environment-ti: make DL_DIR and SSTATE_DIR default values

### DIFF
--- a/scripts/lib/setup-devices/setup-environment-ti
+++ b/scripts/lib/setup-devices/setup-environment-ti
@@ -86,7 +86,8 @@ if ! grep -q "# Torizon" conf/local.conf; then
   sed -i "/^TMPDIR .*/c\TMPDIR = \"\${TOPDIR}/tmp\"" conf/local.conf
   sed -i "/^PACKAGE_CLASSES .*/c\# PACKAGE_CLASSES = \"package_deb\"" conf/local.conf
   sed -i "/^EXTRA_IMAGE_FEATURES = \"debug-tweaks\"/c\# EXTRA_IMAGE_FEATURES = \"debug-tweaks\"" conf/local.conf
-  sed -i "/^SSTATE_DIR .*/c\SSTATE_DIR= \"\${TOPDIR}/../sstate-cache\"" conf/local.conf
+  sed -i "/^SSTATE_DIR .*/c\SSTATE_DIR ?= \"\${TOPDIR}/../sstate-cache\"" conf/local.conf
+  sed -i "s/^DL_DIR = \(.*\)/DL_DIR ?= \1/" conf/local.conf
 
   cat <<EOF >>conf/local.conf
 # Where to save the packages and images


### PR DESCRIPTION
We're running with a problem on our automation scripts, where we wanted sstate-cache and downloads folder on a specific path. But we're using TI's setup environment script, and our automation scripts won't touch local.conf, only auto.conf. And local.conf has precedence over auto.conf.

So to in order to make things work and not make any considerable modifications, we can change the assignments of DL_DIR and SSTATE_DIR to default value assignments, which will only set a value to the variable if it isn't already initialized. This way we can work around the file precedence, and actually have our automation script values set on auto.conf take effect.


(cherry picked from commit 655341c9f6089f7e9b7d2b14bd2e639ecf0745dc)