### PR TITLE
ostree_layer_revision_info: pin OSTREE_LAYER_REVISION_INFO[vardpvalue] to prevent basehash conflicts

### DIFF
--- a/classes/torizon_base_image_type.inc
+++ b/classes/torizon_base_image_type.inc
@@ -58,7 +58,7 @@ EXTRA_OSTREE_COMMIT = " \
     --add-metadata=oe.layers="${OSTREE_LAYER_REVISION_INFO}" \
 "
 
-IMAGE_CMD:ostreecommit[vardepsexclude] += "EXTRA_OSTREE_COMMIT OSTREE_COMMIT_SUBJECT"
+IMAGE_CMD:ostreecommit[vardepsexclude] += "EXTRA_OSTREE_COMMIT OSTREE_COMMIT_SUBJECT OSTREE_LAYER_REVISION_INFO"
 
 require recipes-extended/ostree/gen-cfs-keys.inc
 


### PR DESCRIPTION
This pins OSTREE_LAYER_REVISION_INFO to a fixed string only during basehash calculation (which is the part relevant to bitbake's signature/determinism check). The actual value computed at runtime is left unchanged, so the real layer-revision metadata is still committed into the OSTree image as before.

Related-to: TOR-4216