### PR TITLE
Bump SRCREV to latest for Torizon OS 7.6.0 quarterly release

### DIFF
--- a/recipes-kernel/linux/linux-toradex-kmeta.inc
+++ b/recipes-kernel/linux/linux-toradex-kmeta.inc
@@ -1,4 +1,4 @@
-SRCREV_torizon-meta = "30870270f3d12cb094b3b30013498a5826aa8e62"
+SRCREV_torizon-meta = "1fa37a1ab926086ee65a526f641e366b2396d62e"
 SRCREV_torizon-meta:use-head-next = "${AUTOREV}"
 
 KMETABRANCH = "scarthgap-7.x.y"

--- a/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
+++ b/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
@@ -15,7 +15,7 @@ SRC_URI = " \
   https://github.com/uptane/ota-tuf/releases/download/v${UPTANE_SIGN_PV}/cli-${UPTANE_SIGN_PV}.tgz;unpack=0;name=uptanesign \
 "
 
-SRCREV = "f6d6fbe1f0b1a0065428279616b1e02ec2d5b49b"
+SRCREV = "1f84e64a47dd00243355476f192a85155e28c39a"
 SRCREV:use-head-next = "${AUTOREV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Related-to: TOR-4182