### PR TITLE
docs: standardize setup-environment docs/README-nxp.md

### DIFF
--- a/docs/README-nxp.md
+++ b/docs/README-nxp.md
@@ -21,7 +21,7 @@ Build
 
 1. Source `setup-environment`, specifying the machine to build with the MACHINE variable e.g.:
 ```bash
-$ MACHINE=imx93frdm . torizon-setup-environment <build-directory>
+$ MACHINE=imx93frdm . setup-environment <build-directory>
 ```
 If a build directory is not given, the script will create one named `build`, where all build artifacts will be stored.
 
@@ -74,7 +74,7 @@ $ repo sync -j 10
 ```bash
 $ git clone https://github.com/torizon/meta-toradex-torizon.git -b scarthgap-7.x.y sources/meta-toradex-torizon
 $ git clone https://github.com/uptane/meta-updater.git -b scarthgap sources/meta-updater
-$ ln -s sources/meta-toradex-torizon/scripts/setup-environment torizon-setup-environment
+$ ln -s sources/meta-toradex-torizon/scripts/setup-environment setup-environment
 ```
 
 Additional Setup for i.MX93 FRDM boards


### PR DESCRIPTION
Since b32d01fee7e5aedad5fbf6ab41ef2b86764ba267 changed the source script name from torizon-setup-environment to setup-environment — which is the standard name for Torizon sourcing scripts - it is required to update the README file for nxp common torizon.


Link: https://gitlab.com/toradex/rd/linux-bsp/toradex-manifest/-/merge_requests/753
Related-to: TOR-4490