### PR TITLE
scope: OEROOT path is broken when building out of tree

### DIFF
--- a/conf/template/bblayers.conf
+++ b/conf/template/bblayers.conf
@@ -1,7 +1,7 @@
 # LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
 # changes incompatibly
 LCONF_VERSION = "7"
-OEROOT := "${@os.path.abspath(os.path.dirname(d.getVar('FILE', True)))}/../.."
+OEROOT := "@OEROOT@"
 
 BBPATH = "${TOPDIR}"
 

--- a/scripts/lib/setup-devices/setup-environment-toradex
+++ b/scripts/lib/setup-devices/setup-environment-toradex
@@ -103,7 +103,8 @@ sha512sum "${_TDX_SCRIPTS}"/lib/setup-devices/setup-environment-toradex 2>&1 > c
 if [ ! -f "conf/local.conf" ]; then
     cp "${_TDX_SCRIPTS}"/../conf/template/local.conf conf/local.conf
 fi
-ln -sf "${_TDX_SCRIPTS}"/../conf/template/bblayers.conf conf/bblayers.conf
+cp "${_TDX_SCRIPTS}/../conf/template/bblayers.conf" conf/bblayers.conf
+sed -i "s|@OEROOT@|${_TDX_OEROOT}|g" conf/bblayers.conf
 ln -sf "${_TDX_MANIFESTS}"/README.md README.md
 ln -sf "${_TDX_MANIFESTS}" "${_TDX_OEROOT}"/layers/
 


### PR DESCRIPTION
Attempting to build out of tree, for example with the command ```MACHINE=verdin-imx8mp EULA=1 source setup-environment ~/build-torizon-docker/```, fails due to how OEROOT is being set in the bblayers.conf template file.  See [yocto documentation](https://docs.yoctoproject.org/ref-manual/structure.html#build)

Update bblayers.conf template file and setup-environment-toradex to allow for out of tree build directory.  