### PR TITLE
[master] packagegroup-core-full-cmdline: remove GPLv3 grep package

### DIFF
--- a/recipes-extended/packagegroups/packagegroup-core-full-cmdline.bbappend
+++ b/recipes-extended/packagegroups/packagegroup-core-full-cmdline.bbappend
@@ -3,6 +3,7 @@ RDEPENDS:packagegroup-core-full-cmdline-utils:remove = "\
     cpio \
     findutils \
     gawk \
+    grep \
     mc \
     mc-fish \
     mc-helpers \


### PR DESCRIPTION
This change  require  the test template updates introduced in  [1].

[1] https://gitlab.com/toradex/rd/testing/lava/lava-templates/-/merge_requests/892
Related-to: TOR-4385
