### PR TITLE
torizon_base_image_type: Add bootloader deploy to OTA_FILES_DEPENDS.

### DIFF
--- a/classes/torizon_base_image_type.inc
+++ b/classes/torizon_base_image_type.inc
@@ -324,9 +324,12 @@ gen_bootloader_ota_files () {
     done
 }
 
+ARCH_OTA_FILES_DEPENDS = "virtual/bootloader:do_deploy"
+ARCH_OTA_FILES_DEPENDS:x86-64 = ""
 # Dependencies for gen_bootloader_ota_files():
 GEN_BOOTLOADER_OTA_FILES_DEPENDS ?= "\
     jq-native:do_populate_sysroot \
+    ${ARCH_OTA_FILES_DEPENDS} \
 "
 
 IMAGE_PREPROCESS_COMMAND += "adjust_rootfs_datetime;"

--- a/classes/torizon_base_image_type.inc
+++ b/classes/torizon_base_image_type.inc
@@ -344,9 +344,12 @@ gen_bootloader_ota_files () {
     done
 }
 
+ARCH_OTA_FILES_DEPENDS = "virtual/bootloader:do_deploy"
+ARCH_OTA_FILES_DEPENDS:x86-64 = ""
 # Dependencies for gen_bootloader_ota_files():
 GEN_BOOTLOADER_OTA_FILES_DEPENDS ?= "\
     jq-native:do_populate_sysroot \
+    ${ARCH_OTA_FILES_DEPENDS} \
 "
 
 IMAGE_PREPROCESS_COMMAND += "adjust_rootfs_datetime;"


### PR DESCRIPTION
torizon_base_image_type: Add bootloader deploy to OTA_FILES_DEPENDS.

This fixes a build race where the u-boot-env.json file is not populated.  To manually
trigger this, the following sequence of commands can be used:
  $ bitbake virtual/kernel -c cleansstate
  $ rm -rf deploy/ tmp/
  $ bitbake torizon-docker -c rootfs
  ERROR: torizon-docker-1.0-r0 do_rootfs: Could not find bootloader version file '.../deploy/images/verdin-imx8mm/u-boot-version.json'
  ERROR: torizon-docker-1.0-r0 do_rootfs: ExecutionError('.../tmp/work/verdin_imx8mm-tdx-linux/torizon-docker/1.0/temp/run.gen_bootloader_ota_files.495585', 1, None, None)
  ERROR: Logfile of failure stored in: .../tmp/work/verdin_imx8mm-tdx-linux/torizon-docker/1.0/temp/log.do_rootfs.495585
  ERROR: Task (.../layers/meta-toradex-torizon/recipes-images/images/torizon-docker.bb:do_rootfs) failed with exit code '1'

Note this is gated by architecture as X86_64 does not require it.
