### PR TITLE
Generate WIC image when building with class tdx-signed

### DIFF
--- a/conf/distro/include/torizon.inc
+++ b/conf/distro/include/torizon.inc
@@ -13,6 +13,9 @@ INHERIT += "toradex-sanity toradex-mirrors"
 # We do not need teziimg, ota-ext4 or wic images by default
 IMAGE_FSTYPES_REMOVE ?= "ota-ext4 wic wic.gz wic.bmap wic.xz"
 
+# Set WKS file to be used with Torizon images by default
+WKS_FILE:sota ?= "torizon-sota.wks"
+
 # Compatibility with toradex layers
 BBMASK += " \
     /meta-toradex-bsp-common/recipes-core/systemd/systemd_%.bbappend \

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -149,3 +149,8 @@ CORE_IMAGE_BASE_INSTALL:append:cfs-signed = "\
 CORE_IMAGE_BASE_INSTALL:append:cfs-support = "\
     composefs \
 "
+
+# Enable WIC generation with images utilizing tdx-signed or inherited
+# classes (such as torizon-signed)
+IMAGE_FSTYPES_REMOVE:remove:tdx-signed = "ota-ext4 wic"
+IMAGE_FSTYPES:append:tdx-signed = " ota-ext4 wic"

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -70,8 +70,22 @@ CORE_IMAGE_BASE_INSTALL:append:tdx = " \
     udev-toradex-rules \
 "
 
-CORE_IMAGE_BASE_INSTALL:append:common-torizon-distro = " \
-    resize-helper \
+# Define when the resize-helper is to be used:
+#
+# - The resize-helper is needed on images built with class tdx-signed because we
+#   are currently producing WIC-format images when building with that class.
+# - However, the resize-helper does not currently work with class torizon-signed
+#   (which inherits from tdx-signed) due to composefs; so we keep it disabled for
+#   now on cfs-signed images.
+#
+# TODO: Handle partition resizing on torizon-signed.
+#
+RESIZE_HELPER = ""
+RESIZE_HELPER:common-torizon-distro = "resize-helper"
+RESIZE_HELPER:tdx-signed = "resize-helper"
+RESIZE_HELPER:cfs-signed = ""
+CORE_IMAGE_BASE_INSTALL:append = " \
+    ${RESIZE_HELPER} \
 "
 
 # SOTA related packages

--- a/scripts/lib/wic/canned-wks/torizon-sota.wks
+++ b/scripts/lib/wic/canned-wks/torizon-sota.wks
@@ -1,6 +1,5 @@
-# short-description: Create OTA-enabled SD card image
-# long-description: Creates a partitioned SD card image with OSTree
-# physical sysroot as a payload. Boot files are located in the
-# first vfat partition.
+# short-description: Create OTA-enabled raw image of Torizon OS
+# long-description: Create a single partition raw image with OSTree
+# physical sysroot as a payload.
 
 part / --source otaimage --ondisk mmcblk --fstype=ext4 --align 4096


### PR DESCRIPTION
Enable the generation of a WIC image when building Torizon images with class `tdx-signed`; this covers also child classes such as `torizon-signed`.

The resize-helper service responsible for resizing the main partition to occupy the available space on disk is also installed and executed, but only on `tdx-signed`. On `torizon-signed` the partition resizing is also required but tests showed adaptations would be needed to make it work when the rootfs protection is in place.

Related-to: TOR-4364
Signed-off-by: Rogerio Guerra Borin <rogerio.borin@toradex.com>
