### PR TITLE
conf/machine: add nvidia-drm-loadconf jetson orin nano recipe

### DIFF
--- a/conf/machine/include/jetson-orin-nano-devkit.inc
+++ b/conf/machine/include/jetson-orin-nano-devkit.inc
@@ -11,4 +11,4 @@ BBMASK += "meta-tegra/external/sota/recipes-bsp/uefi/edk2-firmware-tegra_%.bbapp
 
 do_image_tegraflash[depends] += " tegra-minimal-initramfs:do_image_complete"
 
-IMAGE_INSTALL:append:tegra = " nvidia-docker"
+IMAGE_INSTALL:append:tegra = " nvidia-docker nvidia-drm-loadconf"


### PR DESCRIPTION
This recipe is responsible to load a modprobe conf file with the settings needed to configure nvidia-drm.

We need this to being able to make graphics output to work.

Related to TOR-4229