### PR TITLE
go-cross: add patch that corrects patch CVE-2025-61726

### DIFF
--- a/recipes-devtools/go/files/0001-net-url-add-urlmaxqueryparams-GODEBUG-to-limit-the-n.patch
+++ b/recipes-devtools/go/files/0001-net-url-add-urlmaxqueryparams-GODEBUG-to-limit-the-n.patch
@@ -1,0 +1,198 @@
+From bfc2bd8e6d55de2d5441f68aef49f64a1d358672 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Mon, 3 Nov 2025 14:28:47 -0800
+Subject: [PATCH] net/url: add urlmaxqueryparams GODEBUG to limit the number of
+ query parameters
+
+net/url does not currently limit the number of query parameters parsed by
+url.ParseQuery or URL.Query.
+
+When parsing a application/x-www-form-urlencoded form,
+net/http.Request.ParseForm will parse up to 10 MB of query parameters.
+An input consisting of a large number of small, unique parameters can
+cause excessive memory consumption.
+
+We now limit the number of query parameters parsed to 10000 by default.
+The limit can be adjusted by setting GODEBUG=urlmaxqueryparams=<n>.
+Setting urlmaxqueryparams to 0 disables the limit.
+
+Thanks to jub0bs for reporting this issue.
+
+Fixes #77101
+Fixes CVE-2025-61726
+
+CVE: CVE-2025-61726
+Upstream-Status: Backport [https://github.com/golang/go/commit/85c794ddce26]
+
+Change-Id: Iee3374c7ee2d8586dbf158536d3ade424203ff66
+Reviewed-on: https://go-internal-review.googlesource.com/c/go/+/3020
+Reviewed-by: Nicholas Husin <husin@google.com>
+Reviewed-by: Neal Patel <nealpatel@google.com>
+Reviewed-on: https://go-internal-review.googlesource.com/c/go/+/3326
+Reviewed-by: Roland Shoemaker <bracewell@google.com>
+Reviewed-on: https://go-review.googlesource.com/c/go/+/736702
+Auto-Submit: Michael Pratt <mpratt@google.com>
+Reviewed-by: Junyang Shao <shaojunyang@google.com>
+TryBot-Bypass: Michael Pratt <mpratt@google.com>
+(cherry picked from commit 85c794ddce26a092b0ea68d0fca79028b5069d5a)
+Signed-off-by: Deepak Rathore <deeratho@cisco.com>
+Signed-off-by: Eduardo Ferreira <eduardo.barbosa@toradex.com>
+---
+ doc/godebug.md                 |  7 +++++
+ src/internal/godebugs/table.go |  1 +
+ src/net/url/url.go             | 24 +++++++++++++++++
+ src/net/url/url_test.go        | 48 ++++++++++++++++++++++++++++++++++
+ src/runtime/metrics/doc.go     |  5 ++++
+ 5 files changed, 85 insertions(+)
+
+diff --git a/doc/godebug.md b/doc/godebug.md
+index ae4f057..635597e 100644
+--- a/doc/godebug.md
++++ b/doc/godebug.md
+@@ -126,6 +126,13 @@ for example,
+ see the [runtime documentation](/pkg/runtime#hdr-Environment_Variables)
+ and the [go command documentation](/cmd/go#hdr-Build_and_test_caching).
+ 
++Go 1.26 added a new `urlmaxqueryparams` setting that controls the maximum number
++of query parameters that net/url will accept when parsing a URL-encoded query string.
++If the number of parameters exceeds the number set in `urlmaxqueryparams`,
++parsing will fail early. The default value is `urlmaxqueryparams=10000`.
++Setting `urlmaxqueryparams=0`bles the limit. To avoid denial of service attacks,
++this setting and default was backported to Go 1.25.4 and Go 1.24.10.
++
+ Go 1.23.11 disabled build information stamping when multiple VCS are detected due
+ to concerns around VCS injection attacks. This behavior can be renabled with the
+ setting `allowmultiplevcs=1`.
+diff --git a/src/internal/godebugs/table.go b/src/internal/godebugs/table.go
+index 33dcd81..7178df6 100644
+--- a/src/internal/godebugs/table.go
++++ b/src/internal/godebugs/table.go
+@@ -51,6 +51,7 @@ var All = []Info{
+ 	{Name: "tlsmaxrsasize", Package: "crypto/tls"},
+ 	{Name: "tlsrsakex", Package: "crypto/tls", Changed: 22, Old: "1"},
+ 	{Name: "tlsunsafeekm", Package: "crypto/tls", Changed: 22, Old: "1"},
++	{Name: "urlmaxqueryparams", Package: "net/url", Changed: 24, Old: "0"},
+ 	{Name: "x509sha1", Package: "crypto/x509"},
+ 	{Name: "x509usefallbackroots", Package: "crypto/x509"},
+ 	{Name: "x509usepolicies", Package: "crypto/x509"},
+diff --git a/src/net/url/url.go b/src/net/url/url.go
+index d2ae032..5219e3c 100644
+--- a/src/net/url/url.go
++++ b/src/net/url/url.go
+@@ -13,6 +13,7 @@ package url
+ import (
+ 	"errors"
+ 	"fmt"
++	"internal/godebug"
+ 	"net/netip"
+ 	"path"
+ 	"sort"
+@@ -958,7 +959,30 @@ func ParseQuery(query string) (Values, error) {
+ 	return m, err
+ }
+ 
++var urlmaxqueryparams = godebug.New("urlmaxqueryparams")
++
++const defaultMaxParams = 10000
++
++func urlParamsWithinMax(params int) bool {
++	withinDefaultMax := params <= defaultMaxParams
++	if urlmaxqueryparams.Value() == "" {
++		return withinDefaultMax
++	}
++	customMax, err := strconv.Atoi(urlmaxqueryparams.Value())
++	if err != nil {
++		return withinDefaultMax
++	}
++	withinCustomMax := customMax == 0 || params < customMax
++	if withinDefaultMax != withinCustomMax {
++		urlmaxqueryparams.IncNonDefault()
++	}
++	return withinCustomMax
++}
++
+ func parseQuery(m Values, query string) (err error) {
++	if !urlParamsWithinMax(strings.Count(query, "&") + 1) {
++		return errors.New("number of URL query parameters exceeded limit")
++	}
+ 	for query != "" {
+ 		var key string
+ 		key, query, _ = strings.Cut(query, "&")
+diff --git a/src/net/url/url_test.go b/src/net/url/url_test.go
+index fef236e..b2f8bd9 100644
+--- a/src/net/url/url_test.go
++++ b/src/net/url/url_test.go
+@@ -1488,6 +1488,54 @@ func TestParseQuery(t *testing.T) {
+ 	}
+ }
+ 
++func TestParseQueryLimits(t *testing.T) {
++	for _, test := range []struct {
++		params  int
++		godebug string
++		wantErr bool
++	}{{
++		params:  10,
++		wantErr: false,
++	}, {
++		params:  defaultMaxParams,
++		wantErr: false,
++	}, {
++		params:  defaultMaxParams + 1,
++		wantErr: true,
++	}, {
++		params:  10,
++		godebug: "urlmaxqueryparams=9",
++		wantErr: true,
++	}, {
++		params:  defaultMaxParams + 1,
++		godebug: "urlmaxqueryparams=0",
++		wantErr: false,
++	}} {
++		t.Setenv("GODEBUG", test.godebug)
++		want := Values{}
++		var b strings.Builder
++		for i := range test.params {
++			if i > 0 {
++				b.WriteString("&")
++			}
++			p := fmt.Sprintf("p%v", i)
++			b.WriteString(p)
++			want[p] = []string{""}
++		}
++		query := b.String()
++		got, err := ParseQuery(query)
++		if gotErr, wantErr := err != nil, test.wantErr; gotErr != wantErr {
++			t.Errorf("GODEBUG=%v ParseQuery(%v params) = %v, want error: %v", test.godebug, test.params, err, wantErr)
++		}
++		if err != nil {
++			continue
++		}
++		if got, want := len(got), test.params; got != want {
++			t.Errorf("GODEBUG=%v ParseQuery(%v params): got %v params, want %v", test.godebug, test.params, got, want)
++		}
++	}
++}
++
+ type RequestURITest struct {
+ 	url *URL
+ 	out string
+diff --git a/src/runtime/metrics/doc.go b/src/runtime/metrics/doc.go
+index 517ec0e..335f787 100644
+--- a/src/runtime/metrics/doc.go
++++ b/src/runtime/metrics/doc.go
+@@ -328,6 +328,11 @@ Below is the full list of supported metrics, ordered lexicographically.
+ 		The number of non-default behaviors executed by the crypto/tls
+ 		package due to a non-default GODEBUG=tlsunsafeekm=... setting.
+ 
++	/godebug/non-default-behavior/urlmaxqueryparams:events
++		The number of non-default behaviors executed by the net/url
++		package due to a non-default GODEBUG=urlmaxqueryparams=...
++		setting.
++
+ 	/godebug/non-default-behavior/x509sha1:events
+ 		The number of non-default behaviors executed by the crypto/x509
+ 		package due to a non-default GODEBUG=x509sha1=... setting.
+-- 
+2.34.1
+

--- a/recipes-devtools/go/go-cross_%.bbappend
+++ b/recipes-devtools/go/go-cross_%.bbappend
@@ -1,0 +1,14 @@
+# TODO: remove this whole go_1.22.12.bbappend once the fix is included in the upstream release
+# https://patchwork.yoctoproject.org/project/oe-core/patch/20260309165351.311700-1-eduardo.f120@yahoo.com/
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# Remove the patch that originally included the issue.
+SRC_URI:remove = " \
+    file://CVE-2025-61726.patch \
+"
+
+# Re-add the patch, but now corrected with the GODEBUG variable inserted in the right place.
+SRC_URI:append = " \
+    file://0001-net-url-add-urlmaxqueryparams-GODEBUG-to-limit-the-n.patch \
+"


### PR DESCRIPTION
On openembedded-core, a patch was added addressing CVE-2025-61726 on go recipe, but this patch introduced another bug, which was affecting us in docker (see [1] for explanation).

A patch was submitted to OE-core[1], but this is affecting a majority of our tests (that depends on running containers). So, to unblock this, we internalize the patch while it's under review. Once it gets merged, then we can safely remove the recipes-devtools/go folder from this layer.

[1] https://patchwork.yoctoproject.org/project/oe-core/patch/20260309165351.311700-1-eduardo.f120@yahoo.com/

Related-to: TOR-4230