### PR TITLE
initramfs-framework: add lost patch mounting /run

### DIFF
--- a/recipes-core/initramfs-framework/files/0001-initramfs-framework-mount-run-and-move-to-rootfs-bef.patch
+++ b/recipes-core/initramfs-framework/files/0001-initramfs-framework-mount-run-and-move-to-rootfs-bef.patch
@@ -1,0 +1,64 @@
+From b5d8f0f872037e437a0f55037e422fb37501f420 Mon Sep 17 00:00:00 2001
+From: Eduardo Ferreira <eduardo.barbosa@toradex.com>
+Date: Tue, 17 Mar 2026 13:13:15 +0000
+Subject: [PATCH] initramfs-framework: mount /run and move to rootfs before
+ switch_root
+
+Mount /run as tmpfs during early init and include it in the set of
+mounts moved to $ROOTFS_DIR prior to exec switch_root.
+
+Having /run available early lets initramfs modules stamp state that can
+later influence systemd service jobs, since systemd will reuse the mount
+point instead of creating a new one during boot.
+
+This is particularly useful with ostree, as it uses /run/ostree-booted
+as way to describe that the rootfs comes from an ostree deployment.
+
+Upstream-Status: Backport [https://github.com/openembedded/openembedded-core/commit/3a4bd7ddefbf5b412a2b4031d491f5a50f1908cd]
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+Signed-off-by: Mathieu Dubois-Briand <mathieu.dubois-briand@bootlin.com>
+Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
+Signed-off-by: Eduardo Ferreira <eduardo.barbosa@toradex.com>
+---
+ finish | 3 ++-
+ init   | 4 +++-
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/finish b/finish
+index ac0de9f..ed8298d 100755
+--- a/finish
++++ b/finish
+@@ -35,10 +35,11 @@ finish_run() {
+ 			mount -n --move "$dir" "${ROOTFS_DIR}/media/${dir##*/}"
+ 		done
+ 
+-		debug "Moving /dev, /proc and /sys onto rootfs..."
++		debug "Moving /dev, /proc, /sys and /run onto rootfs..."
+ 		mount --move /dev $ROOTFS_DIR/dev
+ 		mount --move /proc $ROOTFS_DIR/proc
+ 		mount --move /sys $ROOTFS_DIR/sys
++		mount --move /run $ROOTFS_DIR/run
+ 
+ 		cd $ROOTFS_DIR
+ 		exec switch_root -c /dev/console $ROOTFS_DIR ${bootparam_init:-/sbin/init}
+diff --git a/init b/init
+index a48b77e..5dd2522 100755
+--- a/init
++++ b/init
+@@ -81,9 +81,11 @@ EFI_DIR=/sys/firmware/efi  # place to store device firmware information
+ touch /etc/fstab
+ 
+ # initialize /proc, /sys, /run/lock and /var/lock
+-mkdir -p /proc /sys /run/lock /var/lock
++mkdir -p /proc /sys /run /var/lock
+ mount -t proc proc /proc
+ mount -t sysfs sysfs /sys
++mount -t tmpfs tmpfs /run
++mkdir -p /run/lock
+ 
+ if [ -d $EFI_DIR ];then
+ 	mount -t efivarfs none /sys/firmware/efi/efivars
+-- 
+2.34.1
+

--- a/recipes-core/initramfs-framework/files/0003-notify-newroot-for-plymouth.patch
+++ b/recipes-core/initramfs-framework/files/0003-notify-newroot-for-plymouth.patch
@@ -1,4 +1,4 @@
-From 228229ca0c76b03842b5a2a069350c26a970338b Mon Sep 17 00:00:00 2001
+From 9ddc37f8bf7d2e5ba42a04a725be5f61bd46e2ca Mon Sep 17 00:00:00 2001
 From: Eduardo Ferreira <eduardo.barbosa@toradex.com>
 Date: Mon, 2 Feb 2026 11:40:52 +0000
 Subject: [PATCH] notify-newroot-for-plymouth
@@ -14,12 +14,12 @@ Signed-off-by: Eduardo Ferreira <eduardo.barbosa@toradex.com>
  1 file changed, 5 insertions(+)
 
 diff --git a/finish b/finish
-index ac0de9f..1ee6a19 100755
+index ed8298d..c55d0c4 100755
 --- a/finish
 +++ b/finish
-@@ -40,6 +40,11 @@ finish_run() {
- 		mount --move /proc $ROOTFS_DIR/proc
+@@ -41,6 +41,11 @@ finish_run() {
  		mount --move /sys $ROOTFS_DIR/sys
+ 		mount --move /run $ROOTFS_DIR/run
  
 +		if [ -f /usr/bin/plymouth ]; then
 +			debug "Notifying plymouth about the rootfs dir change..."

--- a/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
+++ b/recipes-core/initramfs-framework/initramfs-framework_1.0.bbappend
@@ -4,6 +4,7 @@ SRC_URI += "\
     file://plymouth \
     file://ostree \
     file://kmod \
+    file://0001-initramfs-framework-mount-run-and-move-to-rootfs-bef.patch \
     file://0002-only-scan-for-block-devices.patch \
     file://0003-notify-newroot-for-plymouth.patch \
 "


### PR DESCRIPTION
Up until scarthgap (and master) we used to have this patch[1], which is necessary for ostree to run ostree-system-generator. At some point, this change made it to upstream[3], and so we had to drop it from our master branch[2].

When we forked our master to create the walnascar branch, we ended up with half measures: we had the patch removed on our end and it's also not available in walnascar branch of openembedded-core. This is why we're seeing the issue where no home directory exists.

And to fix this, a backport of OE-core main branch[3] was performed,

Note: Due to the fact that, historically this patch was the first one applied[1], and that our patch names were kept '0002' and '0003' (no '0001'), I've decided to add this back as '0001', and with this I needed to change '0003-notify-newroot-for-plymouth.patch', since the context changed.

[1] https://github.com/torizon/meta-toradex-torizon/blob/scarthgap-7.x.y/recipes-core/initramfs-framework/files/0001-Mount-run-with-tmpfs.patch
[2] https://github.com/torizon/meta-toradex-torizon/commit/02a7ae134f5f60e76f5fd05b3d513bb7c1171c64
[3] https://github.com/openembedded/openembedded-core/commit/3a4bd7ddefbf5b412a2b4031d491f5a50f1908cd

Related-to: TOR-4238