### PR TITLE
aquila-imx95-gpu-driver: add the gpu mali driver for aquila-imx95

### DIFF
--- a/conf/distro/include/base-distro.inc
+++ b/conf/distro/include/base-distro.inc
@@ -42,8 +42,7 @@ IMAGE_BOOT_FILES_REMOVE:append:apalis-imx8 = " hdmitxfw.bin dpfw.bin"
 
 DISTRO_FEATURES:append = " virtualization stateless-system"
 DISTRO_FEATURES_REMOVE ?= "3g alsa irda pcmcia nfc ldconfig pulseaudio wayland x11 ptest multiarch vulkan"
-DISTRO_FEATURES_REMOVE:remove:verdin-imx95 = "vulkan"
-DISTRO_FEATURES_REMOVE:remove:toradex-smarc-imx95 = "vulkan"
+DISTRO_FEATURES_REMOVE:remove:mx95-nxp-bsp = "vulkan"
 DISTRO_FEATURES_REMOVE:append:imx-generic-bsp = " opengl"
 DISTRO_FEATURES:remove = "${DISTRO_FEATURES_REMOVE}"
 

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -107,14 +107,6 @@ CORE_IMAGE_BASE_INSTALL:append:mx8mp-nxp-bsp = " \
 "
 
 CORE_IMAGE_BASE_INSTALL:append:mx95-nxp-bsp = " \
-    ${@bb.utils.contains("DISTROOVERRIDES", "common-torizon-distro", "mali-imx", "",d)} \
-"
-
-CORE_IMAGE_BASE_INSTALL:append:verdin-imx95 = " \
-    mali-imx \
-"
-
-CORE_IMAGE_BASE_INSTALL:append:toradex-smarc-imx95 = " \
     mali-imx \
 "
 


### PR DESCRIPTION
The mali gpu driver depends on DISTRO_FEATURE vulkan. So we need to add the vulkan feature.
Worth notice that add in this context means remove from DISTRO_FEATURE_REMOVE.

Related-to: TOR-4258