### PR TITLE
README: update torizon layer to drop git protocol

### DIFF
--- a/docs/README-nvidia.md
+++ b/docs/README-nvidia.md
@@ -1,0 +1,129 @@
+Setup
+======
+1. Set up the default git user and e-mail:
+```
+$ git config --global user.email "you@example.com"
+$ git config --global user.name "Your Name"
+```
+2. Install the repo utility to the development host:
+```
+$ mkdir ~/bin
+$ PATH=~/bin:$PATH
+$ curl http://commondatastorage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
+$ chmod a+x ~/bin/repo
+```
+3. Create a working directory for the Yocto build, go into that directory:
+```
+$ cd ~
+$ mkdir ~/yocto-workdir
+$ cd ~/yocto-workdir
+```
+4. Initialize the Torizon repository:
+```
+$ repo init -u https://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m torizon/integration.xml
+```
+> [!IMPORTANT]
+> Until an official release of Common Torizon OS for NVIDIA Jetson Orin Nano, only the `integration.xml` manifest is suitable for end-users to build. After an official release, users will be able to use the `default.xml` manifest.
+
+Note that `integration.xml` is a development manifest that may contain unfinished features and should therefore be considered unstable.
+
+5. Sync the repositories:
+```
+$ repo sync
+```
+6. Download the `meta-tegra` layer:
+```
+$ git -C layers clone -b scarthgap https://github.com/OE4T/meta-tegra.git
+```
+
+Build
+======
+1. Use the Docker container provided by Toradex to setup the build environment in the work directory `~/yocto-workdir` prepared in previous steps:
+```
+$ docker run --rm -it --name=crops -v ~/yocto-workdir:/workdir --workdir=/workdir torizon/crops:scarthgap-7.x.y /bin/bash
+```
+2. Repeat the step of configuring the Git user name and e-mail:
+```
+$$ git config --global user.email "you@example.com"
+$$ git config --global user.name "Your Name"
+```
+3. In the Docker console set up the environment for the Jetson Orin Nano DevKit: `MACHINE=<MACHINE> source setup-environment [BUILDDIR]`, where `MACHINE` is one of the following:
+ * `jetson-orin-nano-devkit` - Jetson Orin Nano DevKit with SD card boot option
+ * `jetson-orin-nano-devkit-nvme` - Jetson Orin Nano DevKit with NVME SSD boot option
+
+`BUILDDIR` is the directory where you would like to to store the build files. For example:
+```
+$$ MACHINE=jetson-orin-nano-devkit-nvme source setup-environment build-jetson-orin-nano
+```
+4. Build the Torizon images:
+```
+$$ bitbake torizon-docker
+```
+
+Flash the Device
+======
+1. When build is complete the `tegraflash` image shall appear in the deploy directory. This is the tarball containing the NVIDIA installer for the Tegra platform (which is a special build of Linux with initrd to be launched on the target board via USB), the bootloader image to be installed to the QSPI flash and the Ostree-based Torizon image to be installed to SSD or SD-card depending on the selected configuration. To launch the NVIDIA installer, unpack the tegraflash tarball and execute the `doflash.sh` script from it. Suggest to automate this process as follows.
+
+2. Save the following script to `deploy.sh` in the working directory with the Torizon build:
+```
+#!/bin/bash
+
+image=$1
+machine=$2
+
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+deployfile=${image}-${machine}.tegraflash.tar.gz
+tmpdir=`mktemp`
+
+rm -rf $tmpdir
+mkdir -p $tmpdir
+echo "Using temp directory $tmpdir"
+pushd $tmpdir
+cp $scriptdir/build-jetson-orin-nano/deploy/images/${machine}/$deployfile .
+tar -xvf $deployfile
+set -e
+sudo ./doflash.sh
+popd
+echo "Removing temp directory $tmpdir"
+rm -rf $tmpdir
+```
+
+3. Connect the USB port to the host machine and put the target board into the recovery mode: short the `FORCE_RECOVERY` pin (labeled as `FC_REC` on the carrier board) to the ground, this can be done by installing a wired jumper to the contacts `9-10` of the `J14` `button` header on the carrier board (refer to the [Jetson Orin Nano Developer Kit Carrier Board Specification](https://developer.nvidia.com/downloads/assets/embedded/secure/jetson/orin_nano/docs/jetson_orin_nano_devkit_carrier_board_specification_sp.pdf)), then power on the board.
+
+4. Run the deployment script:
+```
+$ sudo ./deploy.sh <IMAGE> <MACHINE>
+```
+for example:
+```
+$ sudo ./deploy.sh torizon-docker jetson-orin-nano-devkit-nvme
+```
+
+Boot
+======
+1. Use the TTL to USB converter cable to connect the serial console (refer to JetsonHacks video: https://www.youtube.com/watch?v=Kwpxhw41W50).
+
+2. Remove the recovery mode jumper and power the target board on.
+
+3. From the serial console terminal, monitor the target boot sequence:
+```
+Jetson System firmware version v36.4.4 date 1970-01-01T00:00:00+00:00
+ESC   to enter Setup.
+...
+Common Torizon OS 7.5.0-devel-20251205093706+build.0 jetson-orin-nano-devkit-nvme ttyTCU0
+
+jetson-orin-nano-devkit-nvme login:
+
+```
+4. Login to the board using the `torizon/torizon` credentials.
+
+Run NVIDIA docker
+======
+
+The NVIDIA container runtime is included in the `jetson-orin-nano-devkit` and `jetson-orin-nano-devkit-nvme` configurations for Torizon.
+
+Use `docker run --runtime nvidia` to run containerized NVIDIA applications. For example, to run the `stable-diffusion` tutorial from the NVIDIA Jetson AI Lab (https://www.jetson-ai-lab.com/archive/tutorial_stable-diffusion.html) use the following command in Torizon:
+
+```
+sudo docker run --runtime nvidia -it --rm --network=host dustynv/stable-diffusion-webui:r36.2.0
+```

--- a/docs/README-nxp.md
+++ b/docs/README-nxp.md
@@ -1,0 +1,86 @@
+Setup
+======
+1. If you don't have the `repo` tool installed, please refer to [Build Torizon OS From Source with Yocto Project](https://developer.toradex.com/torizon/in-depth/build-torizoncore-from-source-with-yocto-projectopenembedded/#download-metadata).
+2. Initialize and sync the repo manifest for NXP:
+```bash
+$ mkdir common-torizon; cd common-torizon
+$ repo init -u https://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/nxp/default.xml
+$ repo sync -j 10
+```
+We **strongly recommend** using the `default.xml` manifest. The `integration.xml` and `next.xml` are development manifests used internally and they might be unstable.
+`default.xml` is the manifest used for our releases, so they are reliable.  
+
+Alternatively, you can manually clone all layers one by one. Refer to the section [_Manual Setup_](#manual-setup) at the end of this document to learn how.
+
+Build
+======
+| Board | MACHINE | Status |
+|---|---|---|
+| FRDM i.MX 93 | imx93frdm  | Supported  |
+| Verdin i.MX95 EVK  | imx95-19x19-verdin  | Supported |
+
+1. Source `setup-environment`, specifying the machine to build with the MACHINE variable e.g.:
+```bash
+$ MACHINE=imx93frdm . torizon-setup-environment <build-directory>
+```
+If a build directory is not given, the script will create one named `build`, where all build artifacts will be stored.
+
+2. Inside the build directory, start the build e.g.:
+```bash
+$ bitbake torizon-docker
+```
+All artifacts should be inside `<build-directory>/deploy/images/${MACHINE}`.
+
+Flash the Device (Verdin i.MX95 EVK)
+======
+1. Change board boot switch to `ON OFF OFF ON` (CM33 Serial Download)
+2. Download [uuu](https://github.com/nxp-imx/mfgtools/releases/tag/uuu_1.5.201) or build it from [source](https://github.com/nxp-imx/mfgtools)
+3. Download image:
+```bash
+sudo ./uuu -b emmc_all <bootloader> <wic image>
+```
+For example, flashing a local build we've generated:
+```bash
+sudo ./uuu -v -b emmc_all imx-boot-imx95-19x19-verdin-sd.bin-flash_all torizon-docker-imx95-19x19-verdin-7.0.0-devel-20250602173442+build.0.wic.zst
+```
+4. Change boot switch to `ON OFF ON OFF` (CM33 eMMC) to boot from eMMC.
+
+Flash the Device (FRDM i.MX93 SDCard)
+======
+1. Change board boot switch to `ON ON OFF OFF` to boot from SDCard.
+2. Flash the wic image to an SDCard.
+```bash
+zstdcat if=torizon-docker-imx93-11x11-lpddr4x-frdm-7.0.0-devel-20250602173442+build.0.wic.zst | sudo dd of=<sdcard-device-node>
+```
+3. Insert the SDCard.
+4. Power on the board.
+
+Flash the Device (FRDM i.MX93 eMMC)
+======
+Coming Soon
+
+Manual Setup
+======
+1. Create the project folder:
+```bash
+$ mkdir common-torizon; cd common-torizon
+```
+2. Clone NXP's BSP layers:
+```bash
+$ repo init -u https://github.com/nxp-imx/imx-manifest.git -b imx-linux-scarthgap -m imx-6.6.52-2.2.0.xml
+$ repo sync -j 10
+```
+3. Clone `meta-toradex-torizon` layer, and its dependencies:
+```bash
+$ git clone https://github.com/torizon/meta-toradex-torizon.git -b scarthgap-7.x.y sources/meta-toradex-torizon
+$ git clone https://github.com/uptane/meta-updater.git -b scarthgap sources/meta-updater
+$ ln -s sources/meta-toradex-torizon/scripts/setup-environment torizon-setup-environment
+```
+
+Additional Setup for i.MX93 FRDM boards
+======
+1. Clone NXP's BSP layers specific to the i.MX93 FRDM board:
+```bash
+$ git clone https://github.com/nxp-imx-support/meta-imx-frdm.git -b imx-frdm-4.0 sources/meta-imx-frdm
+$ ln -s sources/meta-imx-frdm/tools/imx-frdm-setup.sh imx-frdm-setup.sh
+```

--- a/docs/README-stm32mp.md
+++ b/docs/README-stm32mp.md
@@ -1,0 +1,112 @@
+Setup
+======
+1. Set up the default git user and e-mail:
+```
+$ git config --global user.email "you@example.com"
+$ git config --global user.name "Your Name"
+```
+2. Install the repo utility to the development host:
+```
+$ mkdir ~/bin
+$ PATH=~/bin:$PATH
+$ curl http://commondatastorage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
+$ chmod a+x ~/bin/repo
+```
+3. Create a working directory for the Yocto build, go into that directory:
+```
+$ cd ~
+$ mkdir ~/yocto-workdir
+$ cd ~/yocto-workdir
+```
+4. Initialize the Torizon repository:
+```
+$ repo init -u https://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m torizon/default.xml
+```
+5. Sync the repositories:
+```
+$ repo sync
+```
+6. Download the ST32MP BSP layer:
+```
+$ git -C layers clone -b openstlinux-6.6-yocto-scarthgap-mpu-v25.03.19 https://github.com/STMicroelectronics/meta-st-stm32mp
+```
+
+Build
+======
+1. Use the Docker container provided by Toradex to setup the build environment in the work directory ~/yocto-workdir prepared in previous steps:
+```
+$ docker run --rm -it --name=crops -v ~/yocto-workdir:/workdir --workdir=/workdir torizon/crops:scarthgap-7.x.y /bin/bash
+```
+2. Repeat the step of configuring the Git user name and e-mail:
+```
+$$ git config --global user.email "you@example.com"
+$$ git config --global user.name "Your Name"
+```
+3. In the Docker console set up the environment for a specific STM32MP board: `MACHINE=<MACHINE> source setup-environment [BUILDDIR]`, where `MACHINE` is one of the supported STM32MP targets:
+ * `stm32mp25-eval` for the STM32MP2 Evaluation kit
+ * `stm32mp25-disco` for the STM32MP2 Discovery kit
+ * `stm32mp15-disco` for STM32MP157 Discovery kit,
+`BUILDDIR` is the directory where you would like to to store the build files. For example:
+```
+$$ MACHINE=stm32mp25-disco source setup-environment build-stm32mp25-disco
+```
+4. Build the Torizon images:
+```
+$$ bitbake torizon-docker
+```
+
+Flash the Device
+======
+
+1. Go on st.com to download the STM32CubeProgrammer software and install it to the `/opt/st/bin` directory.
+2. Add `STM32_Programmer_CLI` to your `PATH`:
+```
+$ export PATH=$PATH:/opt/st/bin:
+$ STM32_Programmer_CLI
+      -------------------------------------------------------------------
+                        STM32CubeProgrammer v2.14.0
+      -------------------------------------------------------------------
+
+
+Usage :
+STM32_Programmer_CLI.exe [command_1] [Arguments_1][[command_2][Arguments_2]...]
+```
+3. Select the USB Serial Downloader mode. Refer to ST’s WiKi for details on the boot switches for your board:
+ * `STM32MP257X-EV1` - https://wiki.st.com/stm32mpu/wiki/STM32MP257x-EV1_-_hardware_description#Boot_related_switches
+ * `STM32MP257x-DKx` - https://wiki.st.com/stm32mpu/wiki/STM32MP257x-DKx_-_hardware_description#Boot_switches
+ * `STM32MP157x-DKx` - https://wiki.st.com/stm32mpu/wiki/STM32MP157x-DKx_-_hardware_description#Boot_related_switches
+
+4. Pass the `SD card` or `eMMC` Flash Layout file to the `STM32_Programmer_CLI` for programming the images to the boot media: `STM32_Programmer_CLI -c port=usb1 -w flashlayout_torizon-core-docker/optee/FlashLayout_<MEDIA>_<BOARD>-optee.tsv`, where `MEDIA` is one of `sdcard` or `emmc`, `BOARD` is one of `stm32mp257f-ev1`, `stm32mp257f-dk` or `stm32mp157f-dk2`. For example, use the following command to install Torizon to the SD card inserted to the STM32MP2 Discovery Kit board:
+```
+$ cd ~/yocto-workdir/build-stm32mp25-disco/deploy/images/stm32mp25-disco/
+$ STM32_Programmer_CLI -c port=usb1 -w flashlayout_torizon-docker/optee/FlashLayout_sdcard_stm32mp257f-dk-optee.tsv
+```
+
+Boot
+======
+
+1. Power the target board off.
+2. Set the boot mode for booting from `SD` card or `eMMC`.  Refer to the ST’s WiKi for the boot switches details for your board:
+ * `STM32MP257X-EV1` - https://wiki.st.com/stm32mpu/wiki/STM32MP257x-EV1_-_hardware_description#Boot_related_switches
+ * `STM32MP257x-DKx` - https://wiki.st.com/stm32mpu/wiki/STM32MP257x-DKx_-_hardware_description#Boot_switches
+ * `STM32MP157x-DKx` - https://wiki.st.com/stm32mpu/wiki/STM32MP157x-DKx_-_hardware_description#Boot_related_switches
+3. Power the target board on.
+4. From the serial console terminal, monitor the target boot sequence:
+```
+NOTICE:  CPU: STM32MP257FAK Rev.Y
+NOTICE:  Model: STMicroelectronics STM32MP257F-DK Discovery Board
+NOTICE:  Board: MB1605 Var1.0 Rev.C-01
+NOTICE:  Reset reason: Pin reset from NRST (0x2034)
+INFO:    PMIC2 version = 0x11
+INFO:    PMIC2 product ID = 0x20
+INFO:    FCONF: Reading TB_FW firmware configuration file from: 0xe011000
+INFO:    FCONF: Reading firmware configuration information for: stm32mp_fuse
+INFO:    FCONF: Reading firmware configuration information for: stm32mp_io
+INFO:    Using SDMMC
+...
+Common Torizon OS 7.0.0-devel-20250423143254+build.0 torizon-stm32mp25-disco ttySTM0
+
+torizon-stm32mp25-disco login:
+
+```
+5. Login to the board using the `torizon/torizon` credentials.

--- a/docs/README-syn.md
+++ b/docs/README-syn.md
@@ -1,0 +1,134 @@
+Setup
+======
+1. If you don't have the `repo` tool installed, please refer to [Build Torizon OS From Source with Yocto Project](https://developer.toradex.com/torizon/in-depth/build-torizoncore-from-source-with-yocto-projectopenembedded/#download-metadata).
+2. Initialize and sync the repo manifest for Synaptics:
+```bash
+$ mkdir common-torizon; cd common-torizon
+$ repo init -u https://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/syn/integration.xml
+$ repo sync -j 10
+```
+
+> [!IMPORTANT]
+> Until an official release of Common Torizon OS, only the `integration.xml` manifest is suitable for end-users to build. After an official release, users will be able to use the `default.xml` manifest.
+
+Note that `integration.xml` is a development manifest used internally and it might contain development features and thus be considered unstable.
+
+> [!IMPORTANT]
+> Common Torizon OS is only available on branches `scarthgap-7.x.y` or newer!
+
+Alternatively, you can manually clone all layers one by one. Refer to the section [_Manual Setup_](#manual-setup) at the end of this document to learn how.
+
+Build Environment
+======
+You can use Synaptics Crops container to also build Common Torizon
+###### &emsp; The following command must be run inside the common-torizon directory
+```bash
+$ docker run --rm -it --name=syn-crops-common -v $(pwd):/workdir --workdir=/workdir ghcr.io/synaptics-astra/crops:latest
+```
+
+Build
+======
+
+| Board        | MACHINE     | Status     |
+|---           |---          |---         |
+| Luna SL1680  | luna-sl1680 | Supported  |
+| Astra SL1680 | sl1680      | Supported  |
+
+1. Source `setup-environment`, specifying the machine to build with the MACHINE variable e.g.:
+```bash
+$ MACHINE=sl1680 . setup-environment <build-directory>
+```
+If a build directory is not given, the script will create one named `build-${DISTRO}`, where all build artifacts will be stored. By default `DISTRO` is automatically set to `common-torizon` with the Synaptics boards.
+
+2. Inside the build directory, start the build e.g.:
+```bash
+$ bitbake torizon-docker
+```
+All artifacts should be inside `<build-directory>/deploy/images/${MACHINE}`, including the `SYNAIMG` folder.
+
+Recovery Mode
+======
+#### Astra SL1680
+On the device, press the `USB-Boot` button, and while holding it down either power on the device or press the `RESET` button.
+
+#### Luna SL1680
+To the right of the USB-C connector there is a jumper, that's the board `USB-Boot` jumper. Power off the device on the `Power Switch`, short this jumper and then power it on again.
+After the flashing is done, remove the short on that jumper so the device can boot normally.
+
+Flashing eMMC
+======
+For flashing, there are two possible ways: use the helper script `flash-image.sh` or doing the steps manually.
+
+> [!WARNING]  
+> This helper script does NOT yet work with the Luna SL1680 board, it only works with the Astra SL1680 board.
+
+1. The easiest way is to use the helper script:
+
+    a. After the build is done, get the file called `SYNAIMG-flash.tar.gz` from the `deploy/images/${MACHINE}` folder.  
+    b. Unpack it into a proper folder, using the tar command: `tar -xf SYNAIMG-flash.tar.gz`.  
+    c. With the board in recovery mode, execute the script: `./flash-image.sh`.  
+
+2. Another option is to do all the steps manually:
+
+    a. For flashing, you'll need the latest release of Synaptics' `usb-tool`. Please refer to their [usb-tool GitHub repository](https://github.com/synaptics-astra/usb-tool/releases) and download the latest `astra-update`.
+    On `Luna SL1680`, make sure to check the _important note_ at the bottom of this section.
+
+    b. Unpack its contents somewhere, go into that folder and copy `SYNAIMG` from the generated artifacts of your build.
+    ```bash
+    $ cd usb-tool
+    $ cp -r <build-directory>/deploy/images/${MACHINE}/SYNAIMG SYNAIMG
+    ```
+     * Or make a symlink to it
+    ```bash
+    $ cd usb-tool
+    $ ln -s <build-directory>/deploy/images/${MACHINE}/SYNAIMG SYNAIMG
+    ```
+    c. Grab the manifest ID:
+    ```bash
+    $ cat astra-usbboot-images/sl1680_suboot/manifest.yaml | grep ^id:
+    ```
+    d. Run `astra-update`
+    ```bash
+    $ sudo ./bin/linux/x86_64/astra-update -c sl1680 -m 4gb -d lpddr4x -t emmc -i <manifest ID from previous step>
+    ```
+    Or, if you like you could make it in one line using `shyaml`
+    ```bash
+    $ pip install shyaml
+    $ sudo ./bin/linux/x86_64/astra-update -c sl1680 -m 4gb -d lpddr4x -t emmc -i "$(cat astra-usbboot-images/sl1680_suboot/manifest.yaml | shyaml get-value id)"
+    ```
+
+> [!IMPORTANT]
+> For `Luna SL1680`, you'll need to replace the folder `astra-usbboot-images` with the one provided here.
+> Just rename the current one something else, for instance `astra-usbboot-images-sl1680` and add the provided `astra-usbboot-images` in `usb-tool`
+> And if you'll need to flash Astra SL1680, you'll need to switch back to the original binaries, so keep that in mind!
+> TODO: Make Luna SL1680 specific binaries available
+
+Manual Setup
+======
+1. Create the directory structure for the Yocto layers e.g.:
+```bash
+$ mkdir common-torizon; cd common-torizon
+```
+2. Clone the necessary layers to build the Common Torizon image for the Synaptics boards:
+  * Download Synaptics SDK:
+
+    Obs. It is recommended to use the latest version of synaptics-astra sdk. You can get it in their release repository: [https://github.com/synaptics-astra/sdk/releases](https://github.com/synaptics-astra/sdk/releases)
+```bash
+$ git clone https://github.com/synaptics-astra/sdk.git -b scarthgap_6.12_<last_release_version> layers
+```
+For example:
+```bash
+$ git clone https://github.com/synaptics-astra/sdk.git -b scarthgap_6.12_v2.1.0 layers
+```
+
+  * Download `meta-toradex-torizon` and its dependencies:
+```bash
+$ cd layers
+$ git clone https://github.com/torizon/meta-toradex-torizon.git -b scarthgap-7.x.y
+$ git clone https://github.com/uptane/meta-updater.git -b scarthgap
+```
+  * Go back to our top folder `common-torizon`;
+  * Create a symlink to our `setup-environment`:
+```bash
+$ ln -s layers/meta-toradex-torizon/scripts/setup-environment setup-environment
+```

--- a/docs/README-ti.md
+++ b/docs/README-ti.md
@@ -1,0 +1,93 @@
+Setup
+======
+1. If you don't have the `repo` tool installed, please refer to [Build Torizon OS From Source with Yocto Project](https://developer.toradex.com/torizon/in-depth/build-torizoncore-from-source-with-yocto-projectopenembedded/#download-metadata).
+2. Initialize and sync the repo manifest for Texas Instruments:
+```bash
+$ mkdir common-torizon; cd common-torizon
+$ repo init -u https://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/ti/default.xml
+$ repo sync -j 10
+```
+We **strongly recommend** using the `default.xml` manifest. The `integration.xml` and `next.xml` are development manifests used internally and they might be unstable.
+`default.xml` is the manifest used for our releases, so they are reliable.  
+> [!IMPORTANT]  
+> Common Torizon OS is only available on branches `scarthgap-7.x.y` or newer!
+
+Alternatively, you can manually clone all layers one by one. Refer to the section _Manual Setup_ at the end of this document to learn how.
+
+Build
+======
+1. Source `setup-environment`, specifying the machine to build with the MACHINE variable e.g.:
+```bash
+$ MACHINE=am62xx-evm . setup-environment <build-directory>
+```
+If a build directory is not given, the script will create one named `build-ti-${DISTRO}`, where all build artifacts will be stored. By default `DISTRO` is automatically set to `common-torizon` with the TI boards.
+
+2. Inside the build directory, start the build e.g.:
+```bash
+$ bitbake torizon-docker
+```
+All artifacts should be inside `<build-directory>/deploy/images/${MACHINE}`, including the `.wic` file.
+
+Boot the Image from an SD Card
+======
+1. Flash the generated .wic artifact file to a micro SD card and insert it into the board. For example, if using `dd` to flash the image, double-check the device name of the SD card with `lsblk`, make sure it's unmounted, then run the command below:
+```bash
+$ sudo dd if=<image-name>.wic of=/dev/<sdcard-device-name> bs=4M status=progress
+```
+2. Configure the board for SD card boot and connect the UART interface to the host PC. For example, for the AM62x SK EVM you can follow the instructions on the [TI Resource Explorer website](https://dev.ti.com/tirex/explore/node?node=A__AZatcAgHClq18snt16Hmfg__PROCESSORS-DEVTOOLS__FUz-xrs__LATEST).
+3. Establish a serial connection with the board e.g. using `picocom`:
+```bash
+$ picocom -b 115200 /dev/ttyUSB0
+```
+
+Alternate way to flash the SD Card
+======
+With the generated `.wic` file, you could use bmaptool. If you don't have it installed, you could get it by running `sudo apt install bmap-tools`.
+But first, run `lsblk` and make sure that you SD Card is not mounted. If so, please unmount all partitions beforehand.
+```bash
+$ bmaptool create -o torizon.bmap torizon.wic
+$ sudo bmaptool copy --bmap torizon.bmap torizon.wic /dev/sdx
+
+```
+Where you should replace `/dev/sdx` with the SD Card you want to flash.
+
+---
+
+Manual Setup
+======
+1. Create the directory structure for the Yocto layers e.g.:
+```bash
+$ mkdir common-torizon; cd common-torizon
+$ mkdir sources; cd sources
+```
+2. Clone the necessary layers to build the Common Torizon image for the TI boards:
+  * Download Bitbake:
+```bash
+$ git clone https://git.openembedded.org/bitbake -b 2.8
+$ cd bitbake && git checkout 6c2641f7a9 && cd ..
+```
+  * Download `meta-yocto`:
+```bash
+$ git clone https://git.yoctoproject.org/meta-yocto -b scarthgap
+```
+  * Download `meta-ti` and its dependencies:
+```bash
+$ git clone https://git.yoctoproject.org/meta-ti -b scarthgap
+$ git clone https://git.yoctoproject.org/meta-arm -b scarthgap
+$ git clone https://git.yoctoproject.org/openembedded-core -b scarthgap oe-core
+```
+  * Download `meta-toradex-torizon` and its dependencies:
+```bash
+$ git clone https://github.com/torizon/meta-toradex-torizon.git -b scarthgap-7.x.y
+$ git clone https://github.com/uptane/meta-updater.git -b scarthgap
+$ git clone https://git.yoctoproject.org/meta-virtualization -b scarthgap
+```
+  * And finally, download the dependency for `meta-updater` and `meta-virtualization`:
+```bash
+$ git clone https://github.com/openembedded/meta-openembedded -b scarthgap
+```
+  * Go back to our top folder `common-torizon`;
+  * Create a symlink to our `setup-environment`:
+```bash
+$ ln -s sources/meta-toradex-torizon/scripts/setup-environment setup-environment
+```

--- a/docs/README-x86.md
+++ b/docs/README-x86.md
@@ -1,0 +1,94 @@
+Setup
+======
+1. If you don't have the `repo` tool installed, please refer to [Build Torizon OS From Source with Yocto Project](https://developer.toradex.com/torizon/in-depth/build-torizoncore-from-source-with-yocto-projectopenembedded/#download-metadata).
+2. Initialize and sync the repo manifest for x86:
+```bash
+$ mkdir common-torizon; cd common-torizon
+$ repo init -u https://git.toradex.com/toradex-manifest.git -b scarthgap-7.x.y -m common-torizon/x86/default.xml
+$ repo sync -j 10
+```
+We **strongly recommend** using the `default.xml` manifest. The `integration.xml` and `next.xml` are development manifests used internally and they might be unstable.
+`default.xml` is the manifest used for our releases, so they are reliable.  
+> [!IMPORTANT]  
+> Common Torizon OS is only available on branches `scarthgap-7.x.y` or newer!
+
+Alternatively, you can manually clone all layers one by one. Refer to the section _Manual Setup_ at the end of this document to learn how.
+
+Build
+======
+1. Source `setup-environment`:
+```bash
+$ MACHINE=intel-corei7-64 . setup-environment build-corei7-64
+```
+This will create a build folder named `build-corei7-64`, where all build artifacts will be stored.
+
+2. Inside the build directory, start the build e.g.:
+```bash
+$ bitbake torizon-docker
+```
+
+All artifacts should be inside `build-corei7-64/deploy/images/intel-corei7-64`, including the `.wic` file.
+
+Test on Virtual Box
+======
+Setup a virtual machine to test the image built, using the generated `.wic.vdi` or `.wic.vmdk`.
+
+Below is a script for setting up a virtual machine inside Virtual Box, called `Common-Torizon`:
+```bash
+# Setup new machine Common-Torizon
+VBoxManage createvm --name Common-Torizon --ostype "Linux_64" --register --basefolder "$HOME/CommonTorizonVBoxVM"
+VBoxManage modifyvm Common-Torizon --firmware efi64
+# Attempt at serial connection (cant communicate but can inspect serial logs via 'tail -f /tmp/serial')
+VBoxManage modifyvm Common-Torizon --cpus 2 --memory 2048 --vram 256 --graphicscontroller vmsvga --uart1 0x3F8 4 --uartmode1 file /tmp/serial
+
+VBoxManage storagectl Common-Torizon --name "SATA Controller" --add sata --bootable on
+VBoxManage storageattach Common-Torizon --storagectl "SATA Controller" --port 0 --device 0 --type hdd --medium "torizon-docker-intel-corei7-64.wic.vdi"
+# Port forwarding for SSH on port 2222
+VBoxManage modifyvm Common-Torizon --nat-pf1=ssh,tcp,,2222,,3791 --nat-pf2=ssh_tor,tcp,,2223,,22
+
+VBoxManage startvm Common-Torizon
+```
+
+Test on QEMU
+======
+
+Run using QEMU:
+
+```bash
+$ qemu-system-x86_64 -drive if=virtio,file=torizon-docker-intel-corei7-64.wic,format=raw -no-reboot -cpu host -nic user,hostfwd=tcp::2222-:22 -machine pc -vga virtio -m 4096 -bios /usr/share/ovmf/OVMF.fd -enable-kvm -serial pty
+```
+
+---
+
+Manual Setup
+======
+1. Create your build folder structure. Something like:
+```bash
+$ mkdir common-torizon; cd common-torizon
+$ mkdir layers; cd layers
+```
+2. Clone the layers needed to build x86 Common Torizon:  
+  * Download Poky
+```bash
+$ git clone git://git.yoctoproject.org/poky -b scarthgap
+```
+  * Download `meta-intel` and `meta-toradex-torizon`:
+```bash
+$ git clone git://git.yoctoproject.org/meta-intel -b scarthgap
+$ git clone https://github.com/torizon/meta-toradex-torizon.git -b scarthgap-7.x.y
+```
+  * Download `meta-toradex-torizon` dependencies:
+```bash
+$ git clone https://github.com/uptane/meta-updater.git -b scarthgap
+$ git clone https://git.yoctoproject.org/meta-virtualization -b scarthgap
+```
+  * And finally, download `meta-updater` and `meta-virtualization` dependency: 
+```bash
+$ git clone https://github.com/openembedded/meta-openembedded -b scarthgap
+```
+  * Go back into our top folder `common-torizon`
+  * Create a symlink to our `setup-environment`:
+```bash
+$ ln -s layers/meta-toradex-torizon/scripts/setup-environment setup-environment
+```
+


### PR DESCRIPTION
We are dropping git protocol to use https instead for git.toradex.com. This change makes git.toradex.com more robust for downloads

Related-to: TOR-4261
Signed-off-by: Matheus Rodrigues <matheus.rodrigues@toradex.com>
(cherry picked from commit 1e8ca60935c0273276c3040a3b9ba42bbcbeeb74)