### PR TITLE
[master] packagegroups-core: remove GLPv3 cpio package

### DIFF
--- a/recipes-extended/packagegroups/packagegroup-core-full-cmdline.bbappend
+++ b/recipes-extended/packagegroups/packagegroup-core-full-cmdline.bbappend
@@ -1,5 +1,6 @@
 RDEPENDS:packagegroup-core-full-cmdline-utils:remove = "\
     bc \
+    cpio \
     gawk \
     mc \
     mc-fish \


### PR DESCRIPTION
Related-to: TOR-4379
Signed-off-by: Matheus Rodrigues <matheus.rodrigues@toradex.com>