### PR TITLE
[master][common]u-boot-distro-boot: enable forced 'env save' on Synaptics astra machine

### DIFF
--- a/recipes-bsp/u-boot/u-boot-distro-boot.bb
+++ b/recipes-bsp/u-boot/u-boot-distro-boot.bb
@@ -227,6 +227,7 @@ inherit deploy
 # not pre-initialized by the bootloader (e.g. luna-sl1680).
 BOOTCMD_INIT_ENV_SUPP ?= "0"
 BOOTCMD_INIT_ENV_SUPP:luna-sl1680 = "1"
+BOOTCMD_INIT_ENV_SUPP:sl1680 = "1"
 
 UBOOT_BOOT_PARTITION_NUMBER ?= "1"
 OTAROOT_PARTITION_NUMBER ?= "1"


### PR DESCRIPTION
Enabled BOOTCMD_INIT_ENV_SUPP for astra (sl1680) machines.
Signed-off-by: Guilherme Freire [guilherme.almeida@toradex.com](mailto:guilherme.almeida@toradex.com)

Related-to: TOR-4355
Cherry-picked from 64bb418bcfc679227df3d4892aca537b19e64acc