### PR TITLE
[master] torizon-base: Remove GPLv3 dosfstools

### DIFF
--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -73,6 +73,7 @@ CORE_IMAGE_BASE_INSTALL:append:tdx = " \
 # the presence of GPLv3 software in Torizon OS images.
 BAD_RECOMMENDATIONS_GPL_V3 = " \
     gpgme-tool \
+    dosfstools \
 "
 BAD_RECOMMENDATIONS += "${BAD_RECOMMENDATIONS_GPL_V3}"
 


### PR DESCRIPTION
Removed dosfstools package.
Related-to: TOR-4380