### PR TITLE
Install AppArmor only on Toradex Devices (master)

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -25,12 +25,12 @@ BBFILES_DYNAMIC += "\
     meta-synaptics:${LAYERDIR}/dynamic-layers/meta-synaptics/*/*/*.bbappend \
     meta-ti-bsp:${LAYERDIR}/dynamic-layers/meta-ti-bsp/*/*/*.bb \
     meta-ti-bsp:${LAYERDIR}/dynamic-layers/meta-ti-bsp/*/*/*.bbappend \
-    toradex-bsp-common-layer:${LAYERDIR}/dynamic-layers/meta-toradex-bsp-common/*/*/*.bb \
-    toradex-bsp-common-layer:${LAYERDIR}/dynamic-layers/meta-toradex-bsp-common/*/*/*.bbappend \
-    toradex-ti-layer:${LAYERDIR}/dynamic-layers/meta-toradex-ti/*/*/*.bb \
-    toradex-ti-layer:${LAYERDIR}/dynamic-layers/meta-toradex-ti/*/*/*.bbappend \
     stm-st-stm32mp:${LAYERDIR}/dynamic-layers/meta-stm32mp-bsp/*/*/*.bb \
     stm-st-stm32mp:${LAYERDIR}/dynamic-layers/meta-stm32mp-bsp/*/*/*.bbappend \
     tegra:${LAYERDIR}/dynamic-layers/meta-tegra/*/*/*.bb \
     tegra:${LAYERDIR}/dynamic-layers/meta-tegra/*/*/*.bbappend \
+    toradex-bsp-common-layer:${LAYERDIR}/dynamic-layers/meta-toradex-bsp-common/*/*/*.bb \
+    toradex-bsp-common-layer:${LAYERDIR}/dynamic-layers/meta-toradex-bsp-common/*/*/*.bbappend \
+    toradex-ti-layer:${LAYERDIR}/dynamic-layers/meta-toradex-ti/*/*/*.bb \
+    toradex-ti-layer:${LAYERDIR}/dynamic-layers/meta-toradex-ti/*/*/*.bbappend \
 "

--- a/recipes-images/images/torizon-base.inc
+++ b/recipes-images/images/torizon-base.inc
@@ -25,7 +25,6 @@ SPLASH = "plymouth"
 
 # Base packages
 CORE_IMAGE_BASE_INSTALL:append = " \
-    apparmor \
     cpupower \
     curl \
     ethtool \
@@ -64,6 +63,7 @@ CORE_IMAGE_BASE_INSTALL:append = " \
 "
 
 CORE_IMAGE_BASE_INSTALL:append:tdx = " \
+    apparmor \
     alsa-ucm-conf \
     set-hostname \
     tdx-info \


### PR DESCRIPTION
Similar to: https://github.com/torizon/meta-toradex-torizon/pull/553

But for the `master` branch. No need for dynamic layers here so we have no bbappend on `master` for AppArmor.