### PR TITLE
[master] packagegroup-core-full-cmdline: remove GLPv3 gzip package

### DIFF
--- a/recipes-extended/packagegroups/packagegroup-core-full-cmdline.bbappend
+++ b/recipes-extended/packagegroups/packagegroup-core-full-cmdline.bbappend
@@ -9,3 +9,7 @@ RDEPENDS:packagegroup-core-full-cmdline-utils:remove = "\
     mc-helpers-perl \
     mc-shell \
 "
+
+RDEPENDS:packagegroup-core-full-cmdline-multiuser:remove = "\
+    gzip \
+"


### PR DESCRIPTION
Related-to: TOR-4386
Signed-off-by: Matheus Rodrigues <matheus.rodrigues@toradex.com>