### PR TITLE
edk2-firmware-tegra: rebase Torizon boot patch onto edk2-nvidia r36.4.4

### DIFF
--- a/dynamic-layers/meta-tegra/recipes-bsp/uefi/files/0001-Implement-support-for-the-Torizon-boot.patch
+++ b/dynamic-layers/meta-tegra/recipes-bsp/uefi/files/0001-Implement-support-for-the-Torizon-boot.patch
@@ -1,6 +1,7 @@
-From da07467444e81de57ec53f02fd32c36bdf25fc06 Mon Sep 17 00:00:00 2001
+From 275a0ebf94a640ef366cb4294f2f16f9cd1c9fcb Mon Sep 17 00:00:00 2001
+From 275a0ebf94a640ef366cb4294f2f16f9cd1c9fcb Mon Sep 17 00:00:00 2001
 From: Vladimir Skvortsov <vskvortsov@emcraft.com>
-Date: Mon, 13 Apr 2026 12:06:56 +0000
+Date: Thu, 11 Jun 2026 12:12:36 -0300
 Subject: [PATCH] Implement support for the Torizon boot:
 
 * added the dedicated boot mode option NVIDIA_L4T_BOOTMODE_TORIZON
@@ -12,6 +13,7 @@ Subject: [PATCH] Implement support for the Torizon boot:
 
 Signed-off-by: Vladimir Skvortsov <vskvortsov@emcraft.com>
 Signed-off-by: Eduardo Ferreira <eduardo.barbosa@toradex.com>
+Signed-off-by: Matheus Rodrigues <matheus.rodrigues@toradex.com>
 ---
  Platform/NVIDIA/NVIDIA.common.dsc.inc         |   1 +
  .../Application/L4TLauncher/L4TLauncher.c     | 120 ++++++++++++++++--
@@ -23,17 +25,21 @@ Signed-off-by: Eduardo Ferreira <eduardo.barbosa@toradex.com>
  .../Drivers/NvidiaConfigDxe/NvidiaConfigHii.h |   1 +
  .../NvidiaConfigDxe/NvidiaConfigHii.uni       |   7 +
  .../NvidiaConfigDxe/NvidiaConfigHii.vfr       |  18 +++
- .../NvidiaConfigDxe/NvidiaConfigHiiMap.uni    |   6 +
+ .../NvidiaConfigDxe/NvidiaConfigHiiMap.uni    |   5 +
+ .../NvidiaConfigDxe/NvidiaConfigHiiMap.uni    |   5 +
  Silicon/NVIDIA/Include/NVIDIAConfiguration.h  |  11 ++
  Silicon/NVIDIA/NVIDIA.dec                     |   5 +
  .../Tegra/DeviceTree/L4TConfiguration.dts     |   7 +-
- 14 files changed, 241 insertions(+), 10 deletions(-)
+ 14 files changed, 240 insertions(+), 10 deletions(-)
+ 14 files changed, 240 insertions(+), 10 deletions(-)
 
 diff --git a/Platform/NVIDIA/NVIDIA.common.dsc.inc b/Platform/NVIDIA/NVIDIA.common.dsc.inc
-index 3c460e1a..2fd8b9a9 100644
+index 8e8ddbbe..4e513132 100644
+index 8e8ddbbe..4e513132 100644
 --- a/Platform/NVIDIA/NVIDIA.common.dsc.inc
 +++ b/Platform/NVIDIA/NVIDIA.common.dsc.inc
