### PR TITLE
Implement new method for applying custom kernel args

### DIFF
--- a/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
+++ b/recipes-bsp/u-boot/u-boot-distro-boot/uEnv.txt.in
@@ -58,6 +58,7 @@ check_rollback_needed=if test -n "${kernel_image2}" && test "${rollback}" = "1";
     env set fdt_file ${fdt_file2}; \
     env set fdtfile ${fdtfile2}; \
     test -n "${kernel_image_type2}" && env set kernel_image_type ${kernel_image_type2}; \
+    test -n "${torizon_boot_args2}" && env set torizon_boot_args ${torizon_boot_args2}; \
 fi || true
 
 set_fdt_path=if test -n "${fdtdir}"; then \
@@ -75,7 +76,7 @@ bootcmd_dtb=if test ${kernel_image_type} != "fitImage"; then \
                     fi || true; \
             fi || true
 
-set_bootargs_custom=if test -n "${fdt_overlays}"; then \
+set_bootargs_custom=if test -n "${fdt_overlays}" && test -z "${torizon_boot_args}"; then \
                         for overlay_file in ${fdt_overlays}; do \
                             if test "${overlay_file}" = "custom-kargs_overlay.dtbo"; then \
                                 if fdt get value custom_kargs /chosen/ bootargs_custom; then \
@@ -84,6 +85,10 @@ set_bootargs_custom=if test -n "${fdt_overlays}"; then \
                             fi; \
                         done; \
                     fi || true
+
+set_bootargs_torizon=if test -n "${torizon_boot_args}"; then \
+                         env set bootargs ${bootargs} ${torizon_boot_args}; \
+                     fi || true
 
 board_fixups=if test "${board}" = "verdin-imx8mm"; then \
                  if test "${fdtfile}" = "imx8mm-verdin-nonwifi-v1.1-dahlia.dtb"; then \
@@ -239,5 +244,5 @@ uenv_extra_configs=@@UENV_EXTRA_CONFIGS@@
 # Ensure "prog_fuses", "read_fuses", "set_vars", and "reset_dev" are ran first here.
 bootcmd_run=run prog_fuses && run read_fuses && run set_vars && run reset_dev && \
             run board_fixups && run check_rollback_needed && run uenv_extra_configs && run set_bootargs && run set_fdt_path && \
-            run bootcmd_dtb && run bootcmd_args && run set_bootargs_custom && run set_kernel_load_addr && \
-            run bootcmd_load_k && run bootcmd_unzip_k && run bootcmd_load_r && run bootcmd_boot
+            run bootcmd_dtb && run bootcmd_args && run set_bootargs_custom && run set_bootargs_torizon && \
+            run set_kernel_load_addr && run bootcmd_load_k && run bootcmd_unzip_k && run bootcmd_load_r && run bootcmd_boot

--- a/recipes-extended/ostree/files/0002-Add-support-for-the-fdtfile-variable-in-uEnv.txt.patch
+++ b/recipes-extended/ostree/files/0002-Add-support-for-the-fdtfile-variable-in-uEnv.txt.patch
@@ -1,4 +1,4 @@
-From 2081a996bc941ff892fb6b76d23b1cc6bac00770 Mon Sep 17 00:00:00 2001
+From 743ddf0c250176fd042a741a059d5d63a6e1ab37 Mon Sep 17 00:00:00 2001
 From: Sergio Prado <sergio.prado@toradex.com>
 Date: Wed, 13 Jul 2022 14:52:33 -0300
 Subject: [PATCH 1/2] Add support for the fdtfile variable in uEnv.txt
@@ -22,13 +22,20 @@ to be searched in uEnv.txt.
 
 Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
 
+Comments for v3:
+
+Improve uboot_config_get_helper to parse strings that have an "="
+character in their value past the first "=" character.
+
+Signed-off-by: Jeremias Cordoba <jeremias.cordoba@toradex.com>
+
 Upstream-Status: Inappropriate [TorizonCore specific]
 ---
  src/libostree/ostree-bootloader-uboot.c | 44 +++++++++++++++++++++++++
  1 file changed, 44 insertions(+)
 
 diff --git a/src/libostree/ostree-bootloader-uboot.c b/src/libostree/ostree-bootloader-uboot.c
