### PR TITLE
[master] u-boot-distro-boot: force a 'env save' on first boot

### DIFF
--- a/recipes-bsp/u-boot/u-boot-distro-boot.bb
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bb
@@ -221,6 +221,9 @@ keep_fusing_block() {
 
 inherit deploy
 
+FORCE_ENVSAVE_BLOCK_ENABLE = "0"
+FORCE_ENVSAVE_BLOCK_ENABLE:common-torizon-distro = "1"
+
 UBOOT_BOOT_PARTITION_NUMBER ?= "1"
 OTAROOT_PARTITION_NUMBER ?= "1"
 UENV_EXTRA_CONFIGS ?= "true"
@@ -234,6 +237,12 @@ do_compile() {
         -e 's/@@APPEND@@/${APPEND}/' \
         -e 's/@@FITCONF_FDT_OVERLAYS@@/${FITCONF_FDT_OVERLAYS}/' \
         "${S}/boot.cmd.in" > boot.cmd
+
+    if [ "${FORCE_ENVSAVE_BLOCK_ENABLE}" = "1" ]; then
+        sed -i "/#+START_ENVSAVE_BLOCK/d; /#+END_ENVSAVE_BLOCK/d" "boot.cmd"
+    else
+        sed -i "/#+START_ENVSAVE_BLOCK/,/#+END_ENVSAVE_BLOCK/d" "boot.cmd"
+    fi
 
     bbdebug 1 "Building uEnv.txt..."
     sed -e 's#@@UENV_EXTRA_CONFIGS@@#${UENV_EXTRA_CONFIGS}#' \

--- a/recipes-bsp/u-boot/u-boot-distro-boot.bb
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bb
@@ -221,8 +221,12 @@ keep_fusing_block() {
 
 inherit deploy
 
-FORCE_ENVSAVE_BLOCK_ENABLE = "0"
-FORCE_ENVSAVE_BLOCK_ENABLE:common-torizon-distro = "1"
+# BOOTCMD_INIT_ENV_SUPP: when set to "1", includes a block in boot.cmd that
+# forces a 'env save' on first boot to ensure the U-Boot environment storage
+# is properly initialized. Required on platforms where the environment area is
+# not pre-initialized by the bootloader (e.g. luna-sl1680).
+BOOTCMD_INIT_ENV_SUPP ?= "0"
+BOOTCMD_INIT_ENV_SUPP:luna-sl1680 = "1"
 
 UBOOT_BOOT_PARTITION_NUMBER ?= "1"
 OTAROOT_PARTITION_NUMBER ?= "1"
@@ -238,7 +242,7 @@ do_compile() {
         -e 's/@@FITCONF_FDT_OVERLAYS@@/${FITCONF_FDT_OVERLAYS}/' \
         "${S}/boot.cmd.in" > boot.cmd
 
-    if [ "${FORCE_ENVSAVE_BLOCK_ENABLE}" = "1" ]; then
+    if [ "${BOOTCMD_INIT_ENV_SUPP}" = "1" ]; then
         sed -i "/#+START_ENVSAVE_BLOCK/d; /#+END_ENVSAVE_BLOCK/d" "boot.cmd"
     else
         sed -i "/#+START_ENVSAVE_BLOCK/,/#+END_ENVSAVE_BLOCK/d" "boot.cmd"

--- a/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
+++ b/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
@@ -4,6 +4,15 @@
 #
 # Torizon boot script.
 
+#+START_ENVSAVE_BLOCK
+if test "${env_initialized}" != "1"
+then 
+    # Forcing a 'env save' to guarantee that the environment is initialized during a first boot 
+    env set env_initialized 1 
+    env save 
+fi
+#+END_ENVSAVE_BLOCK
+
 if test -z "${altbootcmd}"
 then
     env set altbootcmd 'env set rollback 1; run bootcmd'

--- a/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
+++ b/recipes-bsp/u-boot/u-boot-distro-boot/boot.cmd.in
@@ -4,13 +4,14 @@
 #
 # Torizon boot script.
 
-#+START_ENVSAVE_BLOCK
+#+START_ENVSAVE_BLOCK (this block may be removed)
 if test "${env_initialized}" != "1"
 then 
     # Forcing a 'env save' to guarantee that the environment is initialized during a first boot 
     env set env_initialized 1 
     env save 
 fi
+
 #+END_ENVSAVE_BLOCK
 
 if test -z "${altbootcmd}"


### PR DESCRIPTION
Synaptics boards did not set the boot environment by default, causing the fw_setenv and fw_printenv to fail. This solution forces the 'env save' during the first boot.

(cherry picked from commits 6e1ca46 f6ced6f)

Related-to: TOR-4145