### PR TITLE
setup-environment: fix devtool script not working

### DIFF
--- a/scripts/setup-environment
+++ b/scripts/setup-environment
@@ -195,3 +195,6 @@ else
         ;;
     esac
 fi
+
+export BUILDDIR=${_TDX_BUILDDIR}
+


### PR DESCRIPTION
After the commit f657650 was merged, the variable "BUILDDIR" was renamed as "_TDX_BUILDDIR". Since the script "devtool" expect the variable environment "BUILDDIR", causing an environment error

Related-to: TOR-4221

(cherry picked from commit 49ad8bf0f46932f55a107efdcac48db8bbc679e4)