### PR TITLE
ostree_layer_revision_info: exclude OSTREE_LAYER_REVISION_INFO from vardeps to prevent conflicting basehashes

### DIFF
--- a/classes/torizon_base_image_type.inc
+++ b/classes/torizon_base_image_type.inc
@@ -85,6 +85,7 @@ validate_ostree_layer_revision_info() {
         bbfatal "OSTREE_LAYER_REVISION_INFO is not set, but is required for OSTree image commits"
     fi
 }
+validate_ostree_layer_revision_info[vardepsexclude] += "OSTREE_LAYER_REVISION_INFO"
 
 do_image_ostreecommit[prefuncs] += "validate_ostree_layer_revision_info ${CFS_OSTREECOMMIT_PREFUNCS}"
 do_image_ostreecommit[depends] += "${CFS_OSTREECOMMIT_DEPENDS}"


### PR DESCRIPTION
This change exclude `OSTREE_LAYER_REVISION_INFO` from `ostreecommit` basehash calculation (which is the part relevant to bitbake's signature/determinism check). The actual value computed at runtime is left unchanged, so the real layer-revision metadata is still committed into the OSTree image as before.

Related-to: TOR-4216