### PR TITLE
toradex-smarc-imx95-gpu-driver: Add the gpu driver for toradex-smarc-imx95

### DIFF
--- a/conf/distro/include/base-distro.inc
+++ b/conf/distro/include/base-distro.inc
@@ -43,6 +43,7 @@ IMAGE_BOOT_FILES_REMOVE:append:apalis-imx8 = " hdmitxfw.bin dpfw.bin"
 DISTRO_FEATURES:append = " virtualization stateless-system"
 DISTRO_FEATURES_REMOVE ?= "3g alsa irda pcmcia nfc ldconfig pulseaudio wayland x11 ptest multiarch vulkan"
 DISTRO_FEATURES_REMOVE:remove:verdin-imx95 = "vulkan"
+DISTRO_FEATURES_REMOVE:remove:toradex-smarc-imx95 = "vulkan"
 DISTRO_FEATURES_REMOVE:append:imx-generic-bsp = " opengl"
 DISTRO_FEATURES:remove = "${DISTRO_FEATURES_REMOVE}"
 

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -114,6 +114,10 @@ CORE_IMAGE_BASE_INSTALL:append:verdin-imx95 = " \
     mali-imx \
 "
 
+CORE_IMAGE_BASE_INSTALL:append:toradex-smarc-imx95 = " \
+    mali-imx \
+"
+
 nss_altfiles_set_users_groups () {
 	# Make a temporary directory to be used by pseudo to find the real /etc/passwd,/etc/group
 	pseudo_dir=${WORKDIR}/pseudo-rootfs${sysconfdir}


### PR DESCRIPTION
Similar change done for verdin-imx95 in [here](https://github.com/torizon/meta-toradex-torizon/pull/338)

The main difference is the target: toradex-smarc-imx95

Relates to: TCCP-1069