### PR TITLE
apparmor: Add apparmor userspace utils (master)

### DIFF
--- a/conf/distro/include/base-distro.inc
+++ b/conf/distro/include/base-distro.inc
@@ -38,7 +38,7 @@ IMAGE_BOOT_FILES = ""
 IMAGE_BOOT_FILES_REMOVE:sota = "boot.scr-${MACHINE};boot.scr overlays.txt overlays/*;overlays/"
 IMAGE_BOOT_FILES_REMOVE:append:apalis-imx8 = " hdmitxfw.bin dpfw.bin"
 
-DISTRO_FEATURES:append = " virtualization stateless-system"
+DISTRO_FEATURES:append = " virtualization stateless-system apparmor"
 DISTRO_FEATURES_REMOVE ?= "3g alsa irda pcmcia nfc ldconfig pulseaudio wayland x11 ptest multiarch vulkan"
 DISTRO_FEATURES_REMOVE:remove:verdin-imx95 = "vulkan"
 DISTRO_FEATURES_REMOVE:remove:toradex-smarc-imx95 = "vulkan"

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -25,6 +25,7 @@ SPLASH = "plymouth"
 
 # Base packages
 CORE_IMAGE_BASE_INSTALL:append = " \
+    apparmor \
     cpupower \
     curl \
     ethtool \


### PR DESCRIPTION
Same as: https://github.com/torizon/meta-toradex-torizon/pull/548

But, for the `master` branch. This doesn't have the patch that was needed on Scarthgap since that patch was originally backported from `master` anyways.