### PR TITLE
Adding Realtek WiFi firmware

### DIFF
--- a/conf/distro/include/torizon.inc
+++ b/conf/distro/include/torizon.inc
@@ -19,6 +19,12 @@ BBMASK += " \
     /meta-freescale/recipes-graphics/cairo \
 "
 
+MACHINE_FIRMWARE:append:imx-generic-bsp = " \
+    linux-firmware-rtl8723 \
+    linux-firmware-rtl8821 \
+    linux-firmware-rtl8822 \
+"
+
 # machines where Torizon is experimental
 EXPERIMENTALOVERRIDES = ""
 # Currently Torizon does not support any experimental machines, in future such machines can be added like below:

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,0 +1,4 @@
+FILES:${PN}-rtl8723:append = " \
+  ${nonarch_base_libdir}/firmware/rtw88/rtw8723*.bin* \
+  ${nonarch_base_libdir}/firmware/rtl_bt/rtl8723*.bin* \
+"


### PR DESCRIPTION
The firmwares are already in linux-firmware repository, but were not being installed by OE linux-firmware recipe.
So we make it install with a .bbappend (following what is done in master: https://github.com/openembedded/openembedded-core/blob/master/meta/recipes-kernel/linux-firmware/linux-firmware_20250917.bb#L1386).

And then we make it available to all NXP devices, since the request was originally for Verdin iMX8M Mini.

Related-to: TOR-3993