### PR TITLE
syna2img-tools: add recipe

### DIFF
--- a/conf/machine/include/sl-common.inc
+++ b/conf/machine/include/sl-common.inc
@@ -83,6 +83,9 @@ EOF
     (
         cd ${DEPLOY_DIR_IMAGE}
         cp -L -R syna-metadata/* syna-usb-tool/* ${SYNAIMG_DEPLOY_SUBDIR} ${SYNAIMG_DEPLOY_SUBDIR}-flash
+        if [ -d syna2img-tools ]; then
+            cp -L -R syna2img-tools/* ${SYNAIMG_DEPLOY_SUBDIR}-flash
+        fi
         tar -czf ${SYNAIMG_DEPLOY_SUBDIR}-flash.tar.gz -C ${DEPLOY_DIR_IMAGE} ${SYNAIMG_DEPLOY_SUBDIR}-flash
     )
 }

--- a/conf/machine/include/sl1680.inc
+++ b/conf/machine/include/sl1680.inc
@@ -46,3 +46,5 @@ hostname:pn-base-files = "torizon-sl1680"
 DISTRO_FEATURES_REMOVE:remove = "vulkan"
 
 require sl-common.inc
+
+do_image_ota_ext4[depends] += "syna2img-tools:do_deploy"

--- a/recipes-support/syna2img-tools/syna2img-tools_git.bb
+++ b/recipes-support/syna2img-tools/syna2img-tools_git.bb
@@ -1,0 +1,35 @@
+SUMMARY = "syna2img Tools"
+DESCRIPTION = "Python zipapp tools for converting between raw disk images and the Synaptics Astra SYNAIMG format"
+HOMEPAGE = "https://gitlab.com/toradex/rd/torizon-core/syna2img"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f8119945852ced49987c9fa5b98500d0"
+
+PV = "1.0.0"
+SRC_URI = "git://gitlab.com/toradex/rd/torizon-core/syna2img.git;protocol=https;branch=main"
+SRCREV = "cdc7cdeb401fff4f93dc0c628f7ec3ec774cfce0"
+SRCREV:use-head-next = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+
+inherit deploy
+
+do_configure[noexec] = "1"
+
+do_compile() {
+    cd ${S}
+    python3 build.py syna2img
+    python3 build.py img2syna
+}
+
+SYNAIMG_DEPLOY = "${DEPLOYDIR}/${BPN}"
+
+do_deploy() {
+    install -d ${SYNAIMG_DEPLOY}
+    install -m 755 ${S}/syna2img.pyz ${SYNAIMG_DEPLOY}
+    install -m 755 ${S}/img2syna.pyz ${SYNAIMG_DEPLOY}
+}
+
+addtask deploy after do_compile
+
+COMPATIBLE_MACHINE = "(sl1680|luna-sl1680)"


### PR DESCRIPTION
Add recipe to include for SL1680 images the Python zipapp tools to convert the image between the SYNAIMG format and a raw disk image. These conversion tools are required to allow image customization with TorizonCore Builder, since it cannot handle the SYNAIMG format directly.

Related-to: TCB-842