### PR TITLE
setup-environment: standardize setup-environment script name

### DIFF
--- a/scripts/setup-environment
+++ b/scripts/setup-environment
@@ -19,6 +19,15 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+# If called internally by NXP's imx-setup-release.sh, DISTRO is an FSL distro
+# (e.g. fsl-imx-xwayland). Delegate to the Freescale base and return early.
+case "${DISTRO}" in
+    fsl-*|fslc-*)
+        . sources/base/setup-environment "$@"
+        return
+        ;;
+esac
+
 trap "unset $(declare -p | sed -ne 's/^declare .. \(_TDX_[_a-z0-9]\+\)=.*/\1/ip' &> /dev/null; declare -fp | sed -ne 's/^\(_tdx_[-_a-z0-9]\+\) *()/\1/ip' &> /dev/null)" RETURN
 
 _tdx_usage () {


### PR DESCRIPTION
When called internally by NXP's imx-frdm-setup.sh (or
imx-setup-release.sh) DISTRO is set to an FSL distro
(e.g. fsl-imx-xwayland). Detect this and delegate to sources
/base/setup-environment early, so Jenkins needs no board-specific
exceptions for iMX93 FRDM.

Related-to: TOR-4467
Signed-off-by: Matheus Rodrigues <matheus.rodrigues@toradex.com>