### PR TITLE
fw_env.config: change where boot variables are read

### DIFF
--- a/dynamic-layers/meta-beagle/recipes-bsp/u-boot/beagley-ai/fw_env.config
+++ b/dynamic-layers/meta-beagle/recipes-bsp/u-boot/beagley-ai/fw_env.config
@@ -1,2 +1,2 @@
-# Device name                             Device offset    Env. size
-/var/rootdirs/media/boot/uboot.env        0x0000           0x40000
+# Device name   Device offset    Env. size
+/dev/mmcblk1p1	0x2EF000	     0x40000


### PR DESCRIPTION
Before this change, uboot variables were read from a file mounted in boot partition, instead of being read
directly from partition itself.

This was causing issues in services such as redboot-auto-reboot, which attempted to read variables from uboot.env before it was mounted. Consequently, the value of upgrade_available could not be retrieved, leading to failed AVAL tests related to rollback

Related-to: TOR-4128