### PR TITLE
linux-syna: fix reboot freeze on Luna sl1680 with SDIO wifi up

### DIFF
--- a/dynamic-layers/meta-synaptics/recipes-kernel/linux/linux-syna/0001-dhd_linux-fix-issue-which-freezes-sl1680-chips-board.patch
+++ b/dynamic-layers/meta-synaptics/recipes-kernel/linux/linux-syna/0001-dhd_linux-fix-issue-which-freezes-sl1680-chips-board.patch
@@ -1,0 +1,70 @@
+From 4c711cfbc7ace2065d9e09a00b021712ce26e866 Mon Sep 17 00:00:00 2001
+From: Matheus Rodrigues <matheus.rodrigues@toradex.com>
+Date: Fri, 3 Jul 2026 11:35:20 -0300
+Subject: [PATCH] dhd_linux: fix issue which freezes sl1680 chips boards
+
+Upstream-Status: Pending
+
+Signed-off-by: Matheus Rodrigues <matheus.rodrigues@toradex.com>
+---
+ net/wireless/bcmdhd/dhd_linux.c | 44 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
+
+diff --git a/net/wireless/bcmdhd/dhd_linux.c b/net/wireless/bcmdhd/dhd_linux.c
+index ee1c9a2..4624b1b 100644
+--- a/net/wireless/bcmdhd/dhd_linux.c
++++ b/net/wireless/bcmdhd/dhd_linux.c
+@@ -16349,7 +16349,51 @@ dhd_module_init_hdm(void)
+ static int
+ dhd_reboot_callback(struct notifier_block *this, unsigned long code, void *unused)
+ {
++	dhd_pub_t *dhdp = g_dhd_pub;
++
+ 	DHD_TRACE(("%s: code = %ld\n", __FUNCTION__, code));
++	pr_info("dhd_reboot_callback(bcmdhd): ENTER code=%ld\n", code);
++
++	/*
++	 * This notifier runs from kernel_restart_prepare(), before
++	 * device_shutdown() walks any device's .shutdown() hook. DHD's
++	 * background threads (watchdog, DPC) are otherwise only quiesced
++	 * from dhd_stop()'s callers deep inside that device list
++	 * (wifi_plat_dev_drv_shutdown, dhd_detach), so on a real reboot
++	 * they keep touching the chip on their own schedule for the entire
++	 * device_shutdown() sequence and can wedge whichever device happens
++	 * to be shutting down when they fire.
++	 *
++	 * Mirror what upstream brcmfmac does in brcmf_sdio_remove(): disable
++	 * the SDIO interrupt and mark the bus down *first*, via the same
++	 * dhd_bus_stop() the DPC thread's own normal exit path already
++	 * calls. That makes the watchdog/DPC logic a no-op even if a thread
++	 * is still technically alive when device_shutdown() starts, instead
++	 * of racing to kill threads outright (which previously corrupted
++	 * driver state and caused a kernel panic when done out of order).
++	 */
++	if (dhdp && dhdp->info && dhdp->bus) {
++		dhd_info_t *dhd_info = (dhd_info_t *)dhdp->info;
++		unsigned long flags;
++		bool timer_valid;
++
++		dhd_bus_stop(dhdp->bus, TRUE);
++
++		DHD_GENERAL_LOCK(dhdp, flags);
++		timer_valid = dhd_info->wd_timer_valid;
++		dhd_info->wd_timer_valid = FALSE;
++		DHD_GENERAL_UNLOCK(dhdp, flags);
++		if (timer_valid)
++			del_timer_sync(&dhd_info->timer);
++
++		if ((dhd_info->dhd_state & DHD_ATTACH_STATE_THREADS_CREATED) &&
++		    dhd_info->thr_wdt_ctl.thr_pid >= 0) {
++			PROC_STOP(&dhd_info->thr_wdt_ctl);
++		}
++	}
++
++	pr_info("dhd_reboot_callback(bcmdhd): bus_stop+watchdog stop done\n");
++
+ 	if (code == SYS_RESTART) {
+ #ifdef OEM_ANDROID
+ #ifdef BCMPCIE
+--
+2.43.0

--- a/dynamic-layers/meta-synaptics/recipes-kernel/linux/linux-syna_%.bbappend
+++ b/dynamic-layers/meta-synaptics/recipes-kernel/linux/linux-syna_%.bbappend
@@ -13,7 +13,20 @@ SRC_URI += " \
 SRC_URI:append:luna-sl1680 = " \
     file://0001-dolphin-rdk.dts-enable-sdio-connection.patch \
     file://luna-sl1680.cfg \
+    file://0001-dhd_linux-fix-issue-which-freezes-sl1680-chips-board.patch;patchdir=drivers/synaptics \
 "
+
+# 0001-dhd_linux-fix-issue-which-freezes-sl1680-chips-board.patch touches
+# drivers/synaptics/net/wireless/bcmdhd/dhd_linux.c, which lives inside a nested
+# git repo (drivers/synaptics has its own .git). kernel-yocto.bbclass's do_patch
+# only understands patchdir="kernel-meta" as a special case (see find_patches() in
+# kernel-yocto.bbclass) - any other patchdir value, including ours, is silently
+# excluded from the applied series instead of being applied or erroring out. The
+# patchdir parameter above only serves to keep it out of that automatic series;
+# apply it for real here, directly against the nested repo.
+do_patch:append:luna-sl1680() {
+    ( cd ${S}/drivers/synaptics && git am ${WORKDIR}/0001-dhd_linux-fix-issue-which-freezes-sl1680-chips-board.patch )
+}
 
 # Synaptics kernel recipe is overwriting INITRAMFS_IMAGE
 # We need to set it back to initramfs-ostree-torizon-image


### PR DESCRIPTION
dhd_reboot_callback() only ran late in the shutdown path, after DHD's
watchdog/DPC threads had already been torn down deep inside
device_shutdown(). Until then, those threads kept touching the SDIO
bus on their own schedule and could wedge whatever device was mid
shutdown, freezing the board.
 
Mirror what upstream brcmfmac does in brcmf_sdio_remove(): stop the
bus and cancel the watchdog timer/thread from the reboot notifier
itself, before device_shutdown() starts, instead of racing to kill
the threads once shutdown is already underway.

Reproducible on both Astra sl1680 and Luna sl1680 with an SDIO wifi
module (tested with AP6275A) whose interface is up at reboot time.
Only luna-sl1680 is wired up here; astra-sl1680 still needs the same
SRC_URI:append/do_patch:append hookup in a follow-up.

Related-to: TOR-4220
