### PR TITLE
uboot: mount boot partition in a fixed location

### DIFF
--- a/dynamic-layers/meta-beagle/recipes-bsp/u-boot/beagley-ai/fw_env.config
+++ b/dynamic-layers/meta-beagle/recipes-bsp/u-boot/beagley-ai/fw_env.config
@@ -1,2 +1,2 @@
-# Device name                             Device offset    Env. size
-/var/rootdirs/media/boot/uboot.env        0x0000           0x40000
+# Device name                   Device offset    Env. size
+/boot/vendor_boot/uboot.env     0x0000           0x40000

--- a/recipes-core/base-files/base-files/beagley-ai/fstab
+++ b/recipes-core/base-files/base-files/beagley-ai/fstab
@@ -1,0 +1,12 @@
+# stock fstab - you probably want to override this with a machine specific one
+
+/dev/root            /                    auto       defaults              1  1
+proc                 /proc                proc       defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs                /var/volatile        tmpfs      defaults              0  0
+
+# uncomment this if your device has a SD/MMC/Transflash slot
+#/dev/mmcblk0p1       /media/card          auto       defaults,sync,noauto  0  0
+
+LABEL=boot           /boot/vendor_boot    vfat       defaults              0  2

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -4,6 +4,7 @@ hostname = ""
 
 SRC_URI += " \
 	file://x86/fstab \
+	file://beagley-ai/fstab \
 "
 
 # This deviates a bit from what OE-core is doing. Especially we want the full
@@ -28,3 +29,9 @@ do_install:append:cfs-support () {
 	# systemd-remount-fs.
 	sed -i -e '\#^ */dev/root#d' ${D}${sysconfdir}/fstab
 }
+
+do_install:append:beagley-ai() {
+	install -d ${D}/boot/vendor_boot
+    install -m 644 ${WORKDIR}/beagley-ai/fstab ${D}${sysconfdir}/fstab
+}
+


### PR DESCRIPTION
The boot partition is configured to store, among other artifacts, the
U-Boot environment (uboot.env), which may be read by systemd services
during boot. Mounting it at a fixed, known location early in the boot
process is therefore a requirement for proper system boot. Previously,
the partition was only mounted later in the sequence by udisks2. As a
result, some BeagleY-AI services attempted to read U-Boot environment
variables before uboot.env was available, leaving UPGRADE_AVAILABLE
without a value and causing the AVAL tests related to the rollback
feature to fail.

Listing the boot partition in /etc/fstab ensures it is mounted early
enough for these services and resolves the rollback test failures.