### PR TITLE
fix u-boot deployment for custom machine

### DIFF
--- a/recipes-bsp/u-boot/u-boot-tcb-sign.inc
+++ b/recipes-bsp/u-boot/u-boot-tcb-sign.inc
@@ -2,12 +2,15 @@
 # This is needed by TCB for its signing feature
 
 do_deploy:append:verdin-imx8mp() {
-    install -m 0644 ${B}/${MACHINE}_defconfig/.config ${DEPLOYDIR}/uboot_config
+    local UBOOT_MACHINE_STRIPPED
+    UBOOT_MACHINE_STRIPPED=$(echo "${UBOOT_MACHINE}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+    install -m 0644 ${B}/${UBOOT_MACHINE_STRIPPED}/.config ${DEPLOYDIR}/uboot_config
     install -d ${DEPLOYDIR}/spl
-    install -m 0644 ${B}/${MACHINE}_defconfig/spl/u-boot-spl ${DEPLOYDIR}/spl/
-    install -m 0644 ${B}/${MACHINE}_defconfig/spl/u-boot-spl.dtb ${DEPLOYDIR}/spl/
-    install -m 0644 ${B}/${MACHINE}_defconfig/spl/u-boot-spl-nodtb.bin ${DEPLOYDIR}/spl/
+    install -m 0644 ${B}/${UBOOT_MACHINE_STRIPPED}/spl/u-boot-spl ${DEPLOYDIR}/spl/
+    install -m 0644 ${B}/${UBOOT_MACHINE_STRIPPED}/spl/u-boot-spl.dtb ${DEPLOYDIR}/spl/
+    install -m 0644 ${B}/${UBOOT_MACHINE_STRIPPED}/spl/u-boot-spl-nodtb.bin ${DEPLOYDIR}/spl/
     install -d ${DEPLOYDIR}/u-boot-dtbs/freescale
-    install -m 0644 ${B}/${MACHINE}_defconfig/dts/upstream/src/arm64/freescale/imx8mp-verdin-wifi-dev.dtb \
+    install -m 0644 ${B}/${UBOOT_MACHINE_STRIPPED}/dts/upstream/src/arm64/freescale/imx8mp-verdin-wifi-dev.dtb \
                     ${DEPLOYDIR}/u-boot-dtbs/freescale/
 }


### PR DESCRIPTION
MACHINE and UBOOT_MACHINE may differ on customized machine definition. This is the case in my setup. The installations fails due to a directory name mismatch.

Unfortunately, UBOOT_MACHINE has a preceding whitespace. I didn't found the source of it, so I trim it in the recipe as a workaround.