### PR TITLE
Add flashing files for Luna SL1680

### DIFF
--- a/docs/README-syn.md
+++ b/docs/README-syn.md
@@ -59,9 +59,6 @@ Flashing eMMC
 ======
 For flashing, there are two possible ways: use the helper script `flash-image.sh` or doing the steps manually.
 
-> [!WARNING]  
-> This helper script does NOT yet work with the Luna SL1680 board, it only works with the Astra SL1680 board.
-
 1. The easiest way is to use the helper script:
 
     a. After the build is done, get the file called `SYNAIMG-flash.tar.gz` from the `deploy/images/${MACHINE}` folder.  
@@ -98,10 +95,9 @@ For flashing, there are two possible ways: use the helper script `flash-image.sh
     ```
 
 > [!IMPORTANT]
-> For `Luna SL1680`, you'll need to replace the folder `astra-usbboot-images` with the one provided here.
+> For `Luna SL1680`, you'll need to replace the folder `astra-usbboot-images` with the one provided [here](https://artifacts.toradex.com/artifactory/common-torizon-extras-prod-frankfurt/luna-sl1680/astra-usbboot-images-winglet.tar.gz).
 > Just rename the current one something else, for instance `astra-usbboot-images-sl1680` and add the provided `astra-usbboot-images` in `usb-tool`
 > And if you'll need to flash Astra SL1680, you'll need to switch back to the original binaries, so keep that in mind!
-> TODO: Make Luna SL1680 specific binaries available
 
 Manual Setup
 ======

--- a/recipes-bsp/syna-metadata/files/flash-image.sh
+++ b/recipes-bsp/syna-metadata/files/flash-image.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-# WARNING: This script DOES not yet work with the Luna SL1680/SL2619 boards, it works
-# only with the Astra SL1680 board.
+# WARNING: This script DOES not yet work with the SL2619 board, it works
+# only with the Astra SL1680 and Luna SL1680 boards.
 #
-echo "Flashing Astra SL1680 board using astra update..."
+echo "Flashing board using astra update..."
 ID=$(cat astra-usbboot-images/sl1680_suboot/manifest.yaml | grep -Po "(?<=^id:\s)[^ ]+")
 
 sudo ./bin/linux/x86_64/astra-update -c sl1680 -m 4gb -d lpddr4x -t emmc -i $ID

--- a/recipes-support/syna-usb-tool/syna-usb-tool_git.bb
+++ b/recipes-support/syna-usb-tool/syna-usb-tool_git.bb
@@ -8,6 +8,11 @@ PV = "1.0.5"
 SRC_URI = "git://github.com/synaptics-astra/usb-tool.git;protocol=https;branch=main"
 SRCREV = "e5e9a160ffb1755549e73457bda767e641439dc6"
 
+SRC_URI:append:luna-sl1680 = " \
+    https://artifacts.toradex.com/artifactory/common-torizon-extras-prod-frankfurt/luna-sl1680/astra-usbboot-images-winglet.tar.gz;name=luna-tarball \
+    "
+SRC_URI[luna-tarball.sha256sum] = "c1879d14f9ede4eceb387acb538e031103ecf2cbf41d8a00b87356f6674e65b0"
+
 S = "${WORKDIR}/git"
 
 inherit deploy
@@ -21,6 +26,11 @@ do_deploy() {
     install -d ${SYNAIMG_DEPLOY}
     cp -r ${S}/bin/ ${SYNAIMG_DEPLOY}
     cp -r ${S}/astra-usbboot-images/ ${SYNAIMG_DEPLOY}
+}
+
+# Replace with Luna-specific files from tarball
+do_deploy:append:luna-sl1680() {
+    cp -r ${WORKDIR}/astra-usbboot-images/ ${SYNAIMG_DEPLOY}
 }
 
 addtask deploy after do_compile


### PR DESCRIPTION
This makes it so that the flashing files specific for the Luna SL1680 get packaged when building for this machine.