### PR TITLE
initramfs-ostree-torizon-image: remove unnecessary rootfs post-processes

### DIFF
--- a/recipes-core/images/initramfs-ostree-torizon-image.bb
+++ b/recipes-core/images/initramfs-ostree-torizon-image.bb
@@ -43,3 +43,13 @@ IMAGE_ROOTFS_EXTRA_SPACE = "0"
 IMAGE_OVERHEAD_FACTOR = "1.0"
 
 BAD_RECOMMENDATIONS += "busybox-syslog"
+
+# Remove post-process commands inherited from torizon_base_image_type.inc that
+# are irrelevant for the initramfs (containers, OTA, and os-release tweaks).
+# This also suppresses the warning about the missing IMAGE_VARIANT with
+# initramfs.
+ROOTFS_POSTPROCESS_COMMAND:remove = "\
+    adjust_container_engines; \
+    gen_bootloader_ota_files; \
+    tweak_os_release_variant; \
+"


### PR DESCRIPTION
The "torizon_base_image_type.inc" include file adds several functions to ROOTFS_POSTPROCESS_COMMAND that are irrelevant for the initramfs:

- adjust_container_engines: Only required for images with containers.
- gen_bootloader_ota_files: Only required for OTA bootloaders.
- tweak_os_release_variant: Unnecessary as /etc/os-release is not utilized in the initramfs image.

Removing tweak_os_release_variant specifically fixes the following build-time warning:

WARNING: initramfs-ostree-torizon-image-1.0-r0 do_rootfs: IMAGE_VARIANT is missing, would be better to define it for a Torizon image recipe.