### PR TITLE
kbd: remove kbd-keymaps-pine

### DIFF
--- a/recipes-core/kbd/kbd_%.bbappend
+++ b/recipes-core/kbd/kbd_%.bbappend
@@ -1,0 +1,3 @@
+# Only useful for Pinephone related products.
+# Remove due to GPLv3 on this specific componenet.
+RRECOMMENDS:${PN}-keymaps:remove = "${PN}-keymaps-pine"


### PR DESCRIPTION
This package has a GPLv3 license that we want to remove. Furthermore, it's not very useful for our use-cases.

Related-to: TOR-4387