### PR TITLE
setup-devices: add `use-head-next` to common machines

### DIFF
--- a/scripts/lib/setup-devices/setup-environment-imx
+++ b/scripts/lib/setup-devices/setup-environment-imx
@@ -39,10 +39,37 @@ INHERIT += "rm_work"
 # Torizon
 include conf/machine/include/\${MACHINE}.inc
 EOF
+
+fi
+
+_TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifest.xml
+_TDX_INTEGRATION_BUILD=0
+if [ -L "$_TDX_MANIFEST_FILE" ]; then
+  case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
+    integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
+  esac
+elif [ -f "$_TDX_MANIFEST_FILE" ]; then
+  if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
+    _TDX_INTEGRATION_BUILD=1
+  fi
+fi
+
+# When building on integration, ensure use-head-next is set so you always get
+# the newest software (u-boot, kernel, aktualizr-torizon, etc). Idempotent, so
+# it also applies when local.conf already existed from a previous run.
+if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
+   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/local.conf; then
+  cat <<EOF >>conf/local.conf
+
+# This is needed when building on integration. With use-head-next you
+# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
+# Building on integration without use-head-next your build may fail.
+DISTROOVERRIDES .= ":use-head-next"
+EOF
 fi
 
 
-if ! grep -q "# Torizon" conf/bblayers.conf; then 
+if ! grep -q "# Torizon" conf/bblayers.conf; then
   cat <<EOF >>conf/bblayers.conf
 # Torizon
 BBLAYERS += "\${BSPDIR}/sources/meta-toradex-torizon"

--- a/scripts/lib/setup-devices/setup-environment-intel
+++ b/scripts/lib/setup-devices/setup-environment-intel
@@ -31,7 +31,35 @@ INHERIT += "rm_work"
 # Torizon
 include conf/machine/include/\${MACHINE}.inc
 EOF
+
 fi
+
+_TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifest.xml
+_TDX_INTEGRATION_BUILD=0
+if [ -L "$_TDX_MANIFEST_FILE" ]; then
+  case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
+    integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
+  esac
+elif [ -f "$_TDX_MANIFEST_FILE" ]; then
+  if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
+    _TDX_INTEGRATION_BUILD=1
+  fi
+fi
+
+# When building on integration, ensure use-head-next is set so you always get
+# the newest software (u-boot, kernel, aktualizr-torizon, etc). Idempotent, so
+# it also applies when local.conf already existed from a previous run.
+if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
+   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/local.conf; then
+  cat <<EOF >>conf/local.conf
+
+# This is needed when building on integration. With use-head-next you
+# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
+# Building on integration without use-head-next your build may fail.
+DISTROOVERRIDES .= ":use-head-next"
+EOF
+fi
+
 
 if ! grep -q "# Torizon" conf/bblayers.conf; then
   cat <<EOF >>conf/bblayers.conf

--- a/scripts/lib/setup-devices/setup-environment-nvidia
+++ b/scripts/lib/setup-devices/setup-environment-nvidia
@@ -146,6 +146,22 @@ BBLAYERS = " \\
 EOF
 fi
 
+_TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifest.xml
+if [ ! -e "$_TDX_MANIFEST_FILE" ]; then
+    _TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifests/manifest.xml
+fi
+_TDX_INTEGRATION_BUILD=0
+
+if [ -L "$_TDX_MANIFEST_FILE" ]; then
+    case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
+        integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
+    esac
+elif [ -f "$_TDX_MANIFEST_FILE" ]; then
+    if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
+        _TDX_INTEGRATION_BUILD=1
+    fi
+fi
+
 if [ "$_TDX_AUTO_CONF_CREATED" = "0" ]; then
     cat >> conf/auto.conf <<EOF
 DISTRO ?= "${DISTRO}"
@@ -159,6 +175,21 @@ else
     sed -i "s/^DISTRO ?= \"[^\"]*\"$/DISTRO ?= \"${DISTRO}\"/" conf/auto.conf
     sed -i "s/^MACHINE ?= \"[^\"]*\"$/MACHINE ?= \"${MACHINE}\"/" conf/auto.conf
     sed -i "s/^SDKMACHINE ?= \"[^\"]*\"$/SDKMACHINE ?= \"${SDKMACHINE}\"/" conf/auto.conf
+fi
+
+# When building on integration (integration.xml/next.xml), ensure use-head-next
+# is set so you always get the newest software (u-boot, kernel,
+# aktualizr-torizon, etc). Prepended to the top of auto.conf, and applied even
+# when auto.conf already existed from a previous run.
+if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
+   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/auto.conf; then
+    cat <<EOF >>conf/auto.conf
+
+# This is needed when building on integration. With use-head-next you
+# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
+# Building on integration without use-head-next your build may fail.
+DISTROOVERRIDES .= ":use-head-next"
+EOF
 fi
 
 cat > conf/site.conf <<_EOF

--- a/scripts/lib/setup-devices/setup-environment-synaptics
+++ b/scripts/lib/setup-devices/setup-environment-synaptics
@@ -127,7 +127,35 @@ INHERIT += "rm_work"
 include conf/machine/include/\${MACHINE}.inc
 
 EOF
+
 fi
+
+_TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifest.xml
+_TDX_INTEGRATION_BUILD=0
+if [ -L "$_TDX_MANIFEST_FILE" ]; then
+  case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
+    integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
+  esac
+elif [ -f "$_TDX_MANIFEST_FILE" ]; then
+  if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
+    _TDX_INTEGRATION_BUILD=1
+  fi
+fi
+
+# When building on integration, ensure use-head-next is set so you always get
+# the newest software (u-boot, kernel, aktualizr-torizon, etc). Idempotent, so
+# it also applies when local.conf already existed from a previous run.
+if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
+   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/local.conf; then
+cat <<EOF >>conf/local.conf
+
+# This is needed when building on integration. With use-head-next you
+# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
+# Building on integration without use-head-next your build may fail.
+DISTROOVERRIDES .= ":use-head-next"
+EOF
+fi
+
 
 if ! grep -q "# Torizon" conf/bblayers.conf; then
   cat <<EOF >>conf/bblayers.conf

--- a/scripts/lib/setup-devices/setup-environment-ti
+++ b/scripts/lib/setup-devices/setup-environment-ti
@@ -120,6 +120,33 @@ INHERIT += "rm_work"
 # Torizon
 include conf/machine/include/\${MACHINE}.inc
 EOF
+
+fi
+
+_TDX_MANIFEST_FILE="${OEROOT}"/.repo/manifest.xml
+_TDX_INTEGRATION_BUILD=0
+if [ -L "$_TDX_MANIFEST_FILE" ]; then
+  case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
+    integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
+  esac
+elif [ -f "$_TDX_MANIFEST_FILE" ]; then
+  if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
+    _TDX_INTEGRATION_BUILD=1
+  fi
+fi
+
+# When building on integration, ensure use-head-next is set so you always get
+# the newest software (u-boot, kernel, aktualizr-torizon, etc). Idempotent, so
+# it also applies when local.conf already existed from a previous run.
+if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
+   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/local.conf; then
+  cat <<EOF >>conf/local.conf
+
+# This is needed when building on integration. With use-head-next you
+# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
+# Building on integration without use-head-next your build may fail.
+DISTROOVERRIDES .= ":use-head-next"
+EOF
 fi
 
 if ! grep -q "# Torizon" conf/bblayers.conf; then


### PR DESCRIPTION
Adding a logic block to identify if the `common-torizon` build is using the integration manifest and set the `:use-head-next` on the build. This flag is needed to allow some recipes to overwrite the pinned hashes during this type of build.

Related-to: TOR-4450