### PR TITLE
Add GitHub Actions workflow for backporting PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,27 @@
+name: Backport merged pull request
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backport:
+    name: Backport PR
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true &&
+        (
+          (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'backport-to-master')) ||
+          (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport-to-'))
+        )
+    steps:
+      - uses: actions/checkout@v4
+      - name: Backport
+        uses: korthout/backport-action@v3
+        with:
+          label_pattern: '^backport-to-(?<target>[^ ]+)$'
+          add_author_as_assignee: true
+          conflict_resolution: draft_commit_conflicts
+          # target branch is inferred from the label, e.g. backport-to-master → master


### PR DESCRIPTION
Automate the steps to cherry-pick the PR's commits into the master branch once the PR is merged.
The PR should be labeled as `backport-to-master` to trigger this effect, after merged a new PR will be automatically created for the master.

Here is an example of the bot in action: https://github.com/Freireg/meta-toradex-torizon/pull/3 and https://github.com/Freireg/meta-toradex-torizon/pull/4