### PR TITLE
images/torizon-base.inc: Add rogue drivers for AM69 target

### DIFF
--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -98,6 +98,10 @@ CORE_IMAGE_BASE_INSTALL:append:verdin-am62p = " \
     ti-img-rogue-driver \
 "
 
+CORE_IMAGE_BASE_INSTALL:append:aquila-am69 = " \
+    ti-img-rogue-driver \
+"
+
 CORE_IMAGE_BASE_INSTALL:append:mx8mp-nxp-bsp = " \
     kernel-module-isp-vvcam \
 "


### PR DESCRIPTION
This add support to AM69 hardware in the same way we had for others AM6* targets. Without this we don't have accelerated features while using Chromium container.

Related-to: TCCP-1058