### PR TITLE
base-distro: fix conditional assignments to DISTRO_FEATURES

### DIFF
--- a/conf/distro/include/base-distro.inc
+++ b/conf/distro/include/base-distro.inc
@@ -43,12 +43,12 @@ IMAGE_BOOT_FILES_REMOVE:append:apalis-imx8 = " hdmitxfw.bin dpfw.bin"
 DISTRO_FEATURES:append = " virtualization stateless-system"
 DISTRO_FEATURES_REMOVE ?= "3g alsa irda pcmcia nfc ldconfig pulseaudio wayland x11 ptest multiarch vulkan"
 DISTRO_FEATURES_REMOVE:remove:verdin-imx95 = "vulkan"
+DISTRO_FEATURES_REMOVE:append:imx-generic-bsp = " opengl"
 DISTRO_FEATURES:remove = "${DISTRO_FEATURES_REMOVE}"
-DISTRO_FEATURES:imx-generic-bsp:remove = "opengl"
 
 # No need for x11 even for native
-DISTRO_FEATURES_NATIVE:imx-generic-bsp:remove = "x11"
-DISTRO_FEATURES_NATIVESDK:imx-generic-bsp:remove = "x11"
+DISTRO_FEATURES_NATIVE:remove:imx-generic-bsp = "x11"
+DISTRO_FEATURES_NATIVESDK:remove:imx-generic-bsp = "x11"
 
 # Note, enable or disable the useradd-staticids in a configured system,
 # the TMPDIR/DEPLOY_DIR/SSTATE_DIR may contain incorrect uid/gid values.


### PR DESCRIPTION
Fix assignments to fulfill the original goals, namely:

- To remove the "opengl" distro feature when using the i.MX BSP.
- To also remove the "x11" distro feature when using the i.MX BSP while building native recipes.

Here are the differences in the OE variables before/after the changes (for a `verdin-imx8mm`):

```
$ diff -U0 kernel-nofix.env kernel-fix.env
--- kernel-nofix.env    2025-09-17 20:24:26.455893722 +0000
+++ kernel-fix.env      2025-09-17 20:21:31.512194197 +0000
@@ -1 +1 @@
-DISTRO_FEATURES="acl  bluetooth debuginfod ext2 ipv4 ipv6  usbgadget usbhost wifi xattr nfs zeroconf pci    vfat seccomp opengl     pam systemd usrmerge tpm2 virtualization stateless-system sota usrmerge    gobject-introspection-data "
+DISTRO_FEATURES="acl  bluetooth debuginfod ext2 ipv4 ipv6  usbgadget usbhost wifi xattr nfs zeroconf pci    vfat seccomp            pam systemd usrmerge tpm2 virtualization stateless-system sota usrmerge    gobject-introspection-data "
@@ -7,3 +7,3 @@
-DISTRO_FEATURES_REMOVE="3g alsa irda pcmcia nfc ldconfig pulseaudio wayland x11 ptest multiarch vulkan"
+DISTRO_FEATURES_REMOVE="3g alsa irda pcmcia nfc ldconfig pulseaudio wayland x11 ptest multiarch vulkan opengl"
-DISTRO_FEATURES_NATIVE="acl x11 ipv6 xattr sota"
+DISTRO_FEATURES_NATIVE="acl     ipv6 xattr sota"
-DISTRO_FEATURES_NATIVESDK="x11"
+DISTRO_FEATURES_NATIVESDK=""
```
