### PR TITLE
sl1680: use newer version of meson for cairo package

### DIFF
--- a/conf/machine/include/sl-common.inc
+++ b/conf/machine/include/sl-common.inc
@@ -17,6 +17,9 @@ BBMASK += "/meta-synaptics/dynamic-layers/virtualization-layer/recipes-container
 
 PREFERRED_PROVIDER_virtual/dtb = ""
 
+PREFERRED_VERSION_meson = "1.3.1"
+PREFERRED_VERSION_meson-native = "1.3.1"
+
 IMAGE_CMD:ota-ext4:append () {
     # Clean up
     [ -f "${DEPLOY_DIR_IMAGE}/${SYNAIMG_DEPLOY_SUBDIR}/rootfs.subimg" ] && rm ${DEPLOY_DIR_IMAGE}/${SYNAIMG_DEPLOY_SUBDIR}/rootfs.subimg


### PR DESCRIPTION
Since we are bumbing poky and use 2.1.0 version for synaptics meta layer, it is necessary to use a new version of meson package, which is compatible with cairo's version from poky.

Related-to: TOR-4447
Signed-off-by: Matheus Rodrigues <matheus.rodrigues@toradex.com>