### PR TITLE
conf/distro: bump Common Torizon versioning to 7.4.0

### DIFF
--- a/conf/distro/include/versioning.inc
+++ b/conf/distro/include/versioning.inc
@@ -2,7 +2,7 @@ TDX_BUILDNBR ?= "0"
 TDX_PURPOSE ?= "Testing"
 
 TDX_MAJOR ?= "7"
-TDX_MINOR ?= "0"
+TDX_MINOR ?= "4"
 TDX_PATCH ?= "0"
 
 def get_tdx_prerelease(purpose, datetime):


### PR DESCRIPTION
Prepare for the upcoming Common Torizon release by updating the versioning to 7.4.0. This version is aligned with the Torizon OS release cycle.

Related-to: TOR-3988