### PR TITLE
go-cross: restrict the CVE-2025-61726 patch fix to non synaptics

### DIFF
--- a/recipes-devtools/go/go-cross_%.bbappend
+++ b/recipes-devtools/go/go-cross_%.bbappend
@@ -10,5 +10,5 @@ SRC_URI:remove = " \
 
 # Re-add the patch, but now corrected with the GODEBUG variable inserted in the right place.
 SRC_URI:append = " \
-    file://0001-net-url-add-urlmaxqueryparams-GODEBUG-to-limit-the-n.patch \
+    ${@bb.utils.contains_any('MACHINE', 'luna-sl1680 sl1680 sl2619', '', 'file://0001-net-url-add-urlmaxqueryparams-GODEBUG-to-limit-the-n.patch', d)} \
 "


### PR DESCRIPTION
Due to Synaptics SDK hash of OE-cre being 10 months old, the original patch that caused the docker issue, CVE-2025-61726.patch, is not present, so we need to remove our patch of it so the build isn't affected.

Related-to; TOR-4259