### PR TITLE
[master] gplv3-package-filter: create GPLv3 filtering class for the distro

### DIFF
--- a/classes/gplv3-package-filter.bbclass
+++ b/classes/gplv3-package-filter.bbclass
@@ -1,0 +1,35 @@
+# Remove the packages listed in TORIZON_EXCLUDED_PACKAGES_GPL_V3 from the
+# RDEPENDS/RRECOMMENDS of every package of every recipe, so a GPLv3 package
+# can be dropped from the build by listing it in a single place instead of
+# one .bbappend per recipe that pulls it in.
+#
+# This class is inherited globally from base-distro.inc and the package list
+# is defined there as well.
+#
+# Note: this covers runtime dependencies declared in recipe metadata (e.g.
+# packagegroups). Dependencies generated during do_package (shared library
+# auto-dependencies, dynamic packages) are not affected; BAD_RECOMMENDATIONS
+# in base-distro.inc act as the image-level backstop for those.
+
+TORIZON_EXCLUDED_PACKAGES_GPL_V3 ??= ""
+
+python () {
+    excluded = set((d.getVar('TORIZON_EXCLUDED_PACKAGES_GPL_V3') or '').split())
+    if not excluded:
+        return
+
+    # Host tools may be GPLv3; only filter target recipes.
+    for native_class in ('native', 'nativesdk', 'cross', 'crosssdk'):
+        if bb.data.inherits_class(native_class, d):
+            return
+
+    for pkg in (d.getVar('PACKAGES') or '').split():
+        for depvar in ('RDEPENDS:' + pkg, 'RRECOMMENDS:' + pkg):
+            value = d.getVar(depvar)
+            if not value:
+                continue
+            deps = bb.utils.explode_dep_versions2(value)
+            filtered = {name: constraint for name, constraint in deps.items() if name not in excluded}
+            if len(filtered) != len(deps):
+                d.setVar(depvar, bb.utils.join_deps(filtered, commasep=False))
+}

--- a/conf/distro/include/base-distro.inc
+++ b/conf/distro/include/base-distro.inc
@@ -16,6 +16,23 @@ IMAGE_CLASSES:remove = "image_types_fsl"
 # Torizon machine specific overrides
 INHERIT += "torizon"
 
+# Central list of GPLv3 packages that must not end up in Torizon OS images.
+# Packages listed here are removed from the RDEPENDS/RRECOMMENDS of all
+# recipes (see gplv3-package-filter.bbclass) and are also fed into
+# BAD_RECOMMENDATIONS.
+TORIZON_EXCLUDED_PACKAGES_GPL_V3 = " \
+    dosfstools \
+    findutils \
+    gpgme-tool \
+    mc \
+    mc-fish \
+    mc-helpers \
+    mc-helpers-perl \
+    mc-shell \
+"
+BAD_RECOMMENDATIONS += "${TORIZON_EXCLUDED_PACKAGES_GPL_V3}"
+INHERIT += "gplv3-package-filter"
+
 # This also disables the static packageconfig. runc needs to be dynamically
 # linked for seccomp support. https://github.com/opencontainers/runc/issues/2008
 PACKAGECONFIG:remove:pn-${PREFERRED_PROVIDER_virtual/runc} = "static"

--- a/recipes-extended/packagegroups/packagegroup-core-full-cmdline.bbappend
+++ b/recipes-extended/packagegroups/packagegroup-core-full-cmdline.bbappend
@@ -1,8 +1,0 @@
-RDEPENDS:packagegroup-core-full-cmdline-utils:remove = "\
-    gawk \
-    mc \
-    mc-fish \
-    mc-helpers \
-    mc-helpers-perl \
-    mc-shell \
-"

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -69,12 +69,6 @@ CORE_IMAGE_BASE_INSTALL:append:tdx = " \
     udev-toradex-rules \
 "
 
-# Packages normally installed via RRECOMMENDS that should be dropped to avoid
-# the presence of GPLv3 software in Torizon OS images.
-BAD_RECOMMENDATIONS_GPL_V3 = " \
-    gpgme-tool \
-"
-BAD_RECOMMENDATIONS += "${BAD_RECOMMENDATIONS_GPL_V3}"
 
 # Define when the resize-helper is to be used:
 #


### PR DESCRIPTION
The gplv3-package-filter.bbclass will parse each recipe used by the distro and strip any `RRDEPENDS` defined in `TORIZON_EXCLUDED_PACKAGES_GPL_V3`, this enables a centralized list to drop any dependency related to the GPLv3 removal. Also removed the `BAD_RECOMMENDATIONS_GPL_V3` in favor of using the same variable.

Removed `packagegroup-core-full-cmdline.bbappend` since it's no longer needed in this setup.

Related-to: TOR-4381