### PR TITLE
initramfs/torizon_base_image_type: make nostamp conditional on cfs-signed

### DIFF
--- a/classes/torizon_base_image_type.inc
+++ b/classes/torizon_base_image_type.inc
@@ -89,7 +89,21 @@ validate_ostree_layer_revision_info() {
 do_image_ostreecommit[prefuncs] += "validate_ostree_layer_revision_info ${CFS_OSTREECOMMIT_PREFUNCS}"
 do_image_ostreecommit[depends] += "${CFS_OSTREECOMMIT_DEPENDS}"
 do_image_ostreecommit[file-checksums] += "${CFS_OSTREECOMMIT_FILE_CHECKSUMS}"
-do_image_ostreecommit[nostamp] = "1"
+
+# 'nostamp' is only needed when 'cfs-signed' is active, because that feature
+# generates cryptographic keys at build time, making the task non-cacheable
+# since the keys might change. For projects not using 'cfs-signed', there are
+# no keys involved and the task is deterministic, so setting 'nostamp'
+# unconditionally would cause taint propagation to all dependent tasks,
+# eventually breaking the build.
+#
+# FIXME: due to Yocto bug #13808, it is not possible to use an inline python
+# function to set flags conditionally. An anonymous function is required
+# instead. This can be simplified once the bug has been fixed.
+python() {
+    if 'cfs-signed' in (d.getVar('OVERRIDES') or '').split(':'):
+        d.setVarFlag('do_image_ostreecommit', 'nostamp', '1')
+}
 
 EXTRA_OSTREE_COMMIT:append:cfs-signed = "\
     --generate-composefs-metadata \

--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -108,7 +108,21 @@ CFS_INSTALL_FILE_CHECKSUMS ?= "${@cfs_get_key_file_checksums(d)}"
 do_install[prefuncs] += "${CFS_INSTALL_PREFUNCS}"
 do_install[depends] += "${CFS_INSTALL_DEPENDS}"
 do_install[file-checksums] += "${CFS_INSTALL_FILE_CHECKSUMS}"
-do_install[nostamp] = "1"
+
+# 'nostamp' is only needed when 'cfs-signed' is active, because that feature
+# generates cryptographic keys at build time, making the task non-cacheable
+# since the keys might change. For projects not using 'cfs-signed', there are
+# no keys involved and the task is deterministic, so setting 'nostamp'
+# unconditionally would cause taint propagation to all dependent tasks,
+# eventually breaking the build.
+#
+# FIXME: due to Yocto bug #13808, it is not possible to use an inline python
+# function to set flags conditionally. An anonymous function is required
+# instead. This can be simplified once the bug has been fixed.
+python() {
+    if 'cfs-signed' in (d.getVar('OVERRIDES') or '').split(':'):
+        d.setVarFlag('do_install', 'nostamp', '1')
+}
 
 do_install:append:cfs-signed() {
     # Bundled into initramfs-module-composefs:


### PR DESCRIPTION
The 'nostamp' flag tells bitbake "don't cache this task", so the task is not stored in the sstate cache. When a task has 'nostamp', bitbake assigns it a random UUID on every parse to force it to run again. The problem is that this UUID propagates as a "taint" to every task that depends on it, making their hashes change too, even if nothing in the code actually changed.

This caused build failures when building Torizon OS since tasks were being marked as invalid due to the taint propagation:

  ERROR: When reparsing poet-image.bb:do_image_ostreecommit, the
  basehash value changed from b7d4836c... to 6633ce4c.... The metadata
  is not deterministic and this needs to be fixed.

The root cause was identified by running the '-Sprintdiff' command (suggested by the error), which showed the nostamp UUID changing between parses:

  Task initramfs-framework:do_install couldn't be used from the cache
  because:
    Taint (by forced/invalidated task) changed from
    nostamp(uuid4):cfec6231-6ed3-45bb-a256-3504ecfb0308 to
    nostamp(uuid4):becf49ac-cb3b-49f4-94c1-9833c01dc496

Checking the original commits, 'nostamp' is only needed for the 'cfs-signed' case, because that feature generates cryptographic keys at build time, making the task non-cacheable since the keys might change. For projects not using 'cfs-signed', there are no keys involved and the task is deterministic, so 'nostamp' serves no purpose and eventually breaks the build.

Therefore, make 'nostamp' conditional by using an anonymous python function to set the flag only when 'cfs-signed' is present in DISTROOVERRIDES (as defined in cfs-signed.bbclass).

This approach also avoids the known BitBake bug #13808 [1], which triggers a warning when an inline python function is used to set flags [2].

[1] https://bugzilla.yoctoproject.org/show_bug.cgi?id=13808
[2] https://lore.kernel.org/all/20210602162038.17323-1-chris.laplante@agilent.com/

Fixes: 6200d10fd173 ("initramfs-framework: fix torizon-signed generation")
Fixes: 9d1905cbe40b ("classes: fix torizon-signed generation")