### PR TITLE
conf:distro: bump Common Torizon versioning to 7.7.0

### DIFF
--- a/conf/distro/include/versioning.inc
+++ b/conf/distro/include/versioning.inc
@@ -2,8 +2,8 @@ TDX_BUILDNBR ?= "0"
 TDX_PURPOSE ?= "Testing"
 
 TDX_MAJOR ?= "7"
-TDX_MINOR ?= "6"
-TDX_PATCH ?= "2"
+TDX_MINOR ?= "7"
+TDX_PATCH ?= "0"
 
 def get_tdx_prerelease(purpose, datetime):
     if purpose == "Testing":


### PR DESCRIPTION
In commit f74e83d6 the versioning was bumped to 7.6.2 to perform the Common Torizon patch release. Now that the release is done, revert this back to 7.7.0.

This reverts commit f74e83d66ec2b3f43b37f64d588a4111d425b690.

Related-to: TOR-4422