### PR TITLE
initramfs-graphics: Add missing modules for Aquila AM69 splash screen

### DIFF
--- a/recipes-core/images/initramfs-ostree-torizon-image.bb
+++ b/recipes-core/images/initramfs-ostree-torizon-image.bb
@@ -9,6 +9,11 @@ PACKAGE_INSTALL:append:cfs-support = "\
     initramfs-module-composefs \
 "
 
+# Additional firmware needed for splash screen on DisplayPort with Aquila AM69
+PACKAGE_INSTALL:append:aquila-am69 = "\
+    cadence-mhdp-fw \
+"
+
 SYSTEMD_DEFAULT_TARGET = "initrd.target"
 
 IMAGE_NAME_SUFFIX = ""

--- a/recipes-core/initramfs-framework/initramfs-graphics.inc
+++ b/recipes-core/initramfs-framework/initramfs-graphics.inc
@@ -31,6 +31,17 @@ INITRAMFS_EXTRA_KMODS:ti-soc = "\
 # On BeagleY AI we need this extra module on top of TI modules
 INITRAMFS_EXTRA_KMODS:append:beagley-ai = " ite_it66121"
 
+# On Aquila AM69, we need this extra module to be loaded before the rest
+# This is only needed when using at least V1.3 of the Aquila Development Board
+INITRAMFS_EXTRA_KMODS:prepend:aquila-am69 = "i2c_mux_pca954x "
+
+# Additional modules needed for splash screen on Aquila AM69
+INITRAMFS_EXTRA_KMODS:append:aquila-am69 = "\
+    cdns_dphy \
+    cdns_dsi \
+    cdns_mhdp8546 \
+"
+
 def get_initramfs_kmods(d):
     kmods = d.getVar("INITRAMFS_EXTRA_KMODS").split()
     build_modules = [f"kernel-module-{m.replace('_', '-')}" for m in kmods]


### PR DESCRIPTION
Related-to: TOR-3721