### PR TITLE
plymouth.conf: Increase Plymouth's default DeviceTimeout to 15 seconds.

### DIFF
--- a/recipes-core/plymouth/files/plymouthd.conf
+++ b/recipes-core/plymouth/files/plymouthd.conf
@@ -1,0 +1,2 @@
+[Daemon]
+DeviceTimeout=15

--- a/recipes-core/plymouth/plymouth_%.bbappend
+++ b/recipes-core/plymouth/plymouth_%.bbappend
@@ -4,6 +4,7 @@ SRC_URI += " \
     file://0001-disable-boot-splash-later.patch \
     file://torizonlogo-white.png \
     file://spinner.plymouth \
+    file://plymouthd.conf \
 "
 
 PLYMOUTH_THEMES = "spinner"
@@ -12,4 +13,6 @@ PACKAGECONFIG = "drm udev ${PLYMOUTH_THEMES} ${@bb.utils.filter('DISTRO_FEATURES
 do_install:append () {
     install -m 0644 ${WORKDIR}/torizonlogo-white.png ${D}${datadir}/plymouth/themes/spinner/watermark.png
     install -m 0644 ${WORKDIR}/spinner.plymouth ${D}${datadir}/plymouth/themes/spinner/spinner.plymouth
+    install -d ${D}${sysconfdir}/plymouth
+    install -m 0644 ${WORKDIR}/plymouthd.conf ${D}${sysconfdir}/plymouth/plymouthd.conf
 }


### PR DESCRIPTION
This is a workaround for the intermittent failure during the Splash Screen on the aquila-imx95 boot. To avoid possible race conditions during boot, the default timeout was increased from 8 to 15 seconds. 
The additional seconds seems to grant enough time for the plymouth-quit service to run as intended without compromising the boot time too much (adding as much as half a second to "bad" boots).

(This solution also works for smarc-imx95 machines)

Related-to: TOR-4307