### PR TITLE
intel-corei7-64: fix fw_pritenv/fw_setenv on x86 machines [master]

### DIFF
--- a/conf/machine/include/intel-corei7-64.inc
+++ b/conf/machine/include/intel-corei7-64.inc
@@ -22,8 +22,6 @@ IMAGE_FSTYPES:append = " wic.vmdk wic.vdi"
 hostname:pn-base-files = "torizon-x86"
 
 PREFERRED_PROVIDER_u-boot-default-script = ""
-PREFERRED_PROVIDER_u-boot-fw-utils = "grub-ota-fallback"
-PREFERRED_RPROVIDER_u-boot-fw-utils = "grub-ota-fallback"
 PREFERRED_PROVIDER_virtual/dtb = ""
 
 PREFERRED_PROVIDER_virtual/kernel:xenomai3 = "linux-xenomai-3"
@@ -32,6 +30,7 @@ PREFERRED_VERSION_linux-xenomai-3 ?= "5.10.%"
 PREFERRED_PROVIDER_virtual/kernel:xenomai4 = "linux-xenomai-4"
 PREFERRED_VERSION_linux-xenomai-4 = "5.10.%"
 
+IMAGE_INSTALL:append = " grub-ota-fallback"
 IMAGE_INSTALL:remove = " minnowboard-efi-startup network-configuration"
 LINUX_VERSION_EXTENSION ?= "-torizon-${LINUX_KERNEL_TYPE}"
 LINUX_VERSION_EXTENSION:xenomai3 ?= "-torizon-${LINUX_KERNEL_TYPE}-xenomai3"


### PR DESCRIPTION
Currently u-boot-fw-utils is being set to grub-ota-fallback, which installs the fw_printenv and fw_setenv into the torizon image. However, this value is not being reflected:

$ bitbake-getvar -r u-boot-fw-utils --value PN libubootenv

This happends because the libuootenv from oe-core layer sets "PROVIDES = u-boot-fw-utils", which has higher priority over the preferred provider variable, selecting the wrong recipe.

Because of that, remove the preferred provider since x86 does not use u-boot anyways and use the IMAGE_INSTALL to select the correct package.

Related-to: TOR-4047
Fixes: d372817 ("intel-corei7-64: add x86 support through meta-intel's intel-corei7-64")

(cherry picked from commit 5424c787467ee037a7244f9c18299709f0ce4c00)