### PR TITLE
aktualizr-torizon: make recipe aware of offline-updates

### DIFF
--- a/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
+++ b/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
@@ -32,18 +32,19 @@ SYSTEMD_SERVICE:${PN} = "aktualizr-torizon.service"
 # For find_package(Git)
 OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"
 
-PACKAGECONFIG ?= "ostree dbus ${@bb.utils.filter('SOTA_CLIENT_FEATURES', 'hsm serialcan ubootenv', d)}"
+PACKAGECONFIG ?= "ostree dbus offline-updates ${@bb.utils.filter('SOTA_CLIENT_FEATURES', 'hsm serialcan ubootenv', d)}"
+PACKAGECONFIG:class-native ?= "sota-tools"
+
 PACKAGECONFIG[warning-as-error] = "-DWARNING_AS_ERROR=ON,-DWARNING_AS_ERROR=OFF,"
+PACKAGECONFIG[offline-updates] = "-DBUILD_OFFLINE_UPDATES=ON,-DBUILD_OFFLINE_UPDATES=OFF,systemd,"
 PACKAGECONFIG[ostree] = "-DBUILD_OSTREE=ON,-DBUILD_OSTREE=OFF,ostree,"
 PACKAGECONFIG[ubootenv] = ",,u-boot-fw-utils,u-boot-fw-utils"
-PACKAGECONFIG:remove:class-native = "ubootenv"
-PACKAGECONFIG:class-native = "sota-tools"
 PACKAGECONFIG[sota-tools] = "\
   -DBUILD_SOTA_TOOLS=ON -DGARAGE_SIGN_ARCHIVE=${WORKDIR}/cli-${UPTANE_SIGN_PV}.tgz -DGARAGE_SIGN_TOOL=${GARAGE_SIGN_TOOL}, \
   -DBUILD_SOTA_TOOLS=OFF, \
   glib-2.0 python3-native python3-requests-native, \
 "
-PACKAGECONFIG[dbus] = "-DBUILD_DBUS=ON,-DBUILD_DBUS=OFF,systemd"
+PACKAGECONFIG[dbus] = "-DBUILD_DBUS=ON,-DBUILD_DBUS=OFF,systemd,"
 
 PROVIDES += "aktualizr"
 RPROVIDES:${PN} += "aktualizr aktualizr-info aktualizr-shared-prov"


### PR DESCRIPTION

#### Summary

Make recipe aware of the BUILD_OFFLINE_UPDATES variable in CMake and the depedency to (lib)systemd when offline-updates are enabled. This fixes a dependency issue leading to build failures.

Additionally, I've taken the opportunity to remove this line from the recipe:
```
PACKAGECONFIG:remove:class-native = "ubootenv"
```

The reason is that this line was added in a later commit:
```
PACKAGECONFIG:class-native = "sota-tools"
```
which made the first line not very useful. Plus, the use of a removal makes the recipe less flexible to users trying to customize it in higher layers.

Related-to: TOR-4375


#### Explanation of why latest changes in Aktualizr started causing the build to fail

Before the latest changes we had this in Aktualizr's `CMakeLists.txt`:
```
if(BUILD_DBUS)
    find_package(PkgConfig REQUIRED)
    pkg_check_modules(SYSTEMD REQUIRED libsystemd>=233)
endif(BUILD_DBUS)
```

So, the build required the presence of `libsystemd` if and only if `BUILD_DBUS` was enabled. When making the native build of aktualizr, DBUS was not enabled and the library wasn't required.

With the latest changes we now have:
```
if(BUILD_DBUS OR BUILD_OFFLINE_UPDATES)
    find_package(PkgConfig REQUIRED)
    pkg_check_modules(SYSTEMD REQUIRED libsystemd>=233)
endif(BUILD_DBUS)
```

So, the library is required if `BUILD_DBUS` and/or `BUILD_OFFLINE_UPDATES` is set. But, since `BUILD_OFFLINE_UPDATES` is set by default, and the recipe is not aware and it's not forcing that variable to any value, the library is required even when building the native aktualizr or, in the actual case, only the SOTA tools.

Therefore the solution involves making the recipe aware of `BUILD_OFFLINE_UPDATES` so it can tell what the required dependencies are depending on whether the variable is set or not.
