### PR TITLE
ostree: allow pulling local repos with static-deltas

### DIFF
--- a/recipes-extended/ostree/files/0001-Allow-pulling-local-repos-with-static-deltas.patch
+++ b/recipes-extended/ostree/files/0001-Allow-pulling-local-repos-with-static-deltas.patch
@@ -1,0 +1,36 @@
+From 2cb176c2c10a2cffaadbad4a6d5a3b29e25de86f Mon Sep 17 00:00:00 2001
+From: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+Date: Thu, 19 Mar 2026 14:38:45 -0300
+Subject: [PATCH] Allow pulling local repos with static deltas
+
+In order to allow for smaller Lockboxes, disable a feature (default
+behavior) of OSTree where the static-deltas are normally disabled when
+performing local pulls.
+
+Upstream-Status: Inappropriate [Torizon OS specific]
+Related-to: TOR-4248
+Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
+---
+ src/libostree/ostree-repo-pull.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/src/libostree/ostree-repo-pull.c b/src/libostree/ostree-repo-pull.c
+index 9989415f..cf6d908a 100644
+--- a/src/libostree/ostree-repo-pull.c
++++ b/src/libostree/ostree-repo-pull.c
+@@ -3942,12 +3942,6 @@ ostree_repo_pull_with_options (OstreeRepo *self, const char *remote_name_or_base
+    */
+   if (pull_data->remote_repo_local)
+     {
+-      /* For local pulls, default to disabling static deltas so that the
+-       * exact object files are copied.
+-       */
+-      if (!pull_data->require_static_deltas)
+-        pull_data->disable_static_deltas = TRUE;
+-
+       /* Note the inversion here; PULL_FLAGS_UNTRUSTED is converted to
+        * IMPORT_FLAGS_TRUSTED only if it's unset (and just for local repos).
+        */
+-- 
+2.34.1
+

--- a/recipes-extended/ostree/ostree_%.bbappend
+++ b/recipes-extended/ostree/ostree_%.bbappend
@@ -9,9 +9,10 @@ SRC_URI:append = " \
     file://0004-curl-Make-socket-callback-during-cleanup-into-no-op.patch \
     file://0005-Add-support-for-kernel_image_type-in-uEnv.txt.patch \
     file://0006-Add-support-for-custom-bootargs-in-uEnv.txt.patch \
+    file://0007-ostree-grub-generator-allow-adding-custom-scripts-to.patch \
+    file://0001-Allow-pulling-local-repos-with-static-deltas.patch \
     file://0001-mount-Allow-building-when-macro-MOUNT_ATTR_IDMAP-is-.patch \
     file://0002-mount-Allow-building-when-macro-LOOP_CONFIGURE-is-no.patch \
-    file://0007-ostree-grub-generator-allow-adding-custom-scripts-to.patch \
     file://ostree-pending-reboot.service \
     file://ostree-pending-reboot.path \
     file://ostree-repo-config.sh \


### PR DESCRIPTION
Add a patch to libostree to change its default behavior when pulling commits from local repositories: instead of disabling static-deltas, allow them to be used if present.

The immediate goal is to allow Aktualizr (user of libostree) to load Lockboxes having these static-deltas.

Related-to: TOR-4248