### PR TITLE
images/torizon-base.inc: Add rogue drivers for AM62P target

### DIFF
--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -94,6 +94,10 @@ CORE_IMAGE_BASE_INSTALL:append:am62xx = " \
     ti-img-rogue-driver \
 "
 
+CORE_IMAGE_BASE_INSTALL:append:am62pxx = " \
+    ti-img-rogue-driver \
+"
+
 CORE_IMAGE_BASE_INSTALL:append:mx8mp-nxp-bsp = " \
     kernel-module-isp-vvcam \
 "

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -94,7 +94,7 @@ CORE_IMAGE_BASE_INSTALL:append:am62xx = " \
     ti-img-rogue-driver \
 "
 
-CORE_IMAGE_BASE_INSTALL:append:am62pxx = " \
+CORE_IMAGE_BASE_INSTALL:append:verdin-am62p = " \
     ti-img-rogue-driver \
 "
 


### PR DESCRIPTION
This add support to AM62P hardware in the same way we had for AM62 target. Without this we don't have accelerated features while using Chromium container.

Related-to: TCCP-1046