### PR TITLE
base-distro: re-add opengl to the list of removed features on i.MX

### DIFF
--- a/conf/distro/include/base-distro.inc
+++ b/conf/distro/include/base-distro.inc
@@ -41,6 +41,7 @@ IMAGE_BOOT_FILES_REMOVE:append:apalis-imx8 = " hdmitxfw.bin dpfw.bin"
 DISTRO_FEATURES:append = " virtualization stateless-system"
 DISTRO_FEATURES_REMOVE ?= "3g alsa irda pcmcia nfc ldconfig pulseaudio wayland x11 ptest multiarch vulkan"
 DISTRO_FEATURES_REMOVE:remove:verdin-imx95 = "vulkan"
+DISTRO_FEATURES_REMOVE:append:imx-generic-bsp = " opengl"
 DISTRO_FEATURES:remove = "${DISTRO_FEATURES_REMOVE}"
 
 # No need for x11 even for native


### PR DESCRIPTION
Add the "opengl" feature back to DISTRO_FEATURES_REMOVE (conditioned on override "imx-generic-bsp"); this was removed by mistake. With this, the feature should not be present on the final DISTRO_FEATURES.