-index 41280cf1..6eb41e4e 100644
+index 41280cf1..9d198f7d 100644
 --- a/src/libostree/ostree-bootloader-uboot.c
 +++ b/src/libostree/ostree-bootloader-uboot.c
 @@ -98,6 +98,40 @@ append_system_uenv (OstreeBootloaderUboot *self, const char *bootargs, GPtrArray
@@ -45,7 +52,7 @@ index 41280cf1..6eb41e4e 100644
 +uboot_config_get_helper (const char *line, void *data, GError **error)
 +{
 +  struct uboot_config_get_params *params = data;
-+  g_auto(GStrv) vars = g_strsplit(line, "=", -1);
++  g_auto(GStrv) vars = g_strsplit(line, "=", 2);
 +  if (!g_strcmp0 (vars[0], params->key))
 +    {
 +      params->val = g_strdup (vars[1]);
@@ -90,5 +97,5 @@ index 41280cf1..6eb41e4e 100644
        if (val)
          {
 -- 
-2.34.1
+2.30.2
 

--- a/recipes-extended/ostree/files/0006-Add-support-for-torizon_boot_args-in-uEnv.txt.patch
+++ b/recipes-extended/ostree/files/0006-Add-support-for-torizon_boot_args-in-uEnv.txt.patch
@@ -1,0 +1,43 @@
+From 55fc37923f13c52d8bd18705da14e51aa9800ff6 Mon Sep 17 00:00:00 2001
+From: Jeremias Cordoba <js.cordoba8321@gmail.com>
+Date: Thu, 6 Nov 2025 14:51:57 -0800
+Subject: [PATCH 1/1] Add support for torizon_boot_args in uEnv.txt
+
+Save variable "torizon_boot_args" from previous OSTree deployment.
+This allows the setting of custom boot args by external tooling,
+in a way that OSTree can track.
+
+Upstream-Status: Inappropriate [Torizon OS specific]
+
+Related-to: TOR-4066
+
+Signed-off-by: Jeremias Cordoba <jeremias.cordoba@toradex.com>
+---
+ src/libostree/ostree-bootloader-uboot.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/src/libostree/ostree-bootloader-uboot.c b/src/libostree/ostree-bootloader-uboot.c
+index a566b997..361e8d9f 100644
+--- a/src/libostree/ostree-bootloader-uboot.c
++++ b/src/libostree/ostree-bootloader-uboot.c
+@@ -204,6 +204,17 @@ create_config_from_boot_loader_entries (OstreeBootloaderUboot *self, int bootver
+               g_free (val);
+             }
+         }
++
++      if (i)
++        {
++          val = uboot_config_get ("torizon_boot_args", cancellable, error);
++          if (val)
++            {
++              g_ptr_array_add (new_lines,
++                               g_strdup_printf ("torizon_boot_args%s=%s", index_suffix, val));
++              g_free (val);
++            }
++        }
+     }
+ 
+   return TRUE;
+-- 
+2.30.2
+

--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -8,6 +8,7 @@ SRC_URI:append = " \
     file://0003-ostree-fetcher-curl-set-max-parallel-connections.patch \
     file://0004-curl-Make-socket-callback-during-cleanup-into-no-op.patch \
     file://0005-Add-support-for-kernel_image_type-in-uEnv.txt.patch \
+    file://0006-Add-support-for-torizon_boot_args-in-uEnv.txt.patch \
     file://0001-mount-Allow-building-when-macro-MOUNT_ATTR_IDMAP-is-.patch \
     file://0002-mount-Allow-building-when-macro-LOOP_CONFIGURE-is-no.patch \
     file://ostree-pending-reboot.service \


### PR DESCRIPTION
The new method here uses a new variable `torizon_boot_args` that is in `uEnv.txt`. This new variable is also tracked via OSTree (capability added via patch to libostree), this allows the custom kernel args to be tracked in updates and rollbacks.

The major reason for a new method was that the old method did not work with FIT images which is important for our root-of-trust strategy.

The old method is still supported to prevent potential breaking changes, but the new method will take priority.

Related-to: TOR-4066