### PR TITLE
toradex-kernel-localversion: fix inconsistent use of tabs and spaces

### DIFF
--- a/classes/toradex-kernel-localversion.bbclass
+++ b/classes/toradex-kernel-localversion.bbclass
@@ -56,8 +56,8 @@ kernel_do_configure:append() {
 def get_linux_base_version(d):
     linux_version = d.getVar('LINUX_VERSION')
 
-	if not linux_version:
-		bb.fatal("LINUX_VERSION is not defined. Make sure this class is inherited in a kernel context.")
+    if not linux_version:
+        bb.fatal("LINUX_VERSION is not defined. Make sure this class is inherited in a kernel context.")
 
     if '-rt' in linux_version:
         return linux_version.split('-rt')[0]


### PR DESCRIPTION
'get_linux_base_version' function was written with space as tabs, and the new check for a corner case was implemented using tabs, which caused this parsing error.