### PR TITLE
README: update torizon layer to drop git protocol

### DIFF
--- a/docs/README-nvidia.md
+++ b/docs/README-nvidia.md
@@ -20,7 +20,7 @@ $ cd ~/yocto-workdir
 ```
 4. Initialize the Torizon repository:
 ```
-$ repo init -u git://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m torizon/integration.xml
+$ repo init -u https://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m torizon/integration.xml
 ```
 > [!IMPORTANT]
 > Until an official release of Common Torizon OS for NVIDIA Jetson Orin Nano, only the `integration.xml` manifest is suitable for end-users to build. After an official release, users will be able to use the `default.xml` manifest.

--- a/docs/README-nxp.md
+++ b/docs/README-nxp.md
@@ -4,7 +4,7 @@ Setup
 2. Initialize and sync the repo manifest for NXP:
 ```bash
 $ mkdir common-torizon; cd common-torizon
-$ repo init -u git://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/nxp/default.xml
+$ repo init -u https://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/nxp/default.xml
 $ repo sync -j 10
 ```
 We **strongly recommend** using the `default.xml` manifest. The `integration.xml` and `next.xml` are development manifests used internally and they might be unstable.

--- a/docs/README-stm32mp.md
+++ b/docs/README-stm32mp.md
@@ -20,7 +20,7 @@ $ cd ~/yocto-workdir
 ```
 4. Initialize the Torizon repository:
 ```
-$ repo init -u git://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m torizon/default.xml
+$ repo init -u https://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m torizon/default.xml
 ```
 5. Sync the repositories:
 ```

--- a/docs/README-syn.md
+++ b/docs/README-syn.md
@@ -4,7 +4,7 @@ Setup
 2. Initialize and sync the repo manifest for Synaptics:
 ```bash
 $ mkdir common-torizon; cd common-torizon
-$ repo init -u git://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/syn/integration.xml
+$ repo init -u https://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/syn/integration.xml
 $ repo sync -j 10
 ```
 

--- a/docs/README-ti.md
+++ b/docs/README-ti.md
@@ -4,7 +4,7 @@ Setup
 2. Initialize and sync the repo manifest for Texas Instruments:
 ```bash
 $ mkdir common-torizon; cd common-torizon
-$ repo init -u git://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/ti/default.xml
+$ repo init -u https://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/ti/default.xml
 $ repo sync -j 10
 ```
 We **strongly recommend** using the `default.xml` manifest. The `integration.xml` and `next.xml` are development manifests used internally and they might be unstable.

--- a/docs/README-x86.md
+++ b/docs/README-x86.md
@@ -4,7 +4,7 @@ Setup
 2. Initialize and sync the repo manifest for x86:
 ```bash
 $ mkdir common-torizon; cd common-torizon
-$ repo init -u git://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/x86/default.xml
+$ repo init -u https://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/x86/default.xml
 $ repo sync -j 10
 ```
 We **strongly recommend** using the `default.xml` manifest. The `integration.xml` and `next.xml` are development manifests used internally and they might be unstable.


### PR DESCRIPTION
We are dropping git protocol to use https instead for git.toradex.com. This change makes git.toradex.com more robust for downloads

Related-to: TOR-4261