### PR TITLE
aktualizr-torizon: make recipe aware of offline-updates (walnascar)

### DIFF
--- a/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
+++ b/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
@@ -32,18 +32,19 @@ SYSTEMD_SERVICE:${PN} = "aktualizr-torizon.service"
 # For find_package(Git)
 OECMAKE_FIND_ROOT_PATH_MODE_PROGRAM = "BOTH"
 
-PACKAGECONFIG ?= "ostree dbus ${@bb.utils.filter('SOTA_CLIENT_FEATURES', 'hsm serialcan ubootenv', d)}"
+PACKAGECONFIG ?= "ostree dbus offline-updates ${@bb.utils.filter('SOTA_CLIENT_FEATURES', 'hsm serialcan ubootenv', d)}"
+PACKAGECONFIG:class-native ?= "sota-tools"
+
 PACKAGECONFIG[warning-as-error] = "-DWARNING_AS_ERROR=ON,-DWARNING_AS_ERROR=OFF,"
+PACKAGECONFIG[offline-updates] = "-DBUILD_OFFLINE_UPDATES=ON,-DBUILD_OFFLINE_UPDATES=OFF,systemd,"
 PACKAGECONFIG[ostree] = "-DBUILD_OSTREE=ON,-DBUILD_OSTREE=OFF,ostree,"
 PACKAGECONFIG[ubootenv] = ",,u-boot-fw-utils,u-boot-fw-utils"
-PACKAGECONFIG:remove:class-native = "ubootenv"
-PACKAGECONFIG:class-native = "sota-tools"
 PACKAGECONFIG[sota-tools] = "\
   -DBUILD_SOTA_TOOLS=ON -DGARAGE_SIGN_ARCHIVE=${UNPACKDIR}/cli-${UPTANE_SIGN_PV}.tgz -DGARAGE_SIGN_TOOL=${GARAGE_SIGN_TOOL}, \
   -DBUILD_SOTA_TOOLS=OFF, \
   glib-2.0 python3-native python3-requests-native, \
 "
-PACKAGECONFIG[dbus] = "-DBUILD_DBUS=ON,-DBUILD_DBUS=OFF,systemd"
+PACKAGECONFIG[dbus] = "-DBUILD_DBUS=ON,-DBUILD_DBUS=OFF,systemd,"
 
 PROVIDES += "aktualizr"
 RPROVIDES:${PN} += "aktualizr aktualizr-info aktualizr-shared-prov"


### PR DESCRIPTION
Same as https://github.com/torizon/meta-toradex-torizon/pull/505, but for the walnascar branch.

Related-to: TOR-4375
