### PR TITLE
toradex-kernel-localversion: fix CVE version on Torizon Os

### DIFF
--- a/classes/toradex-kernel-localversion.bbclass
+++ b/classes/toradex-kernel-localversion.bbclass
@@ -13,7 +13,13 @@
 inherit toradex-kernel-config
 
 TDX_VERSION ??= "0"
-SCMVERSION ??= "y"
+# Do not include the kernel repo's git hash to the kernel version.
+# If patches are applied from OE this is not reproducible as patches
+# get applied by 'git am' and a new hash value will be present with
+# each build.
+# Additionally external kernel modules fail to install if the kernel
+# is taken from sstate but the module is rebuilt.
+SCMVERSION = "n"
 KERNEL_LOCALVERSION ?= "-${TDX_VERSION}"
 # mute the meta-freescale/classes/fsl-kernel-localversion setting, otherwise
 # with latest master we get -${TDX_VERSION} twice in the resulting version.

--- a/classes/toradex-kernel-localversion.bbclass
+++ b/classes/toradex-kernel-localversion.bbclass
@@ -55,6 +55,10 @@ kernel_do_configure:append() {
 
 def get_linux_base_version(d):
     linux_version = d.getVar('LINUX_VERSION')
+
+	if not linux_version:
+		bb.fatal("LINUX_VERSION is not defined. Make sure this class is inherited in a kernel context.")
+
     if '-rt' in linux_version:
         return linux_version.split('-rt')[0]
     return linux_version

--- a/classes/toradex-kernel-localversion.bbclass
+++ b/classes/toradex-kernel-localversion.bbclass
@@ -46,3 +46,11 @@ kernel_do_configure:append() {
 		kernel_configure_variable LOCALVERSION_AUTO n
 	fi
 }
+
+def get_linux_base_version(d):
+    linux_version = d.getVar('LINUX_VERSION')
+    if '-rt' in linux_version:
+        return linux_version.split('-rt')[0]
+    return linux_version
+
+CVE_VERSION = "${@get_linux_base_version(d)}"


### PR DESCRIPTION
Since the 7.4.0 release, there were some changes in other layers which impacted the kernel minor version on TorizonOS images. The solution to avoid duplicated lines across layers was to implement a function that extracts the minor version from the kernel version in the meta-toradex-bsp-common class. Given that meta-toradex-torizon has priority over meta-toradex-bsp-common, this class is overwritten by the former, which does not have this function implemented. Hence, our images do not get the minor version from the kernel.

To fix this, we are bringing the missing commit from the BSP layer for the classes/toradex-kernel-localversion.bbclass