### PR TITLE
[Master] docs: create CODEOWNERS for automatic reviewer attribution

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS
+# GitHub uses this file to automatically request reviews from the listed
+# owners whenever a pull request touches matching files.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repository
+*   @EdTheBearded @rborn-tx @jsrc27 @MatheusRodrigues-tor @Freireg

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,6 +10,8 @@ Code Contributor Workflow
 - Open a pull request to the default branch (currently `scarthgap-7.x.y`).
 - Open a second pull request to the `master` branch, unless not applicable.
 
+Reviewers are automatically assigned based on the [`docs/CODEOWNERS`](./CODEOWNERS) file.
+
 Commit Guidelines
 ========
 All commits must be signed-off i.e. have a 'Signed-off-by' line at the end of their messages, similar to this example:


### PR DESCRIPTION
(cherry picked from commit 64b1d986c1b2d656eb530c90e09e174e99f78edb)