### PR TITLE
kernel-devsrc: Backport fix for 6.12+ kernels

### DIFF
--- a/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,4 +1,19 @@
 do_install:append() {
+    (
+        cd ${S}
+
+        if [ "${ARCH}" = "arm64" ]; then
+            # 6.12+
+            cp -a --parents arch/arm64/kernel/vdso/vgetrandom.c $kerneldir/build/ 2>/dev/null || :
+            cp -a --parents arch/arm64/kernel/vdso/vgetrandom-chacha.S $kerneldir/build/ 2>/dev/null || :
+
+            cp -a --parents arch/arm64/tools/syscall_64.tbl $kerneldir/build/ 2>/dev/null || :
+            cp -a --parents arch/arm64/tools/syscall_32.tbl $kerneldir/build/ 2>/dev/null || :
+
+            chown -R root:root ${D}
+        fi
+    )
+
     mv $kerneldir/build $kerneldir/linux
     tar cjfv ${D}/usr/src/linux.tar.bz2 -C $kerneldir linux
     rm -rf ${D}/usr/lib ${D}/usr/src/kernel


### PR DESCRIPTION
Using the deployed kernel source for compiling kernel modules fails if the Linux kernel version is v6.12 or higher.

There is a fix for this on upstream:
https://git.openembedded.org/openembedded-core/commit/meta/recipes-kernel/linux/kernel-devsrc.bb?id=b3c24a31c29aa74a9d63a0ea0bcaccca73db870b

Backport this for the sl1680 machines where the kernel version is v6.12 at the time of writing.

Related-to: TCB-867