-@@ -1195,6 +1195,7 @@ CONFIG_LOGO_IMPLEMENTER = noimplementer.inf
+@@ -1080,6 +1080,7 @@ gEfiSecurityPkgTokenSpaceGuid.PcdSingleBootApplicationGuid|{ GUID("cbf481fb-b373
+@@ -1080,6 +1080,7 @@ gEfiSecurityPkgTokenSpaceGuid.PcdSingleBootApplicationGuid|{ GUID("cbf481fb-b373
    gNVIDIATokenSpaceGuid.PcdOsChainStatusA|L"RootfsStatusSlotA"|gNVIDIAPublicVariableGuid|0x0|0|BS,NV,RT
    gNVIDIATokenSpaceGuid.PcdOsChainStatusB|L"RootfsStatusSlotB"|gNVIDIAPublicVariableGuid|0x0|0|BS,NV,RT
    gNVIDIATokenSpaceGuid.PcdL4TDefaultBootMode|L"L4TDefaultBootMode"|gNVIDIAPublicVariableGuid|0x00|0xFF|BS,NV,RT
@@ -42,10 +48,11 @@ index 3c460e1a..2fd8b9a9 100644
    gNVIDIATokenSpaceGuid.PcdAcpiTimerEnabled|L"AcpiTimerEnabled"|gNVIDIAPublicVariableGuid|0x0|0|BS,NV
    gNVIDIATokenSpaceGuid.PcdUefiShellEnabled|L"UefiShellEnabled"|gNVIDIAPublicVariableGuid|0x0|0x01|BS,NV
 diff --git a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c
-index cb6d8a1c..414c195f 100644
+index c905f852..241d617b 100644
+index c905f852..241d617b 100644
 --- a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c
 +++ b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c
-@@ -1167,7 +1167,7 @@ EFI_STATUS
+@@ -1172,7 +1172,7 @@ EFI_STATUS
  EFIAPI
  ProcessExtLinuxConfig (
    IN EFI_HANDLE             DeviceHandle,
@@ -54,7 +61,7 @@ index cb6d8a1c..414c195f 100644
    OUT EXTLINUX_BOOT_CONFIG  *BootConfig,
    OUT EFI_HANDLE            *RootFsHandle
    )
-@@ -1180,6 +1180,12 @@ ProcessExtLinuxConfig (
+@@ -1185,6 +1185,12 @@ ProcessExtLinuxConfig (
    CHAR16           *Timeout      = NULL;
    CHAR16           *CbootArg     = NULL;
    CHAR16           *PostCbootArg = NULL;
@@ -67,7 +74,7 @@ index cb6d8a1c..414c195f 100644
    BOOLEAN          Ascii;
    UINTN            Index;
  
-@@ -1189,21 +1195,28 @@ ProcessExtLinuxConfig (
+@@ -1194,21 +1200,28 @@ ProcessExtLinuxConfig (
      return EFI_INVALID_PARAMETER;
    }
  
@@ -99,7 +106,7 @@ index cb6d8a1c..414c195f 100644
      return Status;
    }
  
-@@ -1220,6 +1233,63 @@ ProcessExtLinuxConfig (
+@@ -1225,6 +1238,63 @@ ProcessExtLinuxConfig (
  
      CleanLine = CleanExtLinuxLine (FileLine);
      if (*CleanLine != CHAR_NULL) {
@@ -163,7 +170,7 @@ index cb6d8a1c..414c195f 100644
        Status = CheckCommandString (CleanLine, EXTLINUX_KEY_TIMEOUT, &Timeout);
        if (!EFI_ERROR (Status)) {
          BootConfig->Timeout = StrDecimalToUintn (Timeout);
-@@ -1292,6 +1362,22 @@ ProcessExtLinuxConfig (
+@@ -1297,6 +1367,22 @@ ProcessExtLinuxConfig (
      }
    }
  
@@ -186,7 +193,7 @@ index cb6d8a1c..414c195f 100644
    if (FileLine != NULL) {
      FreePool (FileLine);
      FileLine = NULL;
-@@ -1749,10 +1835,24 @@ ProcessBootParams (
+@@ -1757,10 +1843,24 @@ ProcessBootParams (
  
    DataSize = sizeof (BootParams->BootMode);
    Status   = gRT->GetVariable (L4T_BOOTMODE_VARIABLE_NAME, &gNVIDIAPublicVariableGuid, NULL, &DataSize, &BootParams->BootMode);
@@ -212,7 +219,7 @@ index cb6d8a1c..414c195f 100644
    DataSize = sizeof (BootChain);
    Status   = gRT->GetVariable (BOOT_FW_VARIABLE_NAME, &gNVIDIAPublicVariableGuid, NULL, &DataSize, &BootChain);
    // If variable does not exist, is >4 bytes or has a value larger than 1, boot partition A
-@@ -2728,10 +2828,14 @@ L4TLauncher (
+@@ -2646,10 +2746,14 @@ L4TLauncher (
        } while (FALSE);
      }
  
@@ -231,7 +238,7 @@ index cb6d8a1c..414c195f 100644
            ErrorPrint (L"%a: Unable to process extlinux config: %r\r\n", __FUNCTION__, Status);
            BootParams.BootMode = NVIDIA_L4T_BOOTMODE_BOOTIMG;
 diff --git a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h
-index 56ad3138..1dc5c1d9 100644
+index 177af9a4..49bbd95c 100644
 --- a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h
 +++ b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h
 @@ -20,6 +20,7 @@
@@ -260,12 +267,12 @@ index 56ad3138..1dc5c1d9 100644
 +
  #define MAX_EXTLINUX_OPTIONS  10
  
- #define SIG_FILE_SIZE_2KB  SIZE_2KB
+ typedef struct {
 diff --git a/Silicon/NVIDIA/Application/L4TLauncher/L4TRootfsValidation.c b/Silicon/NVIDIA/Application/L4TLauncher/L4TRootfsValidation.c
-index f12ab9f1..3b897c0a 100644
+index aee2d832..d2a489dc 100644
 --- a/Silicon/NVIDIA/Application/L4TLauncher/L4TRootfsValidation.c
 +++ b/Silicon/NVIDIA/Application/L4TLauncher/L4TRootfsValidation.c
-@@ -638,6 +638,10 @@ ValidateRootfsStatus (
+@@ -648,6 +648,10 @@ ValidateRootfsStatus (
      return EFI_SUCCESS;
    }
  
@@ -276,7 +283,7 @@ index f12ab9f1..3b897c0a 100644
    if (BootParams->BootChain > ROOTFS_SLOT_B) {
      DEBUG ((
        DEBUG_ERROR,
-@@ -687,6 +691,7 @@ ValidateRootfsStatus (
+@@ -697,6 +701,7 @@ ValidateRootfsStatus (
  
    // Set BootMode to RECOVERY if there is no more valid rootfs
    if (!IsValidRootfs ()) {
@@ -284,7 +291,7 @@ index f12ab9f1..3b897c0a 100644
      BootParams->BootMode = NVIDIA_L4T_BOOTMODE_RECOVERY;
  
      // Clear the SR_RF when boot to recovery kernel.
-@@ -706,7 +711,8 @@ ValidateRootfsStatus (
+@@ -721,7 +726,8 @@ ValidateRootfsStatus (
    }
  
    // Check redundancy level and validate rootfs status
@@ -294,7 +301,7 @@ index f12ab9f1..3b897c0a 100644
      case NVIDIA_OS_REDUNDANCY_BOOT_ONLY:
        // There is no rootfs B. Ensure to set rootfs slot to A.
        if (mRootfsInfo.CurrentSlot != ROOTFS_SLOT_A) {
-@@ -830,6 +836,55 @@ ValidateRootfsStatus (
+@@ -845,6 +851,55 @@ ValidateRootfsStatus (
          mRootfsInfo.RootfsVar[RF_REDUNDANCY].Value
          ));
        break;
@@ -363,10 +370,10 @@ index 17b3e7f4..51d74e99 100644
  
  /**
 diff --git a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c
-index ad3b7cc6..3b2cc75b 100644
+index cd896efc..9183033b 100644
 --- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c
 +++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c
-@@ -2262,6 +2262,9 @@ InitializeSettings (
+@@ -1776,6 +1776,9 @@ InitializeSettings (
    // Initialize L4T boot mode Form Settings
    PcdSet32S (PcdL4TDefaultBootMode, PcdGet32 (PcdL4TDefaultBootMode));
  
@@ -377,31 +384,31 @@ index ad3b7cc6..3b2cc75b 100644
    PcdSet8S (PcdIpmiNetworkBootMode, PcdGet8 (PcdIpmiNetworkBootMode));
  
 diff --git a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.inf b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.inf
-index cd14c91f..58124c52 100644
+index 16d44f89..dbc45680 100644
 --- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.inf
 +++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.inf
-@@ -101,6 +101,7 @@
+@@ -99,6 +99,7 @@
+   gNVIDIATokenSpaceGuid.PcdBoardRecoveryBoot
    gNVIDIATokenSpaceGuid.PcdSocDisplayHandoffMode
    gNVIDIATokenSpaceGuid.PcdServerPowerControlSetting
-   gNVIDIATokenSpaceGuid.PcdNvGopSupported
 +  gNVIDIATokenSpaceGuid.PcdTorizonBootFlags
  
  [Depex]
    gEfiVariableArchProtocolGuid        AND
 diff --git a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.h b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.h
-index d586ba28..ba764a09 100644
+index f1873a96..c846aa6c 100644
 --- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.h
 +++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.h
-@@ -122,6 +122,7 @@
- #define KEY_EGM_HV_VIRT_UEFI_SIZE_MB   0x1028
- #define KEY_ECC_ALGORITHM              0x1029
- #define KEY_MAX_ALLOWED_NUM_SPARES     0x102A
-+#define KEY_TORIZON_BOOT_FLAGS         0x102B
+@@ -111,6 +111,7 @@
+ #define KEY_MAX_CORES                  0x1023
+ #define KEY_SERVER_POWER_CONTROL       0x1024
+ #define KEY_DBG2_NETWORK_DEVICE        0x1025
++#define KEY_TORIZON_BOOT_FLAGS         0x1026
  
  #define KEY_UPHY0_SOCKET0_CONFIG  0x1100
  #define KEY_UPHY1_SOCKET0_CONFIG  0x1101
 diff --git a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.uni b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.uni
-index 9038ea9a..3e6c695e 100644
+index 99261973..11284895 100644
 --- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.uni
 +++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.uni
 @@ -54,6 +54,8 @@
@@ -413,7 +420,7 @@ index 9038ea9a..3e6c695e 100644
  #string STR_DT_DGPU_EFIFB_PROMPT             #language en-US "dGPU EFIFB Support (DT Mode)"
  #string STR_DT_DGPU_EFIFB_HELP               #language en-US "Enable to support dGPU EFIFB in device tree mode."
  #string STR_EGM_ENABLE_PROMPT                #language en-US "EGM"
-@@ -1270,6 +1272,11 @@
+@@ -941,6 +943,11 @@
  #string STR_L4T_BOOTMODE_BOOTIMG         #language en-US  "Kernel Partition"
  #string STR_L4T_BOOTMODE_RECOVERY        #language en-US  "Recovery Partition"
  #string STR_L4T_BOOTMODE_DEFAULT         #language en-US  "Application Default"
@@ -426,7 +433,7 @@ index 9038ea9a..3e6c695e 100644
  #string STR_RESET_VARIABLES_HELP         #language en-US  "Reset all non-authenticated settings (reboot required)"
  #string STR_RESET_VARIABLES_PROMPT       #language en-US  "Reset Settings"
 diff --git a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr
-index ca329886..d2925fe3 100644
+index 328b7789..a311c9d8 100644
 --- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr
 +++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr
 @@ -80,6 +80,11 @@ formset
@@ -441,7 +448,7 @@ index ca329886..d2925fe3 100644
    efivarstore NVIDIA_IPMI_NETWORK_BOOT_MODE,
      attribute = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_RUNTIME_ACCESS,
      name  = IpmiNetworkBootMode,
-@@ -542,8 +547,21 @@ formset
+@@ -536,8 +541,21 @@ formset
            option text = STRING_TOKEN(STR_L4T_BOOTMODE_DIRECT), value = NVIDIA_L4T_BOOTMODE_DIRECT, flags = 0;
            option text = STRING_TOKEN(STR_L4T_BOOTMODE_BOOTIMG), value = NVIDIA_L4T_BOOTMODE_BOOTIMG, flags = 0;
            option text = STRING_TOKEN(STR_L4T_BOOTMODE_RECOVERY), value = NVIDIA_L4T_BOOTMODE_RECOVERY, flags = 0;
@@ -464,28 +471,21 @@ index ca329886..d2925fe3 100644
          questionid = KEY_DGPU_DT_EFIFB_SUPPORT,
          prompt = STRING_TOKEN(STR_DT_DGPU_EFIFB_PROMPT),
 diff --git a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHiiMap.uni b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHiiMap.uni
-index 3f845255..d57f3ba5 100644
+index d0c71ccb..2b6ee818 100644
 --- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHiiMap.uni
 +++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHiiMap.uni
-@@ -40,12 +40,18 @@
- #string STR_ENABLED_PCIE_NIC_TOPOLOGY_PROMPT    #language x-UEFI-redfish-Bios.v1_2_0 "/Bios/Attributes/EnablePcieNicTopology"
+@@ -46,6 +46,11 @@
+ #string STR_L4T_BOOTMODE_RECOVERY               #language x-uefi-redfish-Bios.v1_2_0 "RecoveryPartition"
+ #string STR_L4T_BOOTMODE_DEFAULT                #language x-uefi-redfish-Bios.v1_2_0 "ApplicationDefault"
  
- #string STR_L4T_BOOTMODE_PROMPT                 #language x-UEFI-redfish-Bios.v1_2_0 "/Bios/Attributes/L4tBootMode"
++#string STR_TORIZON_PROMPT                      #language x-uefi-redfish-Bios.v1_2_0 "/Bios/Attributes/Torizon"
++#string STR_TORIZON_NONE                        #language x-uefi-redfish-Bios.v1_2_0 "normal_boot"
++#string STR_TORIZON_UA                          #language x-uefi-redfish-Bios.v1_2_0 "upgrade_available"
++#string STR_TORIZON_RB                          #language x-uefi-redfish-Bios.v1_2_0 "rollback"
 +
- #string STR_L4T_BOOTMODE_GRUB                   #language x-UEFI-redfish-Bios.v1_2_0 "Grub"
- #string STR_L4T_BOOTMODE_DIRECT                 #language x-UEFI-redfish-Bios.v1_2_0 "ExtLinux"
- #string STR_L4T_BOOTMODE_BOOTIMG                #language x-UEFI-redfish-Bios.v1_2_0 "KernelPartition"
- #string STR_L4T_BOOTMODE_RECOVERY               #language x-UEFI-redfish-Bios.v1_2_0 "RecoveryPartition"
- #string STR_L4T_BOOTMODE_DEFAULT                #language x-UEFI-redfish-Bios.v1_2_0 "ApplicationDefault"
- 
-+#string STR_TORIZON_PROMPT                      #language x-UEFI-redfish-Bios.v1_2_0 "/Bios/Attributes/Torizon"
-+#string STR_TORIZON_NONE                        #language x-UEFI-redfish-Bios.v1_2_0 "normal_boot"
-+#string STR_TORIZON_UA                          #language x-UEFI-redfish-Bios.v1_2_0 "upgrade_available"
-+#string STR_TORIZON_RB                          #language x-UEFI-redfish-Bios.v1_2_0 "rollback"
-+
- #string STR_PCIE_IN_OS_PROMPT                   #language x-UEFI-redfish-Bios.v1_2_0 "/Bios/Attributes/EnablePcieInOs"
- #string STR_EGM_ENABLE_PROMPT                   #language x-UEFI-redfish-Bios.v1_2_0 "/Bios/Attributes/EGM"
- #string STR_EGM_HV_RESERVED_SIZE_PROMPT         #language x-UEFI-redfish-Bios.v1_2_0 "/Bios/Attributes/EGMHypervisorReservedMemory"
+ #string STR_PCIE_IN_OS_PROMPT                   #language x-uefi-redfish-Bios.v1_2_0 "/Bios/Attributes/EnablePcieInOs"
+ #string STR_EGM_ENABLE_PROMPT                   #language x-uefi-redfish-Bios.v1_2_0 "/Bios/Attributes/EGM"
+ #string STR_EGM_HV_RESERVED_SIZE_PROMPT         #language x-uefi-redfish-Bios.v1_2_0 "/Bios/Attributes/EGMHypervisorReservedMemory"
 diff --git a/Silicon/NVIDIA/Include/NVIDIAConfiguration.h b/Silicon/NVIDIA/Include/NVIDIAConfiguration.h
 index 05598960..2c4dc8ee 100644
 --- a/Silicon/NVIDIA/Include/NVIDIAConfiguration.h
@@ -518,10 +518,10 @@ index 05598960..2c4dc8ee 100644
    BOOLEAN    BoardRecoveryBoot;
  } NVIDIA_BOARD_RECOVERY_BOOT;
 diff --git a/Silicon/NVIDIA/NVIDIA.dec b/Silicon/NVIDIA/NVIDIA.dec
-index 6e449898..53a56431 100644
+index 9e9476d8..aef201ae 100644
 --- a/Silicon/NVIDIA/NVIDIA.dec
 +++ b/Silicon/NVIDIA/NVIDIA.dec
-@@ -655,6 +655,11 @@
+@@ -633,6 +633,11 @@
    #255 - Use application default
    gNVIDIATokenSpaceGuid.PcdL4TDefaultBootMode|0xFF|UINT32|0x00000044
  
@@ -534,7 +534,7 @@ index 6e449898..53a56431 100644
    #Type02 Data
    gNVIDIATokenSpaceGuid.PcdBoardChassisLocation|L""|VOID*|0x00000051
 diff --git a/Silicon/NVIDIA/Tegra/DeviceTree/L4TConfiguration.dts b/Silicon/NVIDIA/Tegra/DeviceTree/L4TConfiguration.dts
-index 7e0fe4d8..4d68d77d 100644
+index 7e0fe4d8..536f861f 100644
 --- a/Silicon/NVIDIA/Tegra/DeviceTree/L4TConfiguration.dts
 +++ b/Silicon/NVIDIA/Tegra/DeviceTree/L4TConfiguration.dts
 @@ -47,7 +47,12 @@
@@ -552,6 +552,5 @@ index 7e0fe4d8..4d68d77d 100644
  								non-volatile;
  							};
 -- 
-2.34.1
-
+2.43.0
 


### PR DESCRIPTION
The 0001-Implement-support-for-the-Torizon-boot.patch was generated against an older edk2-nvidia revision and no longer applied cleanly against SRCREV 0887a54c (branch r36.4.4-updates): several hunks failed with large context offsets, and the .inf/.h/.uni context had drifted.

Regenerated the patch against the current SRCREV, manually reapplying the NvidiaConfigDxe.inf, NvidiaConfigHii.h, NvidiaConfigHiiMap.uni and L4TConfiguration.dts hunks. CRLF line endings preserved to match the edk2-nvidia source and the surrounding meta-tegra patches.

Related-to: TOR-4465