### PR TITLE
[Master] initramfs-framework: refactor and add missing module for SMARC iMX8MP

### DIFF
--- a/recipes-core/initramfs-framework/files/50-imx8-graphics.conf
+++ b/recipes-core/initramfs-framework/files/50-imx8-graphics.conf
@@ -1,9 +1,0 @@
-fsl_imx_ldb
-imx8mp_ldb
-phy_fsl_imx8mp_lvds
-irq_imx_irqsteer
-sec_dsim
-display_connector
-sec_mipi_dsim_imx
-ti_sn65dsi83
-lontium_lt8912b

--- a/recipes-core/initramfs-framework/files/50-ti-graphics.conf
+++ b/recipes-core/initramfs-framework/files/50-ti-graphics.conf
@@ -1,10 +1,4 @@
 pwm_tiehrpwm
-fb_sys_fops
-sysimgblt
-sysfillrect
-syscopyarea
-drm_kms_helper
-drm_dma_helper
 tidss
 display_connector
 tc358768

--- a/recipes-core/initramfs-framework/files/50-ti-graphics.conf
+++ b/recipes-core/initramfs-framework/files/50-ti-graphics.conf
@@ -1,7 +1,0 @@
-pwm_tiehrpwm
-tidss
-display_connector
-tc358768
-ti_sn65dsi83
-lontium_lt8912b
-sii902x

--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -42,12 +42,14 @@ FILES:initramfs-module-composefs:append:cfs-signed = "\
     ${sysconfdir}/ostree/initramfs-root-binding.key \
 "
 
+require initramfs-graphics.inc
+
 SUMMARY:initramfs-module-kmod = "initramfs support for loading kernel modules"
-RDEPENDS:initramfs-module-kmod = "${PN}-base"
 FILES:initramfs-module-kmod = "\
     /init.d/01-kmod \
     /etc/modules-load.d/* \
 "
+RDEPENDS:initramfs-module-kmod = "${@get_initramfs_kmods(d)} ${PN}-base"
 
 do_install:append() {
     install -m 0755 ${UNPACKDIR}/plymouth ${D}/init.d/02-plymouth
@@ -109,44 +111,14 @@ do_install:append:cfs-signed() {
     	            ${D}${sysconfdir}/ostree/initramfs-root-binding.key
 }
 
-# Adding modules so plymouth can show the splash screen during boot
-SRC_URI:append:mx8-nxp-bsp = " file://50-imx8-graphics.conf"
-RDEPENDS:initramfs-module-kmod:append:mx8-nxp-bsp = " \
-    kernel-module-fsl-imx-ldb \
-    kernel-module-imx8mp-ldb \
-    kernel-module-phy-fsl-imx8mp-lvds \
-    kernel-module-irq-imx-irqsteer \
-    kernel-module-display-connector \
-    kernel-module-lontium-lt8912b \
-    kernel-module-sec-dsim \
-    kernel-module-sec-mipi-dsim-imx \
-    kernel-module-ti-sn65dsi83 \
-"
-
-do_install:append:mx8-nxp-bsp() {
-    install -d ${D}/etc/modules-load.d/
-    install -m 0755 ${UNPACKDIR}/50-imx8-graphics.conf ${D}/etc/modules-load.d/50-imx8-graphics.conf
-}
-
-SRC_URI:append:ti-soc = " file://50-ti-graphics.conf"
-RDEPENDS:initramfs-module-kmod:append:ti-soc = " \
-    kernel-module-pwm-tiehrpwm \
-    kernel-module-tidss \
-    kernel-module-display-connector \
-    kernel-module-tc358768 \
-    kernel-module-ti-sn65dsi83 \
-    kernel-module-lontium-lt8912b \
-    kernel-module-sii902x \
-"
-
-do_install:append:ti-soc() {
-    install -d ${D}/etc/modules-load.d/
-    install -m 0755 ${UNPACKDIR}/50-ti-graphics.conf ${D}/etc/modules-load.d/50-ti-graphics.conf
-}
-
-RDEPENDS:initramfs-module-kmod:append:beagley-ai = " kernel-module-ite-it66121"
-do_install:append:beagley-ai() {
-    echo "ite_it66121" >> ${D}/etc/modules-load.d/50-ti-graphics.conf
+do_install:append() {
+    if [ -n "${INITRAMFS_EXTRA_KMODS}" ]; then
+        install -d ${D}${sysconfdir}/modules-load.d/
+        install -m 0755 /dev/null ${D}${sysconfdir}/modules-load.d/50-graphics.conf
+        for i in ${INITRAMFS_EXTRA_KMODS}; do
+            echo "${i}" >> ${D}${sysconfdir}/modules-load.d/50-graphics.conf
+        done
+    fi
 }
 
 # Required to ensure runtime SPDX data is updated when kernel modules change

--- a/recipes-core/initramfs-framework/initramfs-graphics.inc
+++ b/recipes-core/initramfs-framework/initramfs-graphics.inc
@@ -15,6 +15,8 @@ INITRAMFS_EXTRA_KMODS:mx8-nxp-bsp = "\
     ti_sn65dsi83 \
     lontium_lt8912b \
 "
+# On Toradex SMARC iMX8MP we need this extra module, before the rest of iMX8 modules
+INITRAMFS_EXTRA_KMODS:prepend:toradex-smarc-imx8mp = "i2c_mux_pca954x "
 
 # Modules necessary for our TI modules to display splash screen.
 INITRAMFS_EXTRA_KMODS:ti-soc = "\

--- a/recipes-core/initramfs-framework/initramfs-graphics.inc
+++ b/recipes-core/initramfs-framework/initramfs-graphics.inc
@@ -1,0 +1,35 @@
+# List of modules to be added to initramfs image.
+# Important: the order here matters, since the modules will be probed
+# in the same order they are added to this variable!
+INITRAMFS_EXTRA_KMODS ?= ""
+
+# Modules necessary for our Verdin iMX8M(M|P) to display splash screen.
+INITRAMFS_EXTRA_KMODS:mx8-nxp-bsp = "\
+    fsl_imx_ldb \
+    imx8mp_ldb \
+    phy_fsl_imx8mp_lvds \
+    irq_imx_irqsteer \
+    sec_dsim \
+    display_connector \
+    sec_mipi_dsim_imx \
+    ti_sn65dsi83 \
+    lontium_lt8912b \
+"
+
+# Modules necessary for our TI modules to display splash screen.
+INITRAMFS_EXTRA_KMODS:ti-soc = "\
+    pwm_tiehrpwm \
+    tidss \
+    display_connector \
+    tc358768 \
+    ti_sn65dsi83 \
+    lontium_lt8912b \
+    sii902x \
+"
+# On BeagleY AI we need this extra module on top of TI modules
+INITRAMFS_EXTRA_KMODS:append:beagley-ai = " ite_it66121"
+
+def get_initramfs_kmods(d):
+    kmods = d.getVar("INITRAMFS_EXTRA_KMODS").split()
+    build_modules = [f"kernel-module-{m.replace('_', '-')}" for m in kmods]
+    return " ".join(build_modules)


### PR DESCRIPTION
Removed leftover modules on for TI devices, refactored the way we add modules to minimize duplication and file creation and added missing module to have splash working on SMARC iMX8MP.

Related-to: TOR-3894
