### PR TITLE
[master] aktualizr-default-sec: fix QA issue files not being shipped

### DIFF
--- a/recipes-sota/config/aktualizr-default-sec.bb
+++ b/recipes-sota/config/aktualizr-default-sec.bb
@@ -31,9 +31,8 @@ do_install:append () {
     install -m 0644 ${UNPACKDIR}/secondaries.json ${D}${libdir}/sota/secondaries.json
     sed -i "s/@@MACHINE@@/${MACHINE}/g" ${D}${libdir}/sota/secondaries.json
 
-    install -d ${D}${bindir}
-
     if [ "${BL_UPDATE_SUPPORT}" = "1" ]; then
+        install -d ${D}${bindir}
         install -m 0744 ${UNPACKDIR}/bl_actions.sh ${D}${bindir}/bl_actions.sh
         install -m 0644 ${UNPACKDIR}/common_actions.sh ${D}${bindir}/common_actions.sh
     fi
@@ -42,6 +41,7 @@ do_install:append () {
 do_install:append:imx-generic-bsp () {
     sed -e 's/@@MACHINE@@/${MACHINE}/' \
         ${UNPACKDIR}/fuse_actions-in.sh > ${UNPACKDIR}/fuse_actions.sh
+    install -d ${D}${bindir}
     install -m 0744 ${UNPACKDIR}/fuse_actions.sh ${D}${bindir}/fuse_actions.sh
 
     local machine="${MACHINE}"


### PR DESCRIPTION
After the modifications from 2ee819b2504797c44612bb9217193e51e2a381c2, installation of scripts were conditional, but the creation of `bindir` was not, which was failing QA test.

So to fix this, we create the `bindir` only when we're actually going to install binaries to it.


(cherry picked from commit 4b70ba7539e3364b86caf4295a45bbc44e15b5c9)