### PR TITLE
linux-firmware: remove unnecessay firmware files

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,4 +1,3 @@
 FILES:${PN}-rtl8723:append = " \
   ${nonarch_base_libdir}/firmware/rtw88/rtw8723*.bin* \
-  ${nonarch_base_libdir}/firmware/rtl_bt/rtl8723*.bin* \
 "


### PR DESCRIPTION
For some reason, having the firmwares from 'rtl_bt' installed, was causing for every firmware to be installed in the final image, which resulted in a image size growth of ~70% and some compilation errors for Colibri and Apalis iMX8 (devices unrelated to the original change).

Since 'rtl_bt' firmware are not required, we simply skip their installation.

Related-to: TOR-4027