### PR TITLE
rpcbind: Disable systemd service

### DIFF
--- a/recipes-extended/rpcbind/rpcbind_%.bbappend
+++ b/recipes-extended/rpcbind/rpcbind_%.bbappend
@@ -6,3 +6,6 @@ SRC_URI:append:sota = " file://0001-rpcbind.service-run-after-systemd-tmpfiles-s
 # /usr/lib/
 PACKAGECONFIG:append = ' ${@bb.utils.contains("DISTRO_FEATURES", "stateless-system", "nss-altfiles", "", d)}'
 PACKAGECONFIG[nss-altfiles] = '--with-nss-modules="files altfiles",,,'
+
+# We do not want rpcbind listening on 0.0.0.0 by default
+SYSTEMD_AUTO_ENABLE:${PN} = "disable"


### PR DESCRIPTION
There are some minor security concerns with having the rpcbind service enabled by default. This is because the service listens on 0.0.0.0.

The risk is fairly minor, but it's better to disable this as the default behavior. Users can re-enable this on a per use-case basis.

Related-to: TOR-3959