### PR TITLE
[master] systemd: add systemd-conf as dependency for systemd

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -15,6 +15,12 @@ SRC_URI:append:genericx86-64 = " file://0001-rules-whitelist-hd-devices.patch"
 PACKAGECONFIG:append = " resolved networkd"
 RRECOMMENDS:${PN}:remove = "os-release"
 
+# systemd-conf is needed to make Torizon Cloud docker-compose updates work.
+# Change it to a depency instead of reccomends, if NO_RECCOMENDS is used the
+# OTA will still work.
+RRECOMMENDS:${PN}:remove = "systemd-conf"
+RDEPENDS:${PN}:append = " systemd-conf"
+
 # /var is expected to be rw, so drop volatile-binds service files
 RDEPENDS:${PN}:remove = "volatile-binds"
 RDEPENDS:${PN} += "bash"


### PR DESCRIPTION
On oe-core layer, systemd-conf is a recommendation [1], but in order to make the Torizon Cloud docker-compose OTA updates work, systemd-conf is a requirement [2]. Without this, the updates fail.

If an image is using NO_RECOMMENDATIONS [3], systemd-conf is not installed. To fix it, change it to a dependency so the Torizon Cloud docker-compose updates will always work.

[1] https://github.com/openembedded/openembedded-core/blob/master/meta/recipes-core/systemd/systemd_258.1.bb#L740
[2] https://github.com/torizon/meta-toradex-torizon/blob/scarthgap-7.x.y/recipes-core/systemd/systemd-conf_%25.bbappend#L15
[3] https://docs.yoctoproject.org/ref-manual/variables.html#term-NO_RECOMMENDATIONS


(cherry picked from commit 574bb5e80769a21de8d649dbc3f758fbd3837cec)