### PR TITLE
[master] Remove GPLv3 nano and mc-shell

### DIFF
--- a/recipes-bsp/mwifiex-delay/mwifiex-delay_1.0.bb
+++ b/recipes-bsp/mwifiex-delay/mwifiex-delay_1.0.bb
@@ -12,8 +12,7 @@ SRC_URI = " \
     file://mwifiex-delay.sh \
 "
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 SYSTEMD_SERVICE:${PN} = "mwifiex-delay.service"
 

--- a/recipes-extended/packagegroups/packagegroup-core-full-cmdline.bbappend
+++ b/recipes-extended/packagegroups/packagegroup-core-full-cmdline.bbappend
@@ -4,4 +4,5 @@ RDEPENDS:packagegroup-core-full-cmdline-utils:remove = "\
     mc-fish \
     mc-helpers \
     mc-helpers-perl \
+    mc-shell \
 "

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -42,7 +42,6 @@ CORE_IMAGE_BASE_INSTALL:append = " \
     less \
     libpwquality \
     mmc-utils \
-    nano \
     networkmanager \
     openssh-sftp-server \
     ostree-customize-plymouth \


### PR DESCRIPTION
Fixed build issue related to S = WORKDIR
https://docs.yoctoproject.org/migration-guides/migration-5.1.html#s-workdir-no-longer-supported

Removed `mc-shell` (TOR-4388) and `nano` (TOR-4390)

Related-to: TOR-4388,TOR-4390