### PR TITLE
[master] plymouth.conf: Increase Plymouth's default DeviceTimeout to 15 seconds.

### DIFF
--- a/recipes-core/plymouth/files/plymouthd.conf
+++ b/recipes-core/plymouth/files/plymouthd.conf
@@ -1,0 +1,2 @@
+[Daemon]
+DeviceTimeout=15

--- a/recipes-core/plymouth/plymouth_%.bbappend
+++ b/recipes-core/plymouth/plymouth_%.bbappend
@@ -4,6 +4,7 @@ SRC_URI += " \
     file://0001-disable-boot-splash-later.patch \
     file://torizonlogo-white.png \
     file://spinner.plymouth \
+    file://plymouthd.conf \
 "
 
 PLYMOUTH_THEMES = "spinner"
@@ -12,4 +13,6 @@ PACKAGECONFIG = "drm udev ${PLYMOUTH_THEMES} ${@bb.utils.filter('DISTRO_FEATURES
 do_install:append () {
     install -m 0644 ${UNPACKDIR}/torizonlogo-white.png ${D}${datadir}/plymouth/themes/spinner/watermark.png
     install -m 0644 ${UNPACKDIR}/spinner.plymouth ${D}${datadir}/plymouth/themes/spinner/spinner.plymouth
+    install -d ${D}${sysconfdir}/plymouth
+    install -m 0644 ${UNPACKDIR}/plymouthd.conf ${D}${sysconfdir}/plymouth/plymouthd.conf
 }


### PR DESCRIPTION
This is a workaround for the intermittent failure during the Splash Screen on the aquila-imx95 boot. To avoid possible race conditions during boot and grant enough time for the plymouth-quit service to run as intended, the default timeout was increased from 8 to 15 seconds.

cherry-picked: b1fdebedd7b00ac0be82083c4039ba1bdcbce0c5

Related-to: TOR-4307