### PR TITLE
[master] Refactor setup-environment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Contributing
 ============
 You may also choose to actively fix issues and bugs or possibly port Common Torizon on new devices. For more details, see [CONTRIBUTING.md](./docs/CONTRIBUTING.md).
 
+See [docs/setup-environment.md](./docs/setup-environment.md) for how the build-environment setup scripts work and how to add support for a new vendor or board.
+
 Development Process
 ===================
 Torizon is maintained by the Toradex R&D team. Development happens in this repository, including issues, PRs, and discussions. This repository is then used by our internal CI/CD infrastructure.

--- a/docs/README-nvidia.md
+++ b/docs/README-nvidia.md
@@ -84,7 +84,7 @@ echo "Removing temp directory $tmpdir"
 rm -rf $tmpdir
 ```
 
-3. Connect the USB port to the host machine and put the target board into the recovery mode: short the `FORCE_RECOVERY` pin (labeled as `FC_REC` on the carrier board) to the ground, this can be done by installing a wired jumper to the contacts `9-10` of the `J50` `button` header on the carrier board (refer to the Jetson Orin Nano Developer Kit Carrier Board Specification), then power on the board.
+3. Connect the USB port to the host machine and put the target board into the recovery mode: short the `FORCE_RECOVERY` pin (labeled as `FC_REC` on the carrier board) to the ground, this can be done by installing a wired jumper to the contacts `9-10` of the `J14` `button` header on the carrier board (refer to the [Jetson Orin Nano Developer Kit Carrier Board Specification](https://developer.nvidia.com/downloads/assets/embedded/secure/jetson/orin_nano/docs/jetson_orin_nano_devkit_carrier_board_specification_sp.pdf)), then power on the board.
 
 4. Run the deployment script:
 ```

--- a/docs/README-nxp.md
+++ b/docs/README-nxp.md
@@ -21,7 +21,7 @@ Build
 
 1. Source `setup-environment`, specifying the machine to build with the MACHINE variable e.g.:
 ```bash
-$ MACHINE=imx93frdm . torizon-setup-environment <build-directory>
+$ MACHINE=imx93frdm . setup-environment <build-directory>
 ```
 If a build directory is not given, the script will create one named `build`, where all build artifacts will be stored.
 
@@ -74,7 +74,7 @@ $ repo sync -j 10
 ```bash
 $ git clone https://github.com/torizon/meta-toradex-torizon.git -b scarthgap-7.x.y sources/meta-toradex-torizon
 $ git clone https://github.com/uptane/meta-updater.git -b scarthgap sources/meta-updater
-$ ln -s sources/meta-toradex-torizon/scripts/setup-environment torizon-setup-environment
+$ ln -s sources/meta-toradex-torizon/scripts/setup-environment setup-environment
 ```
 
 Additional Setup for i.MX93 FRDM boards

--- a/docs/setup-environment.md
+++ b/docs/setup-environment.md
@@ -1,0 +1,84 @@
+Build-environment setup scripts: architecture and how to add a vendor
+======================================================================
+
+
+Overview
+--------
+
+```
+scripts/setup-environment                          <- dispatcher, sourced by the user
+scripts/lib/
+  core.sh                                           <- shared tdx_* function library
+  machines.conf                                     <- MACHINE -> VENDOR -> DISTRO_POLICY table
+  distros.conf                                       <- top-level DISTRO menu (id + description)
+  setup-devices/
+    setup-environment-toradex                       <- one real vendor script per SoC vendor
+    setup-environment-ti
+    setup-environment-intel
+    setup-environment-imx
+    setup-environment-nvidia
+    setup-environment-renesas
+    setup-environment-stm32mp
+    setup-environment-synaptics
+    setup-environment-TEMPLATE                      <- copy this to add a new vendor
+```
+
+The dispatcher resolves the interactive MACHINE/DISTRO menus (or reads
+`$MACHINE`/`$DISTRO` from the environment), looks up the chosen MACHINE's
+vendor in `machines.conf`, and sources the matching
+`setup-environment-<vendor>` script. Everything these scripts do -
+`source`d into the user's live interactive shell, never executed as a
+subprocess - so every function in `core.sh` uses `local` for its own
+bookkeeping, never calls `exit` (only `return`), and never `cd`s except the
+two functions whose documented job is precisely to do that
+(`tdx_set_builddir`, and `tdx_compute_oeroot`'s own re-`cd`).
+
+Data files
+----------
+
+**`scripts/lib/machines.conf`** - one row per MACHINE, whitespace-delimited:
+
+```
+MACHINE  VENDOR  BSP_DISPLAY  DISTRO_POLICY
+```
+
+- `MACHINE` - the value the user sets/selects as `$MACHINE`.
+- `VENDOR` - which `setup-environment-<VENDOR>` script the dispatcher sources.
+- `BSP_DISPLAY` - free-form text shown next to MACHINE in the interactive menu (no whitespace).
+- `DISTRO_POLICY` - how the dispatcher treats `$DISTRO` before handing off: `-` (vendor script decides), `=<value>` (force), `?<value>` (default only if unset).
+ 
+**`scripts/lib/distros.conf`** - the top-level DISTRO picker menu, whitespace-delimited:
+```
+id  description
+```
+Read by both `tdx_usage` (for `-h`/no-dialog-tool output) and the dispatcher's whiptail/dialog menu, so the two can never drift out of sync.
+
+`core.sh` API tour
+------------------
+
+Grouped by concern - see the function's own doc comment in `core.sh` for full parameter details.
+
+- **Bootstrap**: `tdx_compute_oeroot`, `tdx_set_builddir`, `tdx_set_builddir_from_cwd`
+- **Table lookups**: `tdx_vendor_for_machine`, `tdx_distro_policy_for_machine`, `tdx_apply_distro_policy`, `tdx_menu_pairs`, `tdx_distro_pairs`, `tdx_usage`
+- **PATH/env**: `tdx_setup_path`, `tdx_dedupe_sort`, `tdx_setup_bb_env_passthrough`
+- **Native conf generation**: `tdx_native_conf_is_current`, `tdx_write_checksum`, `tdx_conf_from_template`, `tdx_write_auto_conf`, `tdx_write_site_conf`
+- **Integration-build detection**: `tdx_is_integration_build`, `tdx_apply_integration_override`
+- **Once-only append**: `tdx_needs_once`, `tdx_append_once`
+- **EULA/license**: `tdx_license_flag_accept`, `tdx_eula_prompt`, `tdx_append_license_flags`
+- **Banner**: `tdx_print_banner`
+- **Cleanup**: `tdx_cleanup_internal_state` - unsets every internal helper variable/function via a fixed allowlist once the dispatcher's whole invocation returns, so nothing but `MACHINE`/`DISTRO`/`SDKMACHINE`/`BUILDDIR`/`PATH`/`BB_ENV_PASSTHROUGH_ADDITIONS` survive in the user's shell.
+
+Two vendor-script behaviors
+---------------------------
+
+- **Native** (`toradex`, `nvidia`, `stm32mp`): the script builds `conf/local.conf`/`conf/bblayers.conf`/`conf/auto.conf`/`conf/site.conf` itself, with checksum-gated caching via `tdx_native_conf_is_current` so re-sourcing with unchanged MACHINE/DISTRO is a fast no-op.
+- **Delegating** (`ti`, `intel`, `imx`, `synaptics`): the script `source`s the vendor's own env-setup tooling first (poky's `oe-init-build-env`, NXP's `imx-setup-release.sh`, etc.), then patches the result with `tdx_needs_once`/`tdx_append_once`/`tdx_apply_integration_override`.
+- `renesas` is a documented special case: it assumes a container/kas-based flow has already created a base `/build/conf/*`, so it skips the bootstrap functions entirely and just patches those fixed paths.
+
+How to add a new vendor
+------------------------
+
+1. Copy `scripts/lib/setup-devices/setup-environment-TEMPLATE` to `scripts/lib/setup-devices/setup-environment-<vendor>` and fill in every `# TODO:` - it walks through the native shape step by step (`tdx_set_builddir` → `tdx_setup_path` → `tdx_setup_bb_env_passthrough` → `tdx_native_conf_is_current` early-return gate → `tdx_write_checksum` → `tdx_conf_from_template` + `tdx_append_once` for bblayers.conf → manifest README symlink → `tdx_write_auto_conf` → `tdx_apply_integration_override` → `tdx_write_site_conf` → optional `tdx_eula_prompt` → `tdx_print_banner`). If your vendor ships its own env-setup tooling instead, read `setup-environment-ti`/`-intel`/`-imx`/`-synaptics` for the delegating pattern instead - the template's header comment points to these too.
+2. Add a MACHINE row (or block of rows) for the new vendor to `scripts/lib/machines.conf`.
+
+No changes to `scripts/setup-environment` or `core.sh` are needed for either step.

--- a/scripts/lib/core.sh
+++ b/scripts/lib/core.sh
@@ -1,0 +1,722 @@
+#!/bin/bash
+# -*- mode: shell-script-mode; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+#
+# Copyright (C) 2012-13 O.S. Systems Software LTDA.
+# Copyright (C) 2017 Open Source Foundries Ltd.
+# Copyright (C) 2020-2026 Toradex AG
+# Authored-by:  Otavio Salvador <otavio@ossystems.com.br>
+# Adopted to Angstrom:  Khem Raj <raj.khem@gmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# core.sh - shared library for scripts
+#
+# This file is intended to be *sourced* by a vendor's setup-environment
+# script, not executed directly. It provides a set of common functions and
+# variables for all vendor scripts.
+# 
+# Public API functions start with tdx_*, and functions starting with _tdx_*
+# are private helpers.
+#
+#   - Every function uses `local` for its own bookkeeping variables. Nothing
+#     is allowed to leak into the caller's shell except the small set of
+#     variables explicitly documented as intentional (PATH, BUILDDIR,
+#     BB_ENV_PASSTHROUGH_ADDITIONS, DISTRO, MACHINE, SDKMACHINE.
+#   - Nothing here ever calls `exit` - only `return`. A stray `exit` would
+#     kill the user's whole shell.
+#   - Nothing here calls `cd` except the two functions whose documented job
+#     is precisely to change the caller's directory (tdx_set_builddir and,
+#     trivially, tdx_compute_oeroot re-cd'ing into the already-resolved
+#     OEROOT). Both are called out explicitly in their own comments below.
+#   - `mapfile`/`readarray` are avoided throughout in favor of
+#     `while IFS= read -r`, since mapfile isn't available in zsh.
+
+# Double-sourcing guard.
+[ -n "${_TDX_CORE_SH_LOADED:-}" ] && return 0
+_TDX_CORE_SH_LOADED=1
+
+# Locating this file's own directory
+if [ -n "${BASH_SOURCE:-}" ]; then
+    _TDX_CORE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)
+elif [ -n "${ZSH_VERSION:-}" ]; then
+    # shellcheck disable=SC2296  # zsh-only prompt-escape parameter expansion
+    _TDX_CORE_DIR=$(cd "$(dirname "${(%):-%N}")" >/dev/null 2>&1 && pwd)
+fi
+
+# _tdx_lib_conf_path <filename>
+# 
+# Print the resolved path to <filename> or return 1 if it cannot be found.
+_tdx_lib_conf_path() {
+    local fname="${1:-}"
+    if [ -n "${_TDX_CORE_DIR:-}" ] && [ -f "${_TDX_CORE_DIR}/${fname}" ]; then
+        printf '%s\n' "${_TDX_CORE_DIR}/${fname}"
+        return 0
+    fi
+    if [ -n "${_TDX_LAYERS_DIR:-}" ] && \
+       [ -f "${_TDX_LAYERS_DIR}/meta-toradex-torizon/scripts/lib/${fname}" ]; then
+        printf '%s\n' "${_TDX_LAYERS_DIR}/meta-toradex-torizon/scripts/lib/${fname}"
+        return 0
+    fi
+    return 1
+}
+
+# Wrappers around _tdx_lib_conf_path for each data file.
+_tdx_machines_conf_path() { _tdx_lib_conf_path machines.conf; }
+_tdx_distros_conf_path() { _tdx_lib_conf_path distros.conf; }
+
+# tdx_compute_oeroot
+#
+# resolve and export _TDX_OEROOT, _TDX_LAYERS_DIR, _TDX_MANIFESTS and _TDX_SCRIPTS, and apply
+# the one-time bash/zsh compatibility settings.
+tdx_compute_oeroot() {
+    if [ -n "${ZSH_VERSION:-}" ]; then
+        setopt sh_word_split
+        setopt clobber
+    elif [ -n "${BASH_VERSION:-}" ]; then
+        set +o noclobber
+    fi
+
+    # compute OEROOT path relative to _TDX_CORE_DIR
+    _TDX_OEROOT=$(cd "${_TDX_CORE_DIR}/../../../.." >/dev/null 2>&1 && pwd)
+    cd "${_TDX_OEROOT}" || return 1
+    # Preserve the dispatcher's own _TDX_LAYERS_DIR if it already resolved one
+    : "${_TDX_LAYERS_DIR:=${_TDX_OEROOT}/layers}"
+    _TDX_MANIFESTS="${_TDX_OEROOT}/.repo/manifests"
+    _TDX_SCRIPTS="${_TDX_LAYERS_DIR}/meta-toradex-torizon/scripts"
+}
+
+# tdx_set_builddir <builddir name> <distro>
+#
+# builddir resolution that normalizes the (optional) explicit builddir
+# argument (default build-<distro>), and export both _TDX_BUILDDIR and
+# BUILDDIR consistently.
+tdx_set_builddir() {
+    local arg="${1:-}" distro="${2:-}" builddir
+
+    builddir="${arg:-build-${distro}}"
+    # If relative, get full path
+    case "${builddir}" in
+        /*) ;;
+        *) builddir=$(readlink -f "${builddir}") ;;
+    esac
+    # Get rid of a trailing slash, some OE sed calls trip on the double
+    # slash it would otherwise produce.
+    builddir="${builddir%%/}"
+
+    _TDX_BUILDDIR="${builddir}"
+    BUILDDIR="${builddir}"
+    # Set for recipetool's benefit
+    BBPATH="${builddir}"
+    export _TDX_BUILDDIR BUILDDIR BBPATH
+
+    mkdir -p "${_TDX_BUILDDIR}/conf" && cd "${_TDX_BUILDDIR}" || return 1
+}
+
+# tdx_set_builddir_from_cwd
+# 
+# builddir resolution called *after* the vendor's own tooling
+# (oe-init-build-env, imx-setup-release.sh, ...) has already cd'd into the
+# build directory. Exports _TDX_BUILDDIR/BUILDDIR from $PWD.
+tdx_set_builddir_from_cwd() {
+    _TDX_BUILDDIR=$(pwd)
+    BUILDDIR="${_TDX_BUILDDIR}"
+    export _TDX_BUILDDIR BUILDDIR
+}
+
+# tdx_vendor_for_machine <machine>
+#
+# print the VENDOR column for <machine>, or return 1 if not found.
+tdx_vendor_for_machine() {
+    local machine="${1:-}" conf line m v bsp pol rest
+    conf=$(_tdx_machines_conf_path) || return 1
+    while IFS= read -r line; do
+        case "${line}" in ''|'#'*) continue ;; esac
+        read -r m v bsp pol rest <<< "${line}"
+        if [ "${m}" = "${machine}" ]; then
+            printf '%s\n' "${v}"
+            return 0
+        fi
+    done < "${conf}"
+    return 1
+}
+
+# tdx_distro_policy_for_machine <machine>
+#
+# print the raw DISTRO_POLICY column ('-', '=<value>' or '?<value>')
+# for <machine>, or return 1 if not found.
+tdx_distro_policy_for_machine() {
+    local machine="${1:-}" conf line m v bsp pol rest
+    conf=$(_tdx_machines_conf_path) || return 1
+    while IFS= read -r line; do
+        case "${line}" in ''|'#'*) continue ;; esac
+        read -r m v bsp pol rest <<< "${line}"
+        if [ "${m}" = "${machine}" ]; then
+            printf '%s\n' "${pol}"
+            return 0
+        fi
+    done < "${conf}"
+    return 1
+}
+
+# tdx_apply_distro_policy <machine>
+#
+# apply <machine>'s DISTRO_POLICY to the $DISTRO variable:
+#   -            leave $DISTRO untouched, the vendor script decides
+#   =<value>     force $DISTRO to <value>, unconditionally
+#   ?<value>     default $DISTRO to <value>, only if currently unset/empty
+tdx_apply_distro_policy() {
+    local machine="${1:-}" policy
+    policy=$(tdx_distro_policy_for_machine "${machine}") || return 1
+    case "${policy}" in
+        '='*) DISTRO="${policy#=}" ;;
+        '?'*) [ -z "${DISTRO:-}" ] && DISTRO="${policy#?}" ;;
+        *) : ;;  # '-' (or empty/unknown): vendor script decides
+    esac
+    return 0
+}
+
+# tdx_menu_pairs [-v] <filter-regex>
+#
+# print "MACHINE<TAB>BSP_DISPLAY" lines whose VENDOR column matches
+# <filter-regex>, or does NOT match it if -v is given. Used to build
+# whiptail/dialog menu arrays without hardcoding the machine list.
+tdx_menu_pairs() {
+    local invert=0
+    if [ "${1:-}" = "-v" ]; then
+        invert=1
+        shift
+    fi
+    local filter="${1:-}" conf line m v bsp pol rest matched
+    conf=$(_tdx_machines_conf_path) || return 1
+    while IFS= read -r line; do
+        case "${line}" in ''|'#'*) continue ;; esac
+        read -r m v bsp pol rest <<< "${line}"
+        if printf '%s\n' "${v}" | grep -qE "${filter}"; then
+            matched=1
+        else
+            matched=0
+        fi
+        if [ "${invert}" = "1" ]; then
+            [ "${matched}" = "0" ] && printf '%s\t%s\n' "${m}" "${bsp}"
+        else
+            [ "${matched}" = "1" ] && printf '%s\t%s\n' "${m}" "${bsp}"
+        fi
+    done < "${conf}"
+}
+
+# tdx_distro_pairs
+#
+# print "DISTRO_ID<TAB>DESCRIPTION" lines. Used to build whiptail/dialog
+# menu arrays and tdx_usage's listing without hardcoding the distro list.
+tdx_distro_pairs() {
+    local conf line d desc
+    conf=$(_tdx_distros_conf_path) || return 1
+    while IFS= read -r line; do
+        case "${line}" in ''|'#'*) continue ;; esac
+        read -r d desc <<< "${line}"
+        printf '%s\t%s\n' "${d}" "${desc}"
+    done < "${conf}"
+}
+
+# tdx_usage
+#
+# print the help/usage text to stderr.
+tdx_usage() {
+    cat >&2 <<EOF
+
+Usage: [DISTRO=<DISTRO>] [MACHINE=<MACHINE>] [EULA=1] source setup-environment [-h] [BUILDDIR]
+
+If no MACHINE is set, list of all distros will be shown for user to choose, and then the desired machine.
+If no DISTRO is set, it is inferred from MACHINE (see scripts/lib/machines.conf's DISTRO_POLICY column) -
+Toradex machines default to 'torizon' or 'torizon-upstream' per setup-environment-toradex's own logic. The
+Xenomai3/4 distro variants are only reachable via explicit interactive/DISTRO selection.
+If no EULA is set, user will be asked to read it and to accept it (if the selected machine requires it).
+If no BUILDIR is set, it will be set to build-\$DISTRO.
+
+Options:
+  -h    Show this help message.
+EOF
+
+    echo "Distros"
+    while IFS=$'\t' read -r d desc; do
+        printf "\t%s\t%s\n" "${d}" "${desc}"
+    done < <(tdx_distro_pairs)
+    echo ""
+    echo "Toradex Machines"
+    while IFS=$'\t' read -r m d; do
+        printf "\t%s\t%s\n" "${m}" "${d}"
+    done < <(tdx_menu_pairs '^toradex$')
+    echo ""
+    echo "Common Torizon Machines"
+    while IFS=$'\t' read -r m d; do
+        printf "\t%s\t%s\n" "${m}" "${d}"
+    done < <(tdx_menu_pairs -v '^toradex$')
+}
+
+# tdx_setup_path
+#
+# rebuild $PATH: strip any empty/current-directory tokens
+# (a stray "::" or leading/trailing ":" can otherwise make wrong binaries
+# get picked up during task execution), prepend the OE-required directories,
+# then dedupe while preserving order.
+tdx_setup_path() {
+    PATH=$(echo "${PATH}" | sed 's/\(:.\|:\)*:/:/g;s/^.\?://;s/:.\?$//')
+    PATH="${_TDX_OEROOT}/bitbake/bin:${_TDX_OEROOT}/.repo/repo:${PATH}"
+    PATH="${_TDX_OEROOT}/layers/openembedded-core/bitbake/bin:${PATH}"
+    PATH="${_TDX_OEROOT}/layers/openembedded-core/scripts:${PATH}"
+    PATH=$(echo "${PATH}" |
+           awk -F: '{for (i=1;i<=NF;i++) { if ( !x[$i]++ ) printf("%s:",$i); }}' |
+           sed 's/:$//')
+    export PATH
+}
+
+# tdx_dedupe_sort <words...>
+#
+# flatten all arguments into a single whitespace-separated word list,
+# then dedupe+sort it (LC_ALL=C, unique).
+# Order is NOT preserved - only use this where order doesn't matter!
+tdx_dedupe_sort() {
+    echo "$*" | tr ' ' '\n' | LC_ALL=C sort --unique | tr '\n' ' '
+}
+
+# tdx_setup_bb_env_passthrough [extra-vars...]
+#
+# (re)build and export BB_ENV_PASSTHROUGH_ADDITIONS from the standard
+# OE variable-name list, any pre-existing value of
+# $BB_ENV_PASSTHROUGH_ADDITIONS, and any extra vendor-specific variable
+# names passed in.
+tdx_setup_bb_env_passthrough() {
+    local base_vars="MACHINE DISTRO TCMODE TCLIBC HTTP_PROXY http_proxy \
+HTTPS_PROXY https_proxy FTP_PROXY ftp_proxy FTPS_PROXY ftps_proxy ALL_PROXY \
+all_proxy NO_PROXY no_proxy SSH_AGENT_PID SSH_AUTH_SOCK BB_SRCREV_POLICY \
+SDKMACHINE BB_NUMBER_THREADS BB_NO_NETWORK PARALLEL_MAKE GIT_PROXY_COMMAND \
+SOCKS5_PASSWD SOCKS5_USER SCREENDIR STAMPS_DIR BBPATH_EXTRA BB_SETSCENE_ENFORCE"
+
+    BB_ENV_PASSTHROUGH_ADDITIONS="$(tdx_dedupe_sort "${BB_ENV_PASSTHROUGH_ADDITIONS:-}" "${base_vars}" "$*")"
+    export BB_ENV_PASSTHROUGH_ADDITIONS
+}
+
+# tdx_native_conf_is_current [<eula-conf-var>]
+#
+# compares the current $MACHINE/$DISTRO/$EULA against what's
+# recorded in conf/auto.conf (and, if <eula-conf-var> is given, the matching
+# ACCEPT_*-style line in conf/local.conf), and validates conf/checksum
+# against the calling vendor script's own file.
+# Returns 0 only if everything still matches; otherwise returns 1.
+#
+# As a side effect, this sets the handoff variable $_TDX_AUTO_CONF_CREATED to
+# "1" if conf/auto.conf already existed, "0" otherwise.
+#
+# Passing an empty/omitted <eula-conf-var> skips the EULA half of the
+# comparison entirely.
+tdx_native_conf_is_current() {
+    local eula_var="${1:-}"
+    local oldmach="" olddisto="" eulaacpt="" eula_ok=1
+
+    _TDX_AUTO_CONF_CREATED=0
+    if [ -f conf/auto.conf ]; then
+        oldmach=$(grep -E '^MACHINE \?=' conf/auto.conf | sed -e 's%^MACHINE ?= %%' -e 's/^"//' -e 's/"$//')
+        olddisto=$(grep -E '^DISTRO \?=' conf/auto.conf | sed -e 's%^DISTRO ?= %%' -e 's/^"//' -e 's/"$//')
+        _TDX_AUTO_CONF_CREATED=1
+    fi
+
+    if [ -n "${eula_var}" ] && [ -f conf/local.conf ]; then
+        eulaacpt=$(grep -E "^[[:space:]]*${eula_var}[[:space:]]*=[[:space:]]*\".*\"" conf/local.conf |
+                   sed -e "s%^[[:space:]]*${eula_var}[[:space:]]*=[[:space:]]*%%" -e 's/^"//' -e 's/"$//')
+        if [ -n "${EULA:-}" ]; then
+            [ "${EULA}" = "${eulaacpt}" ] || eula_ok=0
+        else
+            [ -n "${eulaacpt}" ] || eula_ok=0
+        fi
+    fi
+
+    if [ -e conf/checksum ] && [ "${MACHINE:-}" = "${oldmach}" ] && \
+       [ "${DISTRO:-}" = "${olddisto}" ] && [ "${eula_ok}" = "1" ]; then
+        sha512sum --quiet -c conf/checksum >/dev/null 2>&1 && return 0
+    fi
+    return 1
+}
+
+# tdx_write_checksum <script-path>
+#
+# record the checksum of the calling vendor script itself.
+tdx_write_checksum() {
+    local script_path="${1:-}"
+    sha512sum "${script_path}" > conf/checksum 2>&1
+}
+
+# tdx_conf_from_template <file...>
+#
+# for each <file>, if conf/<file> doesn't already exist, copy it from
+# conf/template/<file> and substitute @OEROOT@ with $_TDX_OEROOT.
+# No-op per-file if conf/<file> already exists.
+tdx_conf_from_template() {
+    local f
+    for f in "$@"; do
+        if [ ! -f "conf/${f}" ]; then
+            cp "${_TDX_SCRIPTS}/../conf/template/${f}" "conf/${f}" || return 1
+            sed -i "s|@OEROOT@|${_TDX_OEROOT}|g" "conf/${f}"
+        fi
+    done
+}
+
+# tdx_write_auto_conf <distro> <machine> <sdkmachine> <inherit-string>
+#
+# (re)write conf/auto.conf's DISTRO/MACHINE/SDKMACHINE ?= lines and the
+# INHERIT += "<inherit-string>" line.
+tdx_write_auto_conf() {
+    local distro="${1:-}" machine="${2:-}" sdkmachine="${3:-}" inherit="${4:-}"
+
+    if [ "${_TDX_AUTO_CONF_CREATED:-0}" = "0" ]; then
+        cat >> conf/auto.conf <<EOF
+DISTRO ?= "${distro}"
+MACHINE ?= "${machine}"
+SDKMACHINE ?= "${sdkmachine}"
+
+# Extra options that can be changed by the user
+INHERIT += "${inherit}"
+EOF
+    else
+        sed -i "s/^DISTRO ?= \"[^\"]*\"\$/DISTRO ?= \"${distro}\"/" conf/auto.conf
+        sed -i "s/^MACHINE ?= \"[^\"]*\"\$/MACHINE ?= \"${machine}\"/" conf/auto.conf
+        sed -i "s/^SDKMACHINE ?= \"[^\"]*\"\$/SDKMACHINE ?= \"${sdkmachine}\"/" conf/auto.conf
+    fi
+}
+
+# tdx_write_site_conf <oeroot> <builddir>
+#
+# (re)write conf/site.conf
+tdx_write_site_conf() {
+    local oeroot="${1:-}" builddir="${2:-}"
+
+    cat > conf/site.conf <<EOF
+SCONF_VERSION = "1"
+
+# Where to store sources
+DL_DIR ?= "${oeroot}/downloads"
+
+# Where to save shared state
+SSTATE_DIR ?= "${oeroot}/sstate-cache"
+BB_HASHSERVE_DB_DIR ?= "\${SSTATE_DIR}"
+
+# Where to save the build system work output
+TMPDIR = "${builddir}/tmp"
+
+# Where to save the packages and images
+_TDX_DEPLOY_BASE = "${builddir}/deploy"
+DEPLOY_DIR = "\${_TDX_DEPLOY_BASE}\${@'' if d.getVar('BB_CURRENT_MC') == 'default' else '/\${BB_CURRENT_MC}'}"
+
+# Go through the Firewall
+#HTTP_PROXY = "http://${PROXYHOST}:${PROXYPORT}/"
+EOF
+}
+
+# tdx_is_integration_build
+#
+# returns 0 if manifest.xml resolves to/mentions integration.xml or next.xml,
+# 1 otherwise.
+tdx_is_integration_build() {
+    local manifest_file="${_TDX_OEROOT}/.repo/manifest.xml"
+    if [ ! -e "${manifest_file}" ] && [ ! -L "${manifest_file}" ]; then
+        manifest_file="${_TDX_OEROOT}/.repo/manifests/manifest.xml"
+    fi
+
+    if [ -L "${manifest_file}" ]; then
+        case "$(basename "$(readlink -f "${manifest_file}")")" in
+            integration.xml|next.xml) return 0 ;;
+            *) return 1 ;;
+        esac
+    elif [ -f "${manifest_file}" ]; then
+        grep -qE '(integration\.xml|next\.xml)' "${manifest_file}" && return 0
+    fi
+    return 1
+}
+
+# tdx_apply_integration_override <target-conf-file>
+#
+# if tdx_is_integration_build, idempotently append the DISTROOVERRIDES
+# ":use-head-next" block to <target-conf-file>.
+# no-op if already present or not an integration build.
+tdx_apply_integration_override() {
+    local target="${1:-}"
+
+    tdx_is_integration_build || return 0
+    [ -f "${target}" ] && grep -qF 'DISTROOVERRIDES .= ":use-head-next"' "${target}" && return 0
+
+    cat >> "${target}" <<'EOF'
+
+# This is needed when building on integration. With use-head-next you
+# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
+# Building on integration without use-head-next your build may fail.
+DISTROOVERRIDES .= ":use-head-next"
+EOF
+}
+
+# tdx_needs_once <file> [<marker, default "# Torizon">]
+#
+# returns 0 if <file> doesn't exist, or exists but doesn't contain <marker> yet
+# (i.e. the once-only block still needs to be appended); returns 1 if
+# <marker> is already present.
+tdx_needs_once() {
+    local file="${1:-}" marker="${2:-# Torizon}"
+    [ -f "${file}" ] || return 0
+    grep -qF "${marker}" "${file}" && return 1
+    return 0
+}
+
+# tdx_append_once <file> <marker> <<EOF ... EOF
+#
+# check file for <marker>, if file not create or marker not found, append stdin to
+# <file>. Otherwise, drain stdin and do nothing.
+#
+# Usage example:
+#   tdx_append_once conf/local.conf "# Torizon" <<EOF
+#   # Torizon
+#   INHERIT += "rm_work"
+#   EOF
+tdx_append_once() {
+    local file="${1:-}" marker="${2:-}"
+    if tdx_needs_once "${file}" "${marker}"; then
+        cat >> "${file}"
+    else
+        cat >/dev/null  # drain stdin so callers can always pipe a heredoc in
+    fi
+}
+
+# tdx_license_flag_accept <question-text> [<eula-file>]
+#
+# low-level interactive y/n prompt primitive.
+# If <eula-file> is given, first asks if user wants to read it, then ask the
+# actual accept/decline question. If <eula-file> is not given, only the
+# accept/decline <question-text> is asked.
+# All questions default answer is NO.
+tdx_license_flag_accept() {
+    local question="${1:-}" eula_file="${2:-}" reply=""
+
+    if [ -n "${eula_file}" ]; then
+        reply=""
+        while [ -z "${reply}" ]; do
+            echo -n "Would you like to read the EULA ? (y/N) "
+            # EOF/closed stdin (e.g. a non-interactive run with no EULA env
+            # var set) defaults to "n", same as a real answer of "n" - just
+            # don't read it, still go on to ask the actual accept question.
+            read -r reply || reply="n"
+            case "${reply}" in
+                y|Y) more -d "${eula_file}"; echo ;;
+                n|N) : ;;
+                *) reply="" ;;
+            esac
+        done
+    fi
+
+    reply=""
+    while [ -z "${reply}" ]; do
+        echo -n "${question} "
+        # EOF/closed stdin defaults to "n" here too, same as a real decline.
+        read -r reply || reply="n"
+        case "${reply}" in
+            y|Y) echo "EULA has been accepted."; return 0 ;;
+            n|N) echo "EULA has not been accepted."; return 1 ;;
+            *) reply="" ;;
+        esac
+    done
+}
+
+# tdx_eula_prompt <conf-var> <eula-file> [<label>]
+#
+# High-level EULA flow. Checks, in order:
+#   1. an existing "<conf-var> = "..."" line already in conf/local.conf.
+#   2. the $EULA environment variable.
+#   3. otherwise, prompt interactively via tdx_license_flag_accept.
+#
+# <label>, if given, is used in the generated comment ("BSP depends on
+# <label> packages and firmware..."); omit it for generic wording.
+#
+# Machines that need no EULA at all should skip this function.
+#
+# Returns 0 if accepted (or already accepted), 1 if declined.
+tdx_eula_prompt() {
+    local conf_var="${1:-}" eula_file="${2:-}" label="${3:-}"
+    local accepted=""
+    if [ -f conf/local.conf ] && \
+       grep -qE "^[[:space:]]*${conf_var}[[:space:]]*=[[:space:]]*\"[^\"]*\"" conf/local.conf; then
+        accepted=1
+    fi
+
+    if [ -z "${accepted}" ] && [ -n "${EULA:-}" ]; then
+        cat >> conf/local.conf <<EOF
+
+# BSP depends on ${label:+${label} }packages and firmware which are covered by an
+# End User License Agreement (EULA). To have the right to use these
+# binaries in the image, ${conf_var} must be set to '1'
+${conf_var} = "${EULA}"
+EOF
+        return 0
+    elif [ -n "${accepted}" ]; then
+        if [ -n "${EULA:-}" ]; then
+            sed -i "s/^[[:space:]]*${conf_var}[[:space:]]*=[[:space:]]*\"[^\"]*\"\$/${conf_var} = \"${EULA}\"/" conf/local.conf
+        fi
+        return 0
+    else
+        cat <<EOF
+
+The BSP for ${MACHINE} depends on packages and firmware which are covered by an
+End User License Agreement (EULA). To have the right to use these binaries
+in your images, you need to read and accept the following...
+
+EOF
+        if tdx_license_flag_accept "Do you accept the EULA you just read? (y/N)" "${eula_file}"; then
+            cat >> conf/local.conf <<EOF
+
+# BSP depends on ${label:+${label} }packages and firmware which are covered by an
+# End User License Agreement (EULA). To have the right to use these
+# binaries in the image, ${conf_var} must be set to '1'
+${conf_var} = "1"
+EOF
+            return 0
+        else
+            return 1
+        fi
+    fi
+}
+
+# tdx_append_license_flags <file> <flag...>
+#
+# append a LICENSE_FLAGS_ACCEPTED += "<flag> ..." line to <file>.
+tdx_append_license_flags() {
+    local file="${1:-}"
+    shift
+    cat >> "${file}" <<EOF
+
+LICENSE_FLAGS_ACCEPTED += "$*"
+EOF
+}
+
+# tdx_print_banner <title> <show-sdkmachine:yes|no> [<trailer-fn-name>]
+#
+# print the standard "Welcome to <title>" banner.
+# If <trailer-fn-name> is given and names a currently-declared function,
+# it is called after the banner.
+tdx_print_banner() {
+    local title="${1:-}" show_sdk="${2:-no}" trailer_fn="${3:-}"
+
+    cat <<EOF
+
+Welcome to ${title}
+
+For more information about OpenEmbedded see their website:
+
+    http://www.openembedded.org/
+
+Your build environment has been configured with:
+
+    MACHINE = ${MACHINE}
+EOF
+
+    if [ "${show_sdk}" = "yes" ]; then
+        cat <<EOF
+    SDKMACHINE = ${SDKMACHINE}
+EOF
+    fi
+
+    cat <<EOF
+    DISTRO = ${DISTRO}
+
+You can now run 'bitbake <target>'
+
+Some of common targets are:
+
+    torizon-docker
+    torizon-minimal
+    torizon-podman
+
+EOF
+
+    if [ -n "${trailer_fn}" ] && declare -F "${trailer_fn}" >/dev/null 2>&1; then
+        "${trailer_fn}"
+    fi
+}
+
+# tdx_cleanup_internal_state
+#
+# unset every internal _TDX_* helper variable and _tdx_*/tdx_* function this file
+# (and the dispatcher) introduce, via a fixed, explicit allowlist. User-visible
+# variables (MACHINE, DISTRO, SDKMACHINE, BUILDDIR, PATH,
+# BB_ENV_PASSTHROUGH_ADDITIONS) are intentionally never touched
+# here - they must survive for the user's shell/bitbake invocations.
+#
+# Vendor scripts (rewritten in a later phase against this API) may register
+# their own additional one-off internal names for cleanup by appending to
+# the _TDX_EXTRA_CLEANUP_VARS/_TDX_EXTRA_CLEANUP_FUNCS arrays before
+# returning, e.g.:
+#   _TDX_EXTRA_CLEANUP_VARS+=("_TDX_MY_HELPER")
+# without needing to modify this fixed allowlist.
+tdx_cleanup_internal_state() {
+    local -a allow_vars=(
+        _TDX_CORE_SH_LOADED
+        _TDX_CORE_DIR
+        _TDX_LAYERS_DIR
+        _TDX_SOURCE_PATH
+        _TDX_SCRIPTS
+        _TDX_SCRIPTS_PATH
+        _TDX_MANIFESTS
+        _TDX_BUILDDIR
+        _TDX_DIALOG_UTIL
+        _TDX_DISTRO_SELECT
+        _TDX_VENDOR
+        _TDX_MENU_ARGS
+        _TDX_MENU_M
+        _TDX_MENU_D
+        _TDX_AUTO_CONF_CREATED
+        _TDX_OEROOT
+    )
+    local -a allow_funcs=(
+        _tdx_lib_conf_path
+        _tdx_machines_conf_path
+        _tdx_distros_conf_path
+        tdx_distro_pairs
+        _tdx_dispatch
+        _tdx_run_dispatch
+        tdx_compute_oeroot
+        tdx_set_builddir
+        tdx_set_builddir_from_cwd
+        tdx_vendor_for_machine
+        tdx_distro_policy_for_machine
+        tdx_apply_distro_policy
+        tdx_menu_pairs
+        tdx_usage
+        tdx_setup_path
+        tdx_dedupe_sort
+        tdx_setup_bb_env_passthrough
+        tdx_native_conf_is_current
+        tdx_write_checksum
+        tdx_conf_from_template
+        tdx_write_auto_conf
+        tdx_write_site_conf
+        tdx_is_integration_build
+        tdx_apply_integration_override
+        tdx_needs_once
+        tdx_append_once
+        tdx_license_flag_accept
+        tdx_eula_prompt
+        tdx_append_license_flags
+        tdx_print_banner
+        tdx_cleanup_internal_state
+    )
+    local v f
+
+    for v in "${_TDX_EXTRA_CLEANUP_VARS[@]:-}"; do
+        [ -n "${v}" ] && unset -v "${v}" 2>/dev/null
+    done
+    for f in "${_TDX_EXTRA_CLEANUP_FUNCS[@]:-}"; do
+        [ -n "${f}" ] && unset -f "${f}" 2>/dev/null
+    done
+    unset -v _TDX_EXTRA_CLEANUP_VARS _TDX_EXTRA_CLEANUP_FUNCS 2>/dev/null
+
+    for v in "${allow_vars[@]}"; do
+        unset -v "${v}" 2>/dev/null
+    done
+    for f in "${allow_funcs[@]}"; do
+        unset -f "${f}" 2>/dev/null
+    done
+}

--- a/scripts/lib/distros.conf
+++ b/scripts/lib/distros.conf
@@ -1,0 +1,9 @@
+# distros.conf - top-level DISTRO menu entries, read by core.sh's
+# tdx_distro_pairs. Whitespace-delimited (aligned like machines.conf): the
+# first word is the DISTRO id, everything after it is the description -
+# any amount of column-alignment padding between them is fine. Blank lines
+# and lines starting with '#' are ignored.
+torizon                     (for Toradex devices)
+common-torizon              (for 3rd party devices)
+common-torizon-xenomai3     (for intel-corei7-64)
+common-torizon-xenomai4     (for intel-corei7-64)

--- a/scripts/lib/machines.conf
+++ b/scripts/lib/machines.conf
@@ -1,0 +1,61 @@
+# machines.conf - data-driven MACHINE -> VENDOR table for scripts/setup-environment
+#
+# Format (whitespace-delimited, 4 columns):
+#
+#   MACHINE  VENDOR  BSP_DISPLAY  DISTRO_POLICY
+#
+#   MACHINE        the value the user sets/selects as $MACHINE
+#   VENDOR         selects which scripts/lib/setup-devices/setup-environment-<VENDOR>
+#                  script the dispatcher sources for this machine
+#   BSP_DISPLAY    free-form text shown next to MACHINE in the interactive
+#                  whiptail/dialog menu (must not contain whitespace)
+#   DISTRO_POLICY  how the dispatcher treats $DISTRO for this machine before
+#                  handing off to the vendor script:
+#                    -            leave DISTRO alone, the vendor script decides
+#                    =<value>     force DISTRO to <value> unconditionally
+#                    ?<value>     default DISTRO to <value> only if unset
+#
+# Blank lines and lines starting with '#' (after optional leading whitespace)
+# are ignored. Adding a MACHINE is a one-line change here; adding a new
+# vendor is one block of lines here plus one new setup-environment-<vendor>
+# script, with zero changes required in scripts/setup-environment itself.
+
+# --- Toradex machines (native family; the vendor script itself picks
+#     between torizon/torizon-upstream, so policy is always "-") ---
+apalis-imx6                    toradex   meta-freescale-3rdparty          -
+apalis-imx8                    toradex   meta-toradex-nxp                 -
+aquila-am69                    toradex   meta-toradex-ti                  -
+aquila-imx95                   toradex   meta-toradex-nxp                 -
+colibri-imx6                   toradex   meta-freescale-3rdparty          -
+colibri-imx6ull-emmc           toradex   meta-toradex-nxp                 -
+colibri-imx7-emmc              toradex   meta-freescale-3rdparty          -
+colibri-imx8x                  toradex   meta-toradex-nxp                 -
+genericx86-64                  toradex   meta-yocto/meta-yocto-bsp        -
+lino-imx93                     toradex   meta-toradex-nxp                 -
+qemuarm64                      toradex   openembedded-core/meta           -
+toradex-osm-imx93              toradex   meta-toradex-nxp                 -
+toradex-smarc-imx8mp           toradex   meta-toradex-nxp                 -
+toradex-smarc-imx95            toradex   meta-toradex-nxp                 -
+verdin-am62                    toradex   meta-toradex-ti                  -
+verdin-am62p                   toradex   meta-toradex-ti                  -
+verdin-imx8mm                  toradex   meta-toradex-nxp                 -
+verdin-imx8mp                  toradex   meta-toradex-nxp                 -
+verdin-imx95                   toradex   meta-toradex-nxp                 -
+
+# --- Common Torizon (3rd party) machines ---
+am62lxx-evm                    ti        meta-ti-bsp                      =common-torizon
+am62pxx-evm                    ti        meta-ti-bsp                      =common-torizon
+am62xx-evm                     ti        meta-ti-bsp                      =common-torizon
+beagley-ai                     ti        meta-beagle                      =common-torizon
+imx93frdm                      imx       meta-imx-frdm/meta-imx-bsp       =common-torizon
+imx95-19x19-verdin             imx       meta-imx                         =common-torizon
+intel-corei7-64                intel     meta-intel                       ?common-torizon
+jetson-orin-nano-devkit        nvidia    meta-tegra                       =common-torizon
+jetson-orin-nano-devkit-nvme   nvidia    meta-tegra                       =common-torizon
+sl1680                         synaptics meta-synaptics                   =common-torizon
+sl2619                         synaptics meta-synaptics                   =common-torizon
+luna-sl1680                    synaptics meta-synaptics                   =common-torizon
+smarc-rzv2l                    renesas   rz-community-bsp                 =common-torizon
+stm32mp15-disco                stm32mp   meta-st-stm32mp                  =common-torizon
+stm32mp25-disco                stm32mp   meta-st-stm32mp                  =common-torizon
+stm32mp25-eval                 stm32mp   meta-st-stm32mp                  =common-torizon

--- a/scripts/lib/setup-devices/setup-environment-TEMPLATE
+++ b/scripts/lib/setup-devices/setup-environment-TEMPLATE
@@ -1,0 +1,96 @@
+#!/bin/bash
+# -*- mode: shell-script-mode; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+#
+# Copyright (C) 2012-13 O.S. Systems Software LTDA.
+# Copyright (C) 2017 Open Source Foundries Ltd.
+# Copyright (C) 2020-2026 Toradex AG
+# Authored-by:  Otavio Salvador <otavio@ossystems.com.br>
+# Adopted to Angstrom:  Khem Raj <raj.khem@gmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# TEMPLATE for a new scripts/lib/setup-devices/setup-environment-<vendor>
+# script. To add a real vendor:
+#   1. Copy this file to setup-environment-<vendor> and fill in every TODO.
+#   2. Add a MACHINE/VENDOR/BSP_DISPLAY/DISTRO_POLICY row (or block of rows)
+#      for <vendor> to scripts/lib/machines.conf.
+# No changes to scripts/setup-environment or core.sh are needed - the
+# dispatcher sources setup-environment-${VENDOR} purely by reading the
+# machines.conf row, and every helper this file calls already exists in
+# scripts/lib/core.sh.
+#
+# This walkthrough covers the "native family" shape: the vendor script
+# resolves/creates its own BUILDDIR directly and builds conf/local.conf and
+# conf/bblayers.conf itself (see setup-environment-toradex/-nvidia/-stm32mp
+# for real, complete examples of this shape).
+#
+# If your vendor instead ships its own env-setup tooling (something like
+# poky's oe-init-build-env, or a vendor-specific setup script that you
+# `source` to get an initial conf/local.conf + conf/bblayers.conf) you want
+# the "delegating family" shape instead - that pattern varies too much
+# per-vendor to usefully templatize generically. Read one of
+# setup-environment-ti/-intel/-imx/-synaptics instead: the common thread is
+# (a) `source` the vendor's own setup tooling first, (b) immediately call
+# `tdx_set_builddir_from_cwd` (it already `cd`'d you into the build dir),
+# then (c) use `tdx_needs_once`/`tdx_append_once`/`tdx_apply_integration_override`
+# exactly as shown below to patch the vendor-generated conf files.
+
+# TODO: SDKMACHINE default, if this vendor needs one (some don't - see
+# setup-environment-ti, which never sets one).
+[ -z "${SDKMACHINE}" ] && SDKMACHINE='x86_64'
+
+# 1. Resolve/create BUILDDIR.
+# 1.1 If this vendor uses a custom setup-script, like Synaptics, source it here and call
+# tdx_set_builddir_from_cwd. See setup-environment-ti/-intel/-imx/-synaptics for examples.
+#
+# source <path/to>/setup-script "${1:-build-$DISTRO}" >/dev/null 2>&1
+# tdx_set_builddir_from_cwd
+#
+# 1.2 If not, use tdx_set_builddir to resolve/create the build dir yourself, then rebuild
+# PATH and BB_ENV_PASSTHROUGH_ADDITIONS.
+tdx_set_builddir "${1:-}" "${DISTRO}" || return 1
+tdx_setup_path
+tdx_setup_bb_env_passthrough   # TODO: pass any vendor-specific extra var names here, e.g.
+                               # tdx_setup_bb_env_passthrough MY_VENDOR_VAR ANOTHER_VAR
+
+# 2. Early-return if MACHINE/DISTRO/(EULA)/this script's own checksum are
+#    all unchanged since the last run. Pass a conf-var name here ONLY if
+# this vendor has a real EULA that gets written to conf/local.conf (see
+# stm32mp's "ACCEPT_EULA_${MACHINE}"); omit the argument entirely if not
+# (see nvidia, which has none).
+tdx_native_conf_is_current && return 0   # TODO: add eula-conf-var arg if applicable
+
+tdx_write_checksum "${_TDX_SCRIPTS}/lib/setup-devices/setup-environment-<vendor>"   # TODO: <vendor>
+
+# 3. Seed conf/local.conf from the shared template.
+tdx_conf_from_template local.conf
+
+# TODO: add any vendor-specific bblayers.conf seeding here. Use tdx_append_once to
+# add the vendor's BSP layer(s) to conf/bblayers.conf, e.g.:
+#   tdx_append_once conf/bblayers.conf "# Torizon" <<EOF
+#   # Torizon
+#   ... vendor-specific BBLAYERS ...
+#   EOF
+
+# 4. Symlink in the .repo manifest README (native-family convention).
+ln -sf "${_TDX_MANIFESTS}/README.md" README.md
+ln -sf "${_TDX_MANIFESTS}" "${_TDX_OEROOT}/layers/"
+
+# 5. Write conf/auto.conf (DISTRO/MACHINE/SDKMACHINE + INHERIT), then apply
+#    the integration-build override if this checkout is on an
+#    integration/next manifest.
+tdx_write_auto_conf "${DISTRO}" "${MACHINE}" "${SDKMACHINE}" "rm_work cyclonedx-export"   # TODO: inherit list
+tdx_apply_integration_override conf/auto.conf
+
+# 6. Write conf/site.conf (DL_DIR/SSTATE_DIR/TMPDIR/DEPLOY_DIR).
+tdx_write_site_conf "${_TDX_OEROOT}" "${_TDX_BUILDDIR}"
+
+# 7. TODO: if this vendor has a real EULA that needs user acceptance, prompt
+#    for it here (see setup-environment-stm32mp).
+#    If this vendor has NO EULA at all, delete this step entirely:
+#      tdx_eula_prompt <ACCEPT_CONF_VAR> "<path-to-EULA-file>" "<label>"
+
+# 8. Welcome banner. First arg is the title text ("Torizon OS" for
+#    genuine Toradex hardware, "Common Torizon OS" for everything else);
+#    second arg is whether to print the SDKMACHINE line.
+tdx_print_banner "Common Torizon OS" yes   # TODO: title, and yes/no for SDKMACHINE line

--- a/scripts/lib/setup-devices/setup-environment-imx
+++ b/scripts/lib/setup-devices/setup-environment-imx
@@ -40,10 +40,37 @@ INHERIT += "rm_work"
 # Torizon
 include conf/machine/include/\${MACHINE}.inc
 EOF
+
+fi
+
+_TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifest.xml
+_TDX_INTEGRATION_BUILD=0
+if [ -L "$_TDX_MANIFEST_FILE" ]; then
+  case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
+    integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
+  esac
+elif [ -f "$_TDX_MANIFEST_FILE" ]; then
+  if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
+    _TDX_INTEGRATION_BUILD=1
+  fi
+fi
+
+# When building on integration, ensure use-head-next is set so you always get
+# the newest software (u-boot, kernel, aktualizr-torizon, etc). Idempotent, so
+# it also applies when local.conf already existed from a previous run.
+if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
+   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/local.conf; then
+  cat <<EOF >>conf/local.conf
+
+# This is needed when building on integration. With use-head-next you
+# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
+# Building on integration without use-head-next your build may fail.
+DISTROOVERRIDES .= ":use-head-next"
+EOF
 fi
 
 
-if ! grep -q "# Torizon" conf/bblayers.conf; then 
+if ! grep -q "# Torizon" conf/bblayers.conf; then
   cat <<EOF >>conf/bblayers.conf
 # Torizon
 BBLAYERS += "\${BSPDIR}/sources/meta-toradex-torizon"

--- a/scripts/lib/setup-devices/setup-environment-imx
+++ b/scripts/lib/setup-devices/setup-environment-imx
@@ -1,37 +1,64 @@
 #!/bin/bash
+# -*- mode: shell-script-mode; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+#
+# Copyright (C) 2012-13 O.S. Systems Software LTDA.
+# Copyright (C) 2017 Open Source Foundries Ltd.
+# Copyright (C) 2020-2026 Toradex AG
+# Authored-by:  Otavio Salvador <otavio@ossystems.com.br>
+# Adopted to Angstrom:  Khem Raj <raj.khem@gmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
 
 # avoiding 'imx-setup-release' clean-up routine
 _TDX_MACHINE="${MACHINE}"
-_TDX_DISTRO="${_TDX_DISTRO_SELECT}"
+# Use the real, policy-resolved $DISTRO (set by the dispatcher's
+# tdx_apply_distro_policy) rather than the stale _TDX_DISTRO_SELECT, which is
+# only the user's raw pre-policy input and is never updated afterward.
+_TDX_DISTRO="${DISTRO}"
+# This script is sourced at top level (no function scope for `local`), so
+# register these one-off bookkeeping variables with core.sh's cleanup sweep
+# instead of leaving them to leak into the user's shell.
+_TDX_EXTRA_CLEANUP_VARS+=("_TDX_MACHINE" "_TDX_DISTRO" "_IMX_SETUP_SCRIPT")
 
 if [ "${_TDX_MACHINE}" = "imx93frdm" ]; then
     _IMX_SETUP_SCRIPT=imx-frdm-setup.sh
 else
     _IMX_SETUP_SCRIPT=imx-setup-release.sh
 fi
-source ${_IMX_SETUP_SCRIPT} -b "${1:-build-$_TDX_DISTRO}"
 
-if ! grep -q "# Torizon" conf/local.conf; then
+# imx-setup-release.sh/imx-frdm-setup.sh read the real $DISTRO env var to
+# derive their own FSLDISTRO and enforce a Wayland-only machine check that
+# fails outright for our "common-torizon" value.
+# Unset DISTRO before sourcing so NXP's own tooling falls back
+# to its own default, then restore the effective value afterward so the
+# user's shell/bitbake invocations see the correct DISTRO once this script
+# returns.
+unset DISTRO
+source "${_IMX_SETUP_SCRIPT}" -b "${1:-build-$_TDX_DISTRO}"
+export DISTRO="${_TDX_DISTRO}"
+
+tdx_set_builddir_from_cwd
+
+if tdx_needs_once conf/local.conf; then
   sed -i "/^DISTRO .*/c\DISTRO ?= '${_TDX_DISTRO}'" conf/local.conf
 
   sed -i "/^PACKAGE_CLASSES .*/c\# PACKAGE_CLASSES = \"package_deb\"" conf/local.conf
   sed -i "/^EXTRA_IMAGE_FEATURES += \"package-management\"/c\# EXTRA_IMAGE_FEATURES += \"package-management\"" conf/local.conf
 
-  _TDX_OEROOT=$(dirname "$(pwd)")
-  _TDX_BUILDDIR=$(pwd)
-  cat <<EOF >>conf/local.conf
+  tdx_append_once conf/local.conf "# Torizon" <<EOF
 # Where to store sources
-DL_DIR ?= "${_TDX_OEROOT}/downloads"
+DL_DIR ?= "\${BSPDIR}/downloads"
 
 # Where to save shared state
-SSTATE_DIR ?= "${_TDX_OEROOT}/sstate-cache"
+SSTATE_DIR ?= "\${BSPDIR}/sstate-cache"
 BB_HASHSERVE_DB_DIR ?= "\${SSTATE_DIR}"
 
 # Where to save the build system work output
-TMPDIR = "${_TDX_BUILDDIR}/tmp"
+TMPDIR = "\${BSPDIR}/tmp"
 
 # Where to save the packages and images
-TI_COMMON_DEPLOY = "${_TDX_BUILDDIR}/deploy"
+TI_COMMON_DEPLOY = "\${BSPDIR}/deploy"
 DEPLOY_DIR = "\${TI_COMMON_DEPLOY}\${@'' if d.getVar('BB_CURRENT_MC') == 'default' else '/\${BB_CURRENT_MC}'}"
 
 # ease up disk space requirements
@@ -43,62 +70,18 @@ EOF
 
 fi
 
-_TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifest.xml
-_TDX_INTEGRATION_BUILD=0
-if [ -L "$_TDX_MANIFEST_FILE" ]; then
-  case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
-    integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
-  esac
-elif [ -f "$_TDX_MANIFEST_FILE" ]; then
-  if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
-    _TDX_INTEGRATION_BUILD=1
-  fi
-fi
+# When building on integration, ensure use-head-next is set.
+tdx_apply_integration_override conf/local.conf
 
-# When building on integration, ensure use-head-next is set so you always get
-# the newest software (u-boot, kernel, aktualizr-torizon, etc). Idempotent, so
-# it also applies when local.conf already existed from a previous run.
-if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
-   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/local.conf; then
-  cat <<EOF >>conf/local.conf
-
-# This is needed when building on integration. With use-head-next you
-# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
-# Building on integration without use-head-next your build may fail.
-DISTROOVERRIDES .= ":use-head-next"
-EOF
-fi
-
-
-if ! grep -q "# Torizon" conf/bblayers.conf; then
-  cat <<EOF >>conf/bblayers.conf
+tdx_append_once conf/bblayers.conf "# Torizon" <<EOF
 # Torizon
 BBLAYERS += "\${BSPDIR}/sources/meta-toradex-torizon"
 BBLAYERS += "\${BSPDIR}/sources/meta-updater"
 
 OEROOT := "\${@os.path.abspath(os.path.dirname(d.getVar('FILE', True)))}/../.."
 EOF
-fi
 
-cat <<EOF
-
-Welcome to Common Torizon OS
-
-For more information about OpenEmbedded see their website:
-
-    http://www.openembedded.org/
-
-Your build environment has been configured with:
-
-    MACHINE = ${_TDX_MACHINE}
-    DISTRO = ${_TDX_DISTRO}
-
-You can now run 'bitbake <target>'
-
-Some of common targets are:
-
-    torizon-docker
-    torizon-minimal
-    torizon-podman
-
-EOF
+# The banner uses the captured _TDX_MACHINE/_TDX_DISTRO (not $MACHINE/$DISTRO
+# directly), since imx-setup-release.sh/imx-frdm-setup.sh mutate MACHINE as
+# part of their own cleanup routine.
+MACHINE="${_TDX_MACHINE}" DISTRO="${_TDX_DISTRO}" tdx_print_banner "Common Torizon OS" no

--- a/scripts/lib/setup-devices/setup-environment-intel
+++ b/scripts/lib/setup-devices/setup-environment-intel
@@ -32,7 +32,35 @@ INHERIT += "rm_work"
 # Torizon
 include conf/machine/include/\${MACHINE}.inc
 EOF
+
 fi
+
+_TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifest.xml
+_TDX_INTEGRATION_BUILD=0
+if [ -L "$_TDX_MANIFEST_FILE" ]; then
+  case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
+    integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
+  esac
+elif [ -f "$_TDX_MANIFEST_FILE" ]; then
+  if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
+    _TDX_INTEGRATION_BUILD=1
+  fi
+fi
+
+# When building on integration, ensure use-head-next is set so you always get
+# the newest software (u-boot, kernel, aktualizr-torizon, etc). Idempotent, so
+# it also applies when local.conf already existed from a previous run.
+if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
+   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/local.conf; then
+  cat <<EOF >>conf/local.conf
+
+# This is needed when building on integration. With use-head-next you
+# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
+# Building on integration without use-head-next your build may fail.
+DISTROOVERRIDES .= ":use-head-next"
+EOF
+fi
+
 
 if ! grep -q "# Torizon" conf/bblayers.conf; then
   cat <<EOF >>conf/bblayers.conf

--- a/scripts/lib/setup-devices/setup-environment-intel
+++ b/scripts/lib/setup-devices/setup-environment-intel
@@ -1,14 +1,23 @@
 #!/bin/bash
+# -*- mode: shell-script-mode; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+#
+# Copyright (C) 2012-13 O.S. Systems Software LTDA.
+# Copyright (C) 2017 Open Source Foundries Ltd.
+# Copyright (C) 2020-2026 Toradex AG
+# Authored-by:  Otavio Salvador <otavio@ossystems.com.br>
+# Adopted to Angstrom:  Khem Raj <raj.khem@gmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
 
 source ${_TDX_LAYERS_DIR}/poky/oe-init-build-env "${1:-build-$DISTRO}"
+tdx_set_builddir_from_cwd
 
-if ! grep -q "# Torizon" conf/local.conf; then
+if tdx_needs_once conf/local.conf; then
   sed -i "/^MACHINE .*/c\MACHINE ?= '$MACHINE'" conf/local.conf
   sed -i "/^DISTRO .*/c\DISTRO ?= '$DISTRO'" conf/local.conf
 
-  _TDX_OEROOT=$(dirname "$(pwd)")
-  _TDX_BUILDDIR=$(pwd)
-  cat <<EOF >>conf/local.conf
+  tdx_append_once conf/local.conf "# Torizon" <<EOF
 # Where to store sources
 DL_DIR ?= "${_TDX_OEROOT}/downloads"
 
@@ -23,9 +32,6 @@ TMPDIR = "${_TDX_BUILDDIR}/tmp"
 TI_COMMON_DEPLOY = "${_TDX_BUILDDIR}/deploy"
 DEPLOY_DIR = "\${TI_COMMON_DEPLOY}\${@'' if d.getVar('BB_CURRENT_MC') == 'default' else '/\${BB_CURRENT_MC}'}"
 
-# Accept Synaptics FW license
-LICENSE_FLAGS_ACCEPTED = "synaptics-killswitch"
-
 # ease up disk space requirements
 INHERIT += "rm_work"
 
@@ -33,37 +39,14 @@ INHERIT += "rm_work"
 include conf/machine/include/\${MACHINE}.inc
 EOF
 
+  tdx_append_license_flags conf/local.conf synaptics-killswitch
+
 fi
 
-_TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifest.xml
-_TDX_INTEGRATION_BUILD=0
-if [ -L "$_TDX_MANIFEST_FILE" ]; then
-  case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
-    integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
-  esac
-elif [ -f "$_TDX_MANIFEST_FILE" ]; then
-  if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
-    _TDX_INTEGRATION_BUILD=1
-  fi
-fi
+# When building on integration, ensure use-head-next is set.
+tdx_apply_integration_override conf/local.conf
 
-# When building on integration, ensure use-head-next is set so you always get
-# the newest software (u-boot, kernel, aktualizr-torizon, etc). Idempotent, so
-# it also applies when local.conf already existed from a previous run.
-if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
-   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/local.conf; then
-  cat <<EOF >>conf/local.conf
-
-# This is needed when building on integration. With use-head-next you
-# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
-# Building on integration without use-head-next your build may fail.
-DISTROOVERRIDES .= ":use-head-next"
-EOF
-fi
-
-
-if ! grep -q "# Torizon" conf/bblayers.conf; then
-  cat <<EOF >>conf/bblayers.conf
+tdx_append_once conf/bblayers.conf "# Torizon" <<EOF
 OEROOT := "\${@os.path.abspath(os.path.dirname(d.getVar('FILE', True)))}/../.."
 
 # Intel
@@ -79,27 +62,5 @@ BBLAYERS += "\${OEROOT}/layers/meta-openembedded/meta-python"
 BBLAYERS += "\${OEROOT}/layers/meta-openembedded/meta-oe"
 BBLAYERS += "\${OEROOT}/layers/meta-openembedded/meta-networking"
 EOF
-fi
 
-cat <<EOF
-
-Welcome to Common Torizon OS
-
-For more information about OpenEmbedded see their website:
-
-    http://www.openembedded.org/
-
-Your build environment has been configured with:
-
-    MACHINE = ${MACHINE}
-    DISTRO = ${DISTRO}
-
-You can now run 'bitbake <target>'
-
-Some of common targets are:
-
-    torizon-docker
-    torizon-minimal
-    torizon-podman
-
-EOF
+tdx_print_banner "Common Torizon OS" no

--- a/scripts/lib/setup-devices/setup-environment-nvidia
+++ b/scripts/lib/setup-devices/setup-environment-nvidia
@@ -146,6 +146,22 @@ BBLAYERS = " \\
 EOF
 fi
 
+_TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifest.xml
+if [ ! -e "$_TDX_MANIFEST_FILE" ]; then
+    _TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifests/manifest.xml
+fi
+_TDX_INTEGRATION_BUILD=0
+
+if [ -L "$_TDX_MANIFEST_FILE" ]; then
+    case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
+        integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
+    esac
+elif [ -f "$_TDX_MANIFEST_FILE" ]; then
+    if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
+        _TDX_INTEGRATION_BUILD=1
+    fi
+fi
+
 if [ "$_TDX_AUTO_CONF_CREATED" = "0" ]; then
     cat >> conf/auto.conf <<EOF
 DISTRO ?= "${DISTRO}"
@@ -159,6 +175,21 @@ else
     sed -i "s/^DISTRO ?= \"[^\"]*\"$/DISTRO ?= \"${DISTRO}\"/" conf/auto.conf
     sed -i "s/^MACHINE ?= \"[^\"]*\"$/MACHINE ?= \"${MACHINE}\"/" conf/auto.conf
     sed -i "s/^SDKMACHINE ?= \"[^\"]*\"$/SDKMACHINE ?= \"${SDKMACHINE}\"/" conf/auto.conf
+fi
+
+# When building on integration (integration.xml/next.xml), ensure use-head-next
+# is set so you always get the newest software (u-boot, kernel,
+# aktualizr-torizon, etc). Prepended to the top of auto.conf, and applied even
+# when auto.conf already existed from a previous run.
+if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
+   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/auto.conf; then
+    cat <<EOF >>conf/auto.conf
+
+# This is needed when building on integration. With use-head-next you
+# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
+# Building on integration without use-head-next your build may fail.
+DISTROOVERRIDES .= ":use-head-next"
+EOF
 fi
 
 cat > conf/site.conf <<_EOF

--- a/scripts/lib/setup-devices/setup-environment-nvidia
+++ b/scripts/lib/setup-devices/setup-environment-nvidia
@@ -3,107 +3,29 @@
 #
 # Copyright (C) 2012-13 O.S. Systems Software LTDA.
 # Copyright (C) 2017 Open Source Foundries Ltd.
+# Copyright (C) 2020-2026 Toradex AG
 # Authored-by:  Otavio Salvador <otavio@ossystems.com.br>
 # Adopted to Angstrom:  Khem Raj <raj.khem@gmail.com>
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# SPDX-License-Identifier: GPL-2.0-only
 #
 
-_TDX_OEROOT=$(pwd)
-cd "$_TDX_OEROOT"
-if [ -n "$ZSH_VERSION" ]; then
-    setopt sh_word_split
-    setopt clobber
-elif [ -n "$BASH_VERSION" ]; then
-    set +o noclobber
-fi
+[ -z "${SDKMACHINE}" ] && SDKMACHINE='x86_64'
 
-if [ -z "${SDKMACHINE}" ]; then
-    SDKMACHINE='x86_64'
-fi
+# resolve/export BUILDDIR ourselves, then rebuild PATH and
+# BB_ENV_PASSTHROUGH_ADDITIONS.
+tdx_set_builddir "${1:-}" "${DISTRO}" || return 1
+tdx_setup_path
+tdx_setup_bb_env_passthrough
 
-_TDX_MANIFESTS="${_TDX_OEROOT}"/.repo/manifests
-_TDX_SCRIPTS="${_TDX_OEROOT}"/layers/meta-toradex-torizon/scripts
+# Early-return if MACHINE/DISTRO/script-checksum are all unchanged.
+tdx_native_conf_is_current && return 0
 
-# We can be called with only 1 parameter max (build folder)
-_TDX_BUILDDIR=${1:-build-$DISTRO}
-# If current BUILDDIR is relative then prepend OEROOT
-case ${_TDX_BUILDDIR} in
-    /* ) ;;
-    *  ) _TDX_BUILDDIR=$(readlink -f ${_TDX_BUILDDIR});;
-esac
-# Get rid of double slash. sed calls in OE staging_processfixme
-# seems to have troubles if this makes it into OE variables.
-_TDX_BUILDDIR=${_TDX_BUILDDIR%%/}
+tdx_write_checksum "${_TDX_SCRIPTS}/lib/setup-devices/setup-environment-nvidia"
 
-# Set BBPATH for recipetool
-BBPATH=${_TDX_BUILDDIR}
+tdx_conf_from_template local.conf
 
-# Clean up PATH, because if it includes tokens to current directories somehow,
-# wrong binaries can be used instead of the expected ones during task execution
-PATH=$(echo "${PATH}" | sed 's/\(:.\|:\)*:/:/g;s/^.\?://;s/:.\?$//')
-PATH="${_TDX_OEROOT}/bitbake/bin:${_TDX_OEROOT}/.repo/repo:${PATH}"
-PATH="${_TDX_OEROOT}/layers/openembedded-core/bitbake/bin:${PATH}"
-PATH="${_TDX_OEROOT}/layers/openembedded-core/scripts:${PATH}"
-# Remove duplicate path entries
-PATH=$(echo "$PATH" |
-       awk -F: '{for (i=1;i<=NF;i++) { if ( !x[$i]++ ) printf("%s:",$i); }}' |
-       sed 's/:$//')
-
-BB_ENV_PASSTHROUGH_ADDITIONS_OE="MACHINE DISTRO TCMODE TCLIBC HTTP_PROXY http_proxy \
-HTTPS_PROXY https_proxy FTP_PROXY ftp_proxy FTPS_PROXY ftps_proxy ALL_PROXY \
-all_proxy NO_PROXY no_proxy SSH_AGENT_PID SSH_AUTH_SOCK BB_SRCREV_POLICY \
-SDKMACHINE BB_NUMBER_THREADS BB_NO_NETWORK PARALLEL_MAKE GIT_PROXY_COMMAND \
-SOCKS5_PASSWD SOCKS5_USER SCREENDIR STAMPS_DIR BBPATH_EXTRA BB_SETSCENE_ENFORCE"
-
-BB_ENV_PASSTHROUGH_ADDITIONS="$(echo $BB_ENV_PASSTHROUGH_ADDITIONS $BB_ENV_PASSTHROUGH_ADDITIONS_OE | tr ' ' '\n' | LC_ALL=C sort --unique | tr '\n' ' ')"
-
-export PATH
-export _TDX_BUILDDIR
-export BBPATH
-export BB_ENV_PASSTHROUGH_ADDITIONS
-
-_TDX_AUTO_CONF_CREATED=0
-mkdir -p "${_TDX_BUILDDIR}"/conf && cd "${_TDX_BUILDDIR}"
-if [ -f "conf/auto.conf" ]; then
-    oldmach=$(egrep "^MACHINE \?=" "conf/auto.conf" |
-             sed -e 's%^MACHINE ?= %%' | sed -e 's/^"//' -e 's/"$//')
-    olddisto=$(egrep "^DISTRO \?=" "conf/auto.conf" |
-             sed -e 's%^DISTRO ?= %%' | sed -e 's/^"//' -e 's/"$//')
-    eulaacpt=$(egrep "^\s*ACCEPT_EULA_${MACHINE}\s*=\s*\".*\"" conf/local.conf |
-             sed -e "s%^\s*ACCEPT_EULA_${MACHINE}\s*=\s*%%" | sed -e 's/^"//' -e 's/"$//')
-
-    _TDX_AUTO_CONF_CREATED=1
-fi
-
-if [ -e conf/checksum -a "${MACHINE}" = "$oldmach" -a "${DISTRO}" = "$olddisto" -a "${EULA}" = "$eulaacpt" ]; then
-    if sha512sum --quiet -c conf/checksum >/dev/null 2>&1; then
-        return 0
-    fi
-fi
-
-# Evaluate new checksum and regenerate the conf files
-sha512sum "${_TDX_SCRIPTS}"/lib/setup-devices/setup-environment-nvidia 2>&1 > conf/checksum
-
-if [ ! -f "conf/local.conf" ]; then
-    cp "${_TDX_SCRIPTS}"/../conf/template/local.conf conf/local.conf
-fi
-ln -sf "${_TDX_MANIFESTS}"/README.md README.md
-ln -sf "${_TDX_MANIFESTS}" "${_TDX_OEROOT}"/layers/
-
-if [ ! -f "conf/bblayers.conf" ]; then
-    cat > conf/bblayers.conf <<EOF
+tdx_append_once conf/bblayers.conf "# Torizon" <<EOF
 # Torizon
 # LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
 # changes incompatibly
@@ -144,95 +66,13 @@ BBLAYERS = " \\
   \${OEROOT}/layers/openembedded-core/meta \\
 "
 EOF
-fi
 
-_TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifest.xml
-if [ ! -e "$_TDX_MANIFEST_FILE" ]; then
-    _TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifests/manifest.xml
-fi
-_TDX_INTEGRATION_BUILD=0
+ln -sf "${_TDX_MANIFESTS}/README.md" README.md
+ln -sf "${_TDX_MANIFESTS}" "${_TDX_OEROOT}/layers/"
 
-if [ -L "$_TDX_MANIFEST_FILE" ]; then
-    case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
-        integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
-    esac
-elif [ -f "$_TDX_MANIFEST_FILE" ]; then
-    if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
-        _TDX_INTEGRATION_BUILD=1
-    fi
-fi
+tdx_write_auto_conf "${DISTRO}" "${MACHINE}" "${SDKMACHINE}" "rm_work cyclonedx-export"
+tdx_apply_integration_override conf/auto.conf
 
-if [ "$_TDX_AUTO_CONF_CREATED" = "0" ]; then
-    cat >> conf/auto.conf <<EOF
-DISTRO ?= "${DISTRO}"
-MACHINE ?= "${MACHINE}"
-SDKMACHINE ?= "${SDKMACHINE}"
+tdx_write_site_conf "${_TDX_OEROOT}" "${_TDX_BUILDDIR}"
 
-# Extra options that can be changed by the user
-INHERIT += "rm_work"
-EOF
-else
-    sed -i "s/^DISTRO ?= \"[^\"]*\"$/DISTRO ?= \"${DISTRO}\"/" conf/auto.conf
-    sed -i "s/^MACHINE ?= \"[^\"]*\"$/MACHINE ?= \"${MACHINE}\"/" conf/auto.conf
-    sed -i "s/^SDKMACHINE ?= \"[^\"]*\"$/SDKMACHINE ?= \"${SDKMACHINE}\"/" conf/auto.conf
-fi
-
-# When building on integration (integration.xml/next.xml), ensure use-head-next
-# is set so you always get the newest software (u-boot, kernel,
-# aktualizr-torizon, etc). Prepended to the top of auto.conf, and applied even
-# when auto.conf already existed from a previous run.
-if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
-   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/auto.conf; then
-    cat <<EOF >>conf/auto.conf
-
-# This is needed when building on integration. With use-head-next you
-# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
-# Building on integration without use-head-next your build may fail.
-DISTROOVERRIDES .= ":use-head-next"
-EOF
-fi
-
-cat > conf/site.conf <<_EOF
-SCONF_VERSION = "1"
-
-# Where to store sources
-DL_DIR ?= "${_TDX_OEROOT}/downloads"
-
-# Where to save shared state
-SSTATE_DIR ?= "${_TDX_OEROOT}/sstate-cache"
-BB_HASHSERVE_DB_DIR ?= "\${SSTATE_DIR}"
-
-# Where to save the build system work output
-TMPDIR = "${_TDX_BUILDDIR}/tmp"
-
-# Where to save the packages and images
-_COMMON_DEPLOY = "${_TDX_BUILDDIR}/deploy"
-DEPLOY_DIR = "\${_COMMON_DEPLOY}\${@'' if d.getVar('BB_CURRENT_MC') == 'default' else '/\${BB_CURRENT_MC}'}"
-
-# Go through the Firewall
-#HTTP_PROXY = "http://${PROXYHOST}:${PROXYPORT}/"
-_EOF
-
-cat <<EOF
-
-Welcome to Toradex Torizon OS
-
-For more information about OpenEmbedded see their website:
-
-    http://www.openembedded.org/
-
-Your build environment has been configured with:
-
-    MACHINE = ${MACHINE}
-    SDKMACHINE = ${SDKMACHINE}
-    DISTRO = ${DISTRO}
-
-You can now run 'bitbake <target>'
-
-Some of common targets are:
-
-    torizon-docker
-    torizon-minimal
-    torizon-podman
-
-EOF
+tdx_print_banner "Common Torizon OS" yes

--- a/scripts/lib/setup-devices/setup-environment-renesas
+++ b/scripts/lib/setup-devices/setup-environment-renesas
@@ -1,10 +1,24 @@
 #!/bin/bash
+# -*- mode: shell-script-mode; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+#
+# Copyright (C) 2012-13 O.S. Systems Software LTDA.
+# Copyright (C) 2017 Open Source Foundries Ltd.
+# Copyright (C) 2020-2026 Toradex AG
+# Authored-by:  Otavio Salvador <otavio@ossystems.com.br>
+# Adopted to Angstrom:  Khem Raj <raj.khem@gmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
 
-if ! grep -q "# Torizon" /build/conf/local.conf; then
+_TDX_BUILDDIR="/build"
+BUILDDIR="/build"
+export _TDX_BUILDDIR BUILDDIR
+
+if tdx_needs_once /build/conf/local.conf "# Torizon"; then
   sed -i "/^MACHINE .*/c\MACHINE = '$MACHINE'" /build/conf/local.conf
   sed -i "/^DISTRO .*/c\DISTRO = '$DISTRO'" /build/conf/local.conf
 
-  cat <<EOF >>/build/conf/local.conf
+  tdx_append_once /build/conf/local.conf "# Torizon" <<EOF
 # Where to store sources
 DL_DIR = "/build/downloads"
 
@@ -25,8 +39,7 @@ include conf/machine/include/\${MACHINE}.inc
 EOF
 fi
 
-if ! grep -q "# Torizon" /build/conf/bblayers.conf; then 
-  cat <<EOF >>/build/conf/bblayers.conf
+tdx_append_once /build/conf/bblayers.conf "# Torizon" <<EOF
 # Torizon
 BBLAYERS += "\${TOPDIR}/../work/meta-toradex-torizon"
 # Torizon deps
@@ -39,27 +52,5 @@ BBLAYERS += "\${TOPDIR}/../work/meta-openembedded/meta-networking"
 
 OEROOT := "\${@os.path.abspath(os.path.dirname(d.getVar('FILE', True)))}/../.."
 EOF
-fi
 
-cat <<EOF
-
-Welcome to Common Torizon OS
-
-For more information about OpenEmbedded see their website:
-
-    http://www.openembedded.org/
-
-Your build environment has been configured with:
-
-    MACHINE = ${MACHINE}
-    DISTRO = ${DISTRO}
-
-You can now run 'bitbake <target>'
-
-Some of common targets are:
-
-    torizon-docker
-    torizon-minimal
-    torizon-podman
-
-EOF
+tdx_print_banner "Common Torizon OS" no

--- a/scripts/lib/setup-devices/setup-environment-stm32mp
+++ b/scripts/lib/setup-devices/setup-environment-stm32mp
@@ -3,108 +3,29 @@
 #
 # Copyright (C) 2012-13 O.S. Systems Software LTDA.
 # Copyright (C) 2017 Open Source Foundries Ltd.
+# Copyright (C) 2020-2026 Toradex AG
 # Authored-by:  Otavio Salvador <otavio@ossystems.com.br>
 # Adopted to Angstrom:  Khem Raj <raj.khem@gmail.com>
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# SPDX-License-Identifier: GPL-2.0-only
 #
 
-_TDX_OEROOT=$(pwd)
-cd "$_TDX_OEROOT"
-if [ -n "$ZSH_VERSION" ]; then
-    setopt sh_word_split
-    setopt clobber
-elif [ -n "$BASH_VERSION" ]; then
-    set +o noclobber
-fi
+[ -z "${SDKMACHINE}" ] && SDKMACHINE='x86_64'
 
-if [ -z "${SDKMACHINE}" ]; then
-    SDKMACHINE='x86_64'
-fi
+# resolve/export BUILDDIR ourselves, then rebuild PATH and
+# BB_ENV_PASSTHROUGH_ADDITIONS.
+tdx_set_builddir "${1:-}" "${DISTRO}" || return 1
+tdx_setup_path
+tdx_setup_bb_env_passthrough
 
-_TDX_MANIFESTS="${_TDX_OEROOT}"/.repo/manifests
-_TDX_SCRIPTS="${_TDX_OEROOT}"/layers/meta-toradex-torizon/scripts
+# Early-return if MACHINE/DISTRO/EULA/script-checksum are all unchanged.
+tdx_native_conf_is_current "ACCEPT_EULA_${MACHINE}" && return 0
 
-# We can be called with only 1 parameter max (build folder)
-_TDX_BUILDDIR=${1:-build-$DISTRO}
-# If current BUILDDIR is relative then prepend OEROOT
-case ${_TDX_BUILDDIR} in
-    /* ) ;;
-    *  ) _TDX_BUILDDIR=$(readlink -f ${_TDX_BUILDDIR});;
-esac
-# Get rid of double slash. sed calls in OE staging_processfixme
-# seems to have troubles if this makes it into OE variables.
-_TDX_BUILDDIR=${_TDX_BUILDDIR%%/}
+tdx_write_checksum "${_TDX_SCRIPTS}/lib/setup-devices/setup-environment-stm32mp"
 
-# Set BBPATH for recipetool
-BBPATH=${_TDX_BUILDDIR}
+tdx_conf_from_template local.conf
 
-# Clean up PATH, because if it includes tokens to current directories somehow,
-# wrong binaries can be used instead of the expected ones during task execution
-PATH=$(echo "${PATH}" | sed 's/\(:.\|:\)*:/:/g;s/^.\?://;s/:.\?$//')
-PATH="${_TDX_OEROOT}/bitbake/bin:${_TDX_OEROOT}/.repo/repo:${PATH}"
-PATH="${_TDX_OEROOT}/layers/openembedded-core/bitbake/bin:${PATH}"
-PATH="${_TDX_OEROOT}/layers/openembedded-core/scripts:${PATH}"
-# Remove duplicate path entries
-PATH=$(echo "$PATH" |
-       awk -F: '{for (i=1;i<=NF;i++) { if ( !x[$i]++ ) printf("%s:",$i); }}' |
-       sed 's/:$//')
-
-BB_ENV_PASSTHROUGH_ADDITIONS_OE="MACHINE DISTRO TCMODE TCLIBC HTTP_PROXY http_proxy \
-HTTPS_PROXY https_proxy FTP_PROXY ftp_proxy FTPS_PROXY ftps_proxy ALL_PROXY \
-all_proxy NO_PROXY no_proxy SSH_AGENT_PID SSH_AUTH_SOCK BB_SRCREV_POLICY \
-SDKMACHINE BB_NUMBER_THREADS BB_NO_NETWORK PARALLEL_MAKE GIT_PROXY_COMMAND \
-SOCKS5_PASSWD SOCKS5_USER SCREENDIR STAMPS_DIR BBPATH_EXTRA BB_SETSCENE_ENFORCE"
-
-BB_ENV_PASSTHROUGH_ADDITIONS="$(echo $BB_ENV_PASSTHROUGH_ADDITIONS $BB_ENV_PASSTHROUGH_ADDITIONS_OE | tr ' ' '\n' | LC_ALL=C sort --unique | tr '\n' ' ')"
-
-export PATH
-export _TDX_BUILDDIR
-export BBPATH
-export BB_ENV_PASSTHROUGH_ADDITIONS
-
-_TDX_AUTO_CONF_CREATED=0
-mkdir -p "${_TDX_BUILDDIR}"/conf && cd "${_TDX_BUILDDIR}"
-if [ -f "conf/auto.conf" ]; then
-    oldmach=$(egrep "^MACHINE \?=" "conf/auto.conf" |
-             sed -e 's%^MACHINE ?= %%' | sed -e 's/^"//' -e 's/"$//')
-    olddisto=$(egrep "^DISTRO \?=" "conf/auto.conf" |
-             sed -e 's%^DISTRO ?= %%' | sed -e 's/^"//' -e 's/"$//')
-    eulaacpt=$(egrep "^\s*ACCEPT_EULA_${MACHINE}\s*=\s*\".*\"" conf/local.conf |
-             sed -e "s%^\s*ACCEPT_EULA_${MACHINE}\s*=\s*%%" | sed -e 's/^"//' -e 's/"$//')
-
-    _TDX_AUTO_CONF_CREATED=1
-fi
-
-if [ -e conf/checksum -a "${MACHINE}" = "$oldmach" -a "${DISTRO}" = "$olddisto" -a "${EULA}" = "$eulaacpt" ]; then
-    if sha512sum --quiet -c conf/checksum >/dev/null 2>&1; then
-        return 0
-    fi
-fi
-
-# Evaluate new checksum and regenerate the conf files
-sha512sum "${_TDX_SCRIPTS}"/lib/setup-devices/setup-environment-stm32mp 2>&1 > conf/checksum
-
-if [ ! -f "conf/local.conf" ]; then
-    cp "${_TDX_SCRIPTS}"/../conf/template/local.conf conf/local.conf
-fi
-# ln -sf "${_TDX_SCRIPTS}"/../conf/template/bblayers.conf conf/bblayers.conf
-ln -sf "${_TDX_MANIFESTS}"/README.md README.md
-ln -sf "${_TDX_MANIFESTS}" "${_TDX_OEROOT}"/layers/
-
-if [ ! -f "conf/bblayers.conf" ]; then
-    cat > conf/bblayers.conf <<EOF
+tdx_append_once conf/bblayers.conf "# Torizon" <<EOF
 # Torizon
 # LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
 # changes incompatibly
@@ -145,145 +66,15 @@ BBLAYERS = " \\
   \${OEROOT}/layers/openembedded-core/meta \\
 "
 EOF
-fi
 
-if [ "$_TDX_AUTO_CONF_CREATED" = "0" ]; then
-    cat >> conf/auto.conf <<EOF
-DISTRO ?= "${DISTRO}"
-MACHINE ?= "${MACHINE}"
-SDKMACHINE ?= "${SDKMACHINE}"
+ln -sf "${_TDX_MANIFESTS}/README.md" README.md
+ln -sf "${_TDX_MANIFESTS}" "${_TDX_OEROOT}/layers/"
 
-# Extra options that can be changed by the user
-INHERIT += "rm_work"
-EOF
-else
-    sed -i "s/^DISTRO ?= \"[^\"]*\"$/DISTRO ?= \"${DISTRO}\"/" conf/auto.conf
-    sed -i "s/^MACHINE ?= \"[^\"]*\"$/MACHINE ?= \"${MACHINE}\"/" conf/auto.conf
-    sed -i "s/^SDKMACHINE ?= \"[^\"]*\"$/SDKMACHINE ?= \"${SDKMACHINE}\"/" conf/auto.conf
-fi
+tdx_write_auto_conf "${DISTRO}" "${MACHINE}" "${SDKMACHINE}" "rm_work cyclonedx-export"
+tdx_apply_integration_override conf/auto.conf
 
-cat > conf/site.conf <<_EOF
-SCONF_VERSION = "1"
+tdx_write_site_conf "${_TDX_OEROOT}" "${_TDX_BUILDDIR}"
 
-# Where to store sources
-DL_DIR ?= "${_TDX_OEROOT}/downloads"
+tdx_eula_prompt "ACCEPT_EULA_${MACHINE}" "${_TDX_OEROOT}/layers/meta-st-stm32mp/conf/eula/${MACHINE}" "ST"
 
-# Where to save shared state
-SSTATE_DIR ?= "${_TDX_OEROOT}/sstate-cache"
-BB_HASHSERVE_DB_DIR ?= "\${SSTATE_DIR}"
-
-# Where to save the build system work output
-TMPDIR = "${_TDX_BUILDDIR}/tmp"
-
-# Where to save the packages and images
-_COMMON_DEPLOY = "${_TDX_BUILDDIR}/deploy"
-DEPLOY_DIR = "\${_COMMON_DEPLOY}\${@'' if d.getVar('BB_CURRENT_MC') == 'default' else '/\${BB_CURRENT_MC}'}"
-
-# Go through the Firewall
-#HTTP_PROXY = "http://${PROXYHOST}:${PROXYPORT}/"
-_EOF
-
-_TDX_EULA_ACCEPTED=""
-
-if egrep -q "^\s*ACCEPT_EULA_${MACHINE}\s*=\s*\"[^\"]*\"" conf/local.conf; then
-    _TDX_EULA_ACCEPTED=1
-fi
-
-if [ -z "$_TDX_EULA_ACCEPTED" ] && [ -n "$EULA" ]; then
-    # EULA is not accepted int conf/local.conf but
-    # user set the EULA environment variable, so we set
-    # ACCEPT_EULA_$MACHINE with $EULA value
-    cat >> conf/local.conf <<EOF
-
-# BSP depends on ST packages and firmware which are covered by an
-# End User License Agreement (EULA). To have the right to use these
-# binaries in the image, ACCEPT_EULA_$MACHINE must be set to '1'
-ACCEPT_EULA_$MACHINE = "$EULA"
-EOF
-elif [ -n "$_TDX_EULA_ACCEPTED" ]; then
-    # EULA has been accepted before and it is set in conf/local.conf.
-    if [ -n "$EULA" ]; then
-        # If EULA is not null, we change it to the value passed by it
-        sed -i "s/^\s*ACCEPT_EULA_${MACHINE}\s*=\s*\"[^\"]*\"$/ACCEPT_EULA_${MACHINE} = \"${EULA}\"/" conf/local.conf
-    fi
-else
-    # EULA has not been accepted and EULA environment
-    # variable is not set. Show user the EULA and ask they accept
-    cat <<EOF
-
-The BSP for $MACHINE depends on packages and firmware which are covered by an
-End User License Agreement (EULA). To have the right to use these binaries
-in your images, you need to read and accept the following...
-
-EOF
-
-    echo
-    REPLY=
-    while [ -z "$REPLY" ]; do
-        echo -n "Would you like to read the EULA ? (y/n) "
-        read -r REPLY
-        case "$REPLY" in
-            y|Y)
-                READ_EULA=1
-                ;;
-            n|N)
-                READ_EULA=0
-                ;;
-            *)
-                REPLY=
-                ;;
-        esac
-    done
-
-    if [ "$READ_EULA" = 1 ]; then
-        more -d "${_TDX_OEROOT}/layers/meta-st-stm32mp/conf/eula/$MACHINE"
-        echo
-        REPLY=
-        while [ -z "$REPLY" ]; do
-            echo -n "Do you accept the EULA you just read? (y/n) "
-            read -r REPLY
-            case "$REPLY" in
-                y|Y)
-                    echo "EULA has been accepted."
-                    cat >> conf/local.conf <<EOF
-
-# BSP depends on ST packages and firmware which are covered by an
-# End User License Agreement (EULA). To have the right to use these
-# binaries in the image, ACCEPT_EULA_$MACHINE must be set to '1'
-ACCEPT_EULA_$MACHINE = "1"
-EOF
-                    ;;
-                n|N)
-                    echo "EULA has not been accepted."
-                    ;;
-                *)
-                    REPLY=
-                    ;;
-            esac
-        done
-    fi
-fi
-
-cat <<EOF
-
-Welcome to Toradex Torizon OS
-
-For more information about OpenEmbedded see their website:
-
-    http://www.openembedded.org/
-
-Your build environment has been configured with:
-
-    MACHINE = ${MACHINE}
-    SDKMACHINE = ${SDKMACHINE}
-    DISTRO = ${DISTRO}
-
-You can now run 'bitbake <target>'
-
-Some of common targets are:
-
-    torizon-docker
-    torizon-minimal
-    torizon-podman
-
-EOF
+tdx_print_banner "Common Torizon OS" yes

--- a/scripts/lib/setup-devices/setup-environment-synaptics
+++ b/scripts/lib/setup-devices/setup-environment-synaptics
@@ -128,7 +128,35 @@ INHERIT += "rm_work"
 include conf/machine/include/\${MACHINE}.inc
 
 EOF
+
 fi
+
+_TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifest.xml
+_TDX_INTEGRATION_BUILD=0
+if [ -L "$_TDX_MANIFEST_FILE" ]; then
+  case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
+    integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
+  esac
+elif [ -f "$_TDX_MANIFEST_FILE" ]; then
+  if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
+    _TDX_INTEGRATION_BUILD=1
+  fi
+fi
+
+# When building on integration, ensure use-head-next is set so you always get
+# the newest software (u-boot, kernel, aktualizr-torizon, etc). Idempotent, so
+# it also applies when local.conf already existed from a previous run.
+if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
+   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/local.conf; then
+cat <<EOF >>conf/local.conf
+
+# This is needed when building on integration. With use-head-next you
+# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
+# Building on integration without use-head-next your build may fail.
+DISTROOVERRIDES .= ":use-head-next"
+EOF
+fi
+
 
 if ! grep -q "# Torizon" conf/bblayers.conf; then
   cat <<EOF >>conf/bblayers.conf

--- a/scripts/lib/setup-devices/setup-environment-synaptics
+++ b/scripts/lib/setup-devices/setup-environment-synaptics
@@ -1,76 +1,48 @@
-#!/usr/bin/env bash
+#!/bin/bash
+# -*- mode: shell-script-mode; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+#
+# Copyright (C) 2012-13 O.S. Systems Software LTDA.
+# Copyright (C) 2017 Open Source Foundries Ltd.
+# Copyright (C) 2020-2026 Toradex AG
+# Authored-by:  Otavio Salvador <otavio@ossystems.com.br>
+# Adopted to Angstrom:  Khem Raj <raj.khem@gmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
 
 source ${_TDX_LAYERS_DIR}/poky/oe-init-build-env "${1:-build-$DISTRO}" >/dev/null 2>&1
+tdx_set_builddir_from_cwd
 
-# check if this <build> folder was already configured
-_TDX_EULA_ACCEPTED=""
-_TDX_SYN_EULA_STR="Synaptics-EULA"
-_TDX_LICENSE_FLAGS_STR="$(grep LICENSE_FLAGS_ACCEPTED conf/local.conf || true)"
-# checks if EULA was already accepted and present in conf files
-if echo "$_TDX_LICENSE_FLAGS_STR" | grep -q "$_TDX_SYN_EULA_STR"; then
-    _TDX_EULA_ACCEPTED=1
-fi
+# check if this <build> folder was already configured. Marker is the
+# specific "Synaptics-EULA" flag value, NOT the generic "LICENSE_FLAGS_ACCEPTED"
+# variable name.
+if tdx_needs_once conf/local.conf "Synaptics-EULA"; then
+    # Synaptics requires two independent flags to be accumulated into
+    # LICENSE_FLAGS_ACCEPTED: the Synaptics EULA itself, and (separately)
+    # acceptance of VSSDK's proprietary/commercial license terms.
+    _TDX_LICENSE_FLAGS=()
 
-# if EULA was not previously accepted, prompt user
-if [ "$_TDX_EULA_ACCEPTED" != "1" ]; then
-    # if EULA environment var is set to 1, accept EULA without prompting user
     if [ "$EULA" == "1" ]; then
-        cat <<EOF >> conf/local.conf
-
-LICENSE_FLAGS_ACCEPTED += "${_TDX_SYN_EULA_STR} commercial"
-EOF
+        # if EULA environment var is set to 1, accept both without prompting
+        _TDX_LICENSE_FLAGS=("Synaptics-EULA" "commercial")
     else
-        _TDX_EULA_FILE="${_TDX_LAYERS_DIR}/meta-synaptics/EULA.rst"
-        if [ ! -f "$_TDX_EULA_FILE" ]; then
-            echo "The Synaptics End User License Agreement file is missing! Please check your environment."
-        else
-            more -d "$_TDX_EULA_FILE"
-            _TDX_RESPONSE=
-            while [ -z "$_TDX_RESPONSE" ]; do
-                echo -n "Do you accept the terms of the Synaptics End User License Agreement? (y/n) "
-                read -r _TDX_RESPONSE
-                case "$_TDX_RESPONSE" in
-                    y|Y)
-                        echo "The terms of the Synaptics End User License Agreement have been accepted."
-                        _TDX_LICENSE_FLAGS_ACCEPTED="${_TDX_SYN_EULA_STR}"
-                        ;;
-                    n|N)
-                        echo "The terms of the Synaptics End User License Agreement have been declined."
-                        _TDX_EULA_ACCEPTED=0
-                        ;;
-                    *)
-                        echo "Invalid Response, please try again"
-                        _TDX_RESPONSE=
-                        ;;
-                esac
-            done
+        if tdx_license_flag_accept \
+            "Do you accept the terms of the Synaptics End User License Agreement? (y/N)" \
+            "${_TDX_LAYERS_DIR}/meta-synaptics/EULA.rst"; then
+            _TDX_LICENSE_FLAGS+=("Synaptics-EULA")
         fi
-        _TDX_RESPONSE=
-        while [ -z "$_TDX_RESPONSE" ]; do
-            echo -n "VSSDK contains some proprietary components, do you accept the commercial license? (y/n) "
-            read -r _TDX_RESPONSE
-            case "$_TDX_RESPONSE" in
-                y|Y)
-                    echo "The commercial license has been accepted."
-                    _TDX_LICENSE_FLAGS_ACCEPTED="${_TDX_LICENSE_FLAGS_ACCEPTED} commercial"
-                    ;;
-                n|N)
-                    echo "The commercial has been declined."
-                    _TDX_EULA_ACCEPTED=0
-                    ;;
-                *)
-                    echo "Invalid Response, please try again"
-                    _TDX_RESPONSE=
-                    ;;
-            esac
-        done
-        if [ -n "$_TDX_LICENSE_FLAGS_ACCEPTED" ]; then
-            cat <<EOF >> conf/local.conf
 
-LICENSE_FLAGS_ACCEPTED += "${_TDX_LICENSE_FLAGS_ACCEPTED}"
-EOF
+        if tdx_license_flag_accept \
+            "VSSDK contains some proprietary components, do you accept the commercial license? (y/N)"; then
+            _TDX_LICENSE_FLAGS+=("commercial")
         fi
     fi
+
+    if [ ${#_TDX_LICENSE_FLAGS[@]} -gt 0 ]; then
+        tdx_append_license_flags conf/local.conf "${_TDX_LICENSE_FLAGS[@]}"
+    fi
+    # register this one-off bookkeeping array with core.sh's cleanup sweep
+    _TDX_EXTRA_CLEANUP_VARS+=("_TDX_LICENSE_FLAGS")
 fi
 
 # encrypt OPTEE TA with production key by default
@@ -78,14 +50,12 @@ if [ "${OPTEE_TA_ENC}" != "dev" ]; then
     OPTEE_TA_ENC="prod"
 fi
 
-if ! grep -q "#OPTEE TA encryption" conf/local.conf; then
-    if [ -n "$OPTEE_TA_ENC" ]; then
-        cat <<EOF >>conf/local.conf
+if [ -n "$OPTEE_TA_ENC" ]; then
+    tdx_append_once conf/local.conf "#OPTEE TA encryption" <<EOF
 
 #OPTEE TA encryption
 OPTEE_TA_ENC = "${OPTEE_TA_ENC}"
 EOF
-    fi
 fi
 
 # Change settings according environment
@@ -105,10 +75,7 @@ SOURCE_MIRROR_URL ?= "${SOURCE_MIRROR_URL}"
 EOF
 fi
 
-if ! grep -q "# Torizon" conf/local.conf; then
-  _TDX_OEROOT=$(dirname "$(pwd)")
-  _TDX_BUILDDIR=$(pwd)
-
+if tdx_needs_once conf/local.conf; then
   sed -i "/^MACHINE .*/c\MACHINE = \"${MACHINE}\"" conf/local.conf
   sed -i "/^DISTRO .*/c\DISTRO = \"${DISTRO}\"" conf/local.conf
   sed -i "/^#DL_DIR .*/c\DL_DIR ?= \"${_TDX_OEROOT}/downloads\"" conf/local.conf
@@ -116,7 +83,7 @@ if ! grep -q "# Torizon" conf/local.conf; then
   sed -i "/^SSTATE_DIR .*/a BB_HASHSERVE_DB_DIR ?= \"\${SSTATE_DIR}\"" conf/local.conf
   sed -i "/^#TMPDIR .*/c\TMPDIR = \"${_TDX_BUILDDIR}/tmp\"" conf/local.conf
 
-  cat <<EOF >>conf/local.conf
+  tdx_append_once conf/local.conf "# Torizon" <<EOF
 
 # Where to save the packages and images
 DEPLOY_DIR = "${_TDX_BUILDDIR}/deploy"
@@ -131,35 +98,10 @@ EOF
 
 fi
 
-_TDX_MANIFEST_FILE="${_TDX_OEROOT}"/.repo/manifest.xml
-_TDX_INTEGRATION_BUILD=0
-if [ -L "$_TDX_MANIFEST_FILE" ]; then
-  case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
-    integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
-  esac
-elif [ -f "$_TDX_MANIFEST_FILE" ]; then
-  if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
-    _TDX_INTEGRATION_BUILD=1
-  fi
-fi
+# When building on integration, ensure use-head-next is set.
+tdx_apply_integration_override conf/local.conf
 
-# When building on integration, ensure use-head-next is set so you always get
-# the newest software (u-boot, kernel, aktualizr-torizon, etc). Idempotent, so
-# it also applies when local.conf already existed from a previous run.
-if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
-   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/local.conf; then
-cat <<EOF >>conf/local.conf
-
-# This is needed when building on integration. With use-head-next you
-# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
-# Building on integration without use-head-next your build may fail.
-DISTROOVERRIDES .= ":use-head-next"
-EOF
-fi
-
-
-if ! grep -q "# Torizon" conf/bblayers.conf; then
-  cat <<EOF >>conf/bblayers.conf
+tdx_append_once conf/bblayers.conf "# Torizon" <<EOF
 
 BBLAYERS += " \\
   ${_TDX_LAYERS_DIR}/meta-openembedded/meta-oe \\
@@ -183,27 +125,5 @@ BBLAYERS += "${_TDX_LAYERS_DIR}/meta-updater"
 OEROOT := "\${@os.path.abspath(os.path.dirname(d.getVar('FILE', True)))}/../.."
 
 EOF
-fi
 
-cat <<EOF
-
-Welcome to Common Torizon OS
-
-For more information about OpenEmbedded see their website:
-
-    http://www.openembedded.org/
-
-Your build environment has been configured with:
-
-    MACHINE = ${MACHINE}
-    DISTRO = ${DISTRO}
-
-You can now run 'bitbake <target>'
-
-Some of common targets are:
-
-    torizon-docker
-    torizon-minimal
-    torizon-podman
-
-EOF
+tdx_print_banner "Common Torizon OS" no

--- a/scripts/lib/setup-devices/setup-environment-ti
+++ b/scripts/lib/setup-devices/setup-environment-ti
@@ -121,6 +121,33 @@ INHERIT += "rm_work"
 # Torizon
 include conf/machine/include/\${MACHINE}.inc
 EOF
+
+fi
+
+_TDX_MANIFEST_FILE="${OEROOT}"/.repo/manifest.xml
+_TDX_INTEGRATION_BUILD=0
+if [ -L "$_TDX_MANIFEST_FILE" ]; then
+  case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
+    integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
+  esac
+elif [ -f "$_TDX_MANIFEST_FILE" ]; then
+  if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
+    _TDX_INTEGRATION_BUILD=1
+  fi
+fi
+
+# When building on integration, ensure use-head-next is set so you always get
+# the newest software (u-boot, kernel, aktualizr-torizon, etc). Idempotent, so
+# it also applies when local.conf already existed from a previous run.
+if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
+   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/local.conf; then
+  cat <<EOF >>conf/local.conf
+
+# This is needed when building on integration. With use-head-next you
+# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
+# Building on integration without use-head-next your build may fail.
+DISTROOVERRIDES .= ":use-head-next"
+EOF
 fi
 
 if ! grep -q "# Torizon" conf/bblayers.conf; then

--- a/scripts/lib/setup-devices/setup-environment-ti
+++ b/scripts/lib/setup-devices/setup-environment-ti
@@ -1,10 +1,18 @@
 #!/bin/bash
+# -*- mode: shell-script-mode; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+#
+# Copyright (C) 2012-13 O.S. Systems Software LTDA.
+# Copyright (C) 2017 Open Source Foundries Ltd.
+# Copyright (C) 2020-2026 Toradex AG
+# Authored-by:  Otavio Salvador <otavio@ossystems.com.br>
+# Adopted to Angstrom:  Khem Raj <raj.khem@gmail.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
 
-OEROOT=$(pwd)
-BUILDDIR="${1:-build-ti-$DISTRO}"
+OEROOT="${_TDX_OEROOT}"
 
-mkdir -p "${BUILDDIR}/conf"
-cd "${BUILDDIR}"
+tdx_set_builddir "${1:-build-ti-$DISTRO}" "${DISTRO}" || return 1
 
 function wget_retry {
   local url="$1"
@@ -26,6 +34,7 @@ function wget_retry {
   echo "Failed to download $url after $max_retries attempts."
   return 1
 }
+_TDX_EXTRA_CLEANUP_FUNCS+=("wget_retry")
 
 if [ ! -e "conf/bblayers.conf" ]; then
   echo "Downloading sample bblayers.conf from git.ti.com..."
@@ -88,6 +97,11 @@ SFW_FILE"
 EOF
 
 source conf/setenv
+# OEROOT is only needed as a plain shell variable up to this `source` (it's
+# looked up here via conf/setenv's own, already-generated
+# `export OEBASE="${OEROOT}"` line); register it for cleanup so it doesn't
+# leak into the user's interactive shell.
+_TDX_EXTRA_CLEANUP_VARS+=("OEROOT")
 
 # Update DISTRO and MACHINE
 sed -E -i "/(^|#|#.*( |#))DISTRO .*/c\DISTRO = '${DISTRO}'" conf/local.conf
@@ -102,8 +116,7 @@ EOF
   fi
 fi
 
-if ! grep -q "# Torizon" conf/local.conf; then
-  echo "Adapting conf/local.conf for a Torizon OS build."
+if tdx_needs_once conf/local.conf; then
   sed -i "/^TMPDIR .*/c\TMPDIR = \"\${TOPDIR}/tmp\"" conf/local.conf
   sed -i "/^PACKAGE_CLASSES .*/c\# PACKAGE_CLASSES = \"package_deb\"" conf/local.conf
   sed -i "/^EXTRA_IMAGE_FEATURES = \"debug-tweaks\"/c\# EXTRA_IMAGE_FEATURES = \"debug-tweaks\"" conf/local.conf
@@ -111,7 +124,7 @@ if ! grep -q "# Torizon" conf/local.conf; then
   sed -i "/^SSTATE_DIR .*/a BB_HASHSERVE_DB_DIR ?= \"\${SSTATE_DIR}\"" conf/local.conf
   sed -i "s/^DL_DIR = \(.*\)/DL_DIR ?= \1/" conf/local.conf
 
-  cat <<EOF >>conf/local.conf
+  tdx_append_once conf/local.conf "# Torizon" <<EOF
 # Where to save the packages and images
 TI_COMMON_DEPLOY = "\${TOPDIR}/deploy"
 
@@ -124,35 +137,11 @@ EOF
 
 fi
 
-_TDX_MANIFEST_FILE="${OEROOT}"/.repo/manifest.xml
-_TDX_INTEGRATION_BUILD=0
-if [ -L "$_TDX_MANIFEST_FILE" ]; then
-  case "$(basename "$(readlink -f "$_TDX_MANIFEST_FILE")")" in
-    integration.xml|next.xml) _TDX_INTEGRATION_BUILD=1 ;;
-  esac
-elif [ -f "$_TDX_MANIFEST_FILE" ]; then
-  if grep -qE "(integration.xml|next.xml)" "$_TDX_MANIFEST_FILE"; then
-    _TDX_INTEGRATION_BUILD=1
-  fi
-fi
+# When building on integration, ensure use-head-next is set.
+tdx_apply_integration_override conf/local.conf
 
-# When building on integration, ensure use-head-next is set so you always get
-# the newest software (u-boot, kernel, aktualizr-torizon, etc). Idempotent, so
-# it also applies when local.conf already existed from a previous run.
-if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && \
-   ! grep -qF 'DISTROOVERRIDES .= ":use-head-next"' conf/local.conf; then
-  cat <<EOF >>conf/local.conf
-
-# This is needed when building on integration. With use-head-next you
-# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
-# Building on integration without use-head-next your build may fail.
-DISTROOVERRIDES .= ":use-head-next"
-EOF
-fi
-
-if ! grep -q "# Torizon" conf/bblayers.conf; then
-  echo "Adapting conf/bblayers.conf for a Torizon OS build."
-  cat <<EOF >>conf/bblayers.conf
+if tdx_needs_once conf/bblayers.conf; then
+  tdx_append_once conf/bblayers.conf "# Torizon" <<EOF
 # Torizon
 BBLAYERS += "\${OEROOT}/sources/meta-toradex-torizon"
 BBLAYERS += "\${OEROOT}/sources/meta-updater"
@@ -161,25 +150,4 @@ OEROOT := "\${@os.path.abspath(os.path.dirname(d.getVar('FILE', True)))}/../.."
 EOF
 fi
 
-cat <<EOF
-
-Welcome to Common Torizon OS
-
-For more information about OpenEmbedded see their website:
-
-    http://www.openembedded.org/
-
-Your build environment has been configured with:
-
-    MACHINE = ${MACHINE}
-    DISTRO = ${DISTRO}
-
-You can now run 'bitbake <target>'
-
-Some of common targets are:
-
-    torizon-docker
-    torizon-minimal
-    torizon-podman
-
-EOF
+tdx_print_banner "Common Torizon OS" no

--- a/scripts/lib/setup-devices/setup-environment-toradex
+++ b/scripts/lib/setup-devices/setup-environment-toradex
@@ -3,294 +3,70 @@
 #
 # Copyright (C) 2012-13 O.S. Systems Software LTDA.
 # Copyright (C) 2017 Open Source Foundries Ltd.
+# Copyright (C) 2020-2026 Toradex AG
 # Authored-by:  Otavio Salvador <otavio@ossystems.com.br>
 # Adopted to Angstrom:  Khem Raj <raj.khem@gmail.com>
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation.
+# SPDX-License-Identifier: GPL-2.0-only
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-#
-
-_TDX_OEROOT=$(pwd)
-cd "$_TDX_OEROOT"
-if [ -n "$ZSH_VERSION" ]; then
-    setopt sh_word_split
-    setopt clobber
-elif [ -n "$BASH_VERSION" ]; then
-    set +o noclobber
-fi
 
 # DISTRO defaults to 'torizon' for am62(p)/imx8(m|p|SMARC)/imx95(verdin|SMARC)/am69/qemuarm64/genericx86-64 machines
 # DISTRO defaults to 'torizon-upstream' for other machines
-_TDX_DISTRO_DEFAULT="torizon-upstream" && echo "$MACHINE" | grep -E -q '(imx8|imx93|imx95|am62|am69|qemuarm64|genericx86-64)' && _TDX_DISTRO_DEFAULT="torizon"
-DISTRO=${DISTRO:-$_TDX_DISTRO_DEFAULT}
+_TDX_DISTRO_DEFAULT="torizon-upstream"
+echo "${MACHINE}" | grep -E -q '(imx8|imx93|imx95|am62|am69|qemuarm64|genericx86-64)' && _TDX_DISTRO_DEFAULT="torizon"
+DISTRO=${DISTRO:-${_TDX_DISTRO_DEFAULT}}
+# This script is sourced at top level (no function scope for `local`), so
+# register this one-off bookkeeping variable with core.sh's cleanup sweep
+# instead of leaving it to leak into the user's shell.
+_TDX_EXTRA_CLEANUP_VARS+=("_TDX_DISTRO_DEFAULT")
 
-if [ -z "${SDKMACHINE}" ]; then
-    SDKMACHINE='x86_64'
-fi
+[ -z "${SDKMACHINE}" ] && SDKMACHINE='x86_64'
 
-_TDX_MANIFESTS="${_TDX_OEROOT}"/.repo/manifests
-_TDX_SCRIPTS="${_TDX_OEROOT}"/layers/meta-toradex-torizon/scripts
+# resolve/export BUILDDIR ourselves (mkdir+cd into it), then rebuild PATH
+# and BB_ENV_PASSTHROUGH_ADDITIONS.
+tdx_set_builddir "${1:-}" "${DISTRO}" || return 1
+tdx_setup_path
+tdx_setup_bb_env_passthrough
 
-# We can be called with only 1 parameter max (build folder)
-_TDX_BUILDDIR=${1:-build-$DISTRO}
-# If current BUILDDIR is relative then prepend OEROOT
-case ${_TDX_BUILDDIR} in
-    /* ) ;;
-    *  ) _TDX_BUILDDIR=$(readlink -f ${_TDX_BUILDDIR});;
-esac
-# Get rid of double slash. sed calls in OE staging_processfixme
-# seems to have troubles if this makes it into OE variables.
-_TDX_BUILDDIR=${_TDX_BUILDDIR%%/}
+# Early-return if MACHINE/DISTRO/EULA/script-checksum are all unchanged.
+tdx_native_conf_is_current ACCEPT_FSL_EULA && return 0
 
-# Set BBPATH for recipetool
-BBPATH=${_TDX_BUILDDIR}
+tdx_write_checksum "${_TDX_SCRIPTS}/lib/setup-devices/setup-environment-toradex"
 
-# Clean up PATH, because if it includes tokens to current directories somehow,
-# wrong binaries can be used instead of the expected ones during task execution
-PATH=$(echo "${PATH}" | sed 's/\(:.\|:\)*:/:/g;s/^.\?://;s/:.\?$//')
-PATH="${_TDX_OEROOT}/bitbake/bin:${_TDX_OEROOT}/.repo/repo:${PATH}"
-PATH="${_TDX_OEROOT}/layers/openembedded-core/bitbake/bin:${PATH}"
-PATH="${_TDX_OEROOT}/layers/openembedded-core/scripts:${PATH}"
-# Remove duplicate path entries
-PATH=$(echo "$PATH" |
-       awk -F: '{for (i=1;i<=NF;i++) { if ( !x[$i]++ ) printf("%s:",$i); }}' |
-       sed 's/:$//')
-
-BB_ENV_PASSTHROUGH_ADDITIONS_OE="MACHINE DISTRO TCMODE TCLIBC HTTP_PROXY http_proxy \
-HTTPS_PROXY https_proxy FTP_PROXY ftp_proxy FTPS_PROXY ftps_proxy ALL_PROXY \
-all_proxy NO_PROXY no_proxy SSH_AGENT_PID SSH_AUTH_SOCK BB_SRCREV_POLICY \
-SDKMACHINE BB_NUMBER_THREADS BB_NO_NETWORK PARALLEL_MAKE GIT_PROXY_COMMAND \
-SOCKS5_PASSWD SOCKS5_USER SCREENDIR STAMPS_DIR BBPATH_EXTRA BB_SETSCENE_ENFORCE"
-
-BB_ENV_PASSTHROUGH_ADDITIONS="$(echo $BB_ENV_PASSTHROUGH_ADDITIONS $BB_ENV_PASSTHROUGH_ADDITIONS_OE | tr ' ' '\n' | LC_ALL=C sort --unique | tr '\n' ' ')"
-
-export PATH
-export _TDX_BUILDDIR
-export BBPATH
-export BB_ENV_PASSTHROUGH_ADDITIONS
-
-_TDX_AUTO_CONF_CREATED=0
-mkdir -p "${_TDX_BUILDDIR}"/conf && cd "${_TDX_BUILDDIR}"
-if [ -f "conf/auto.conf" ]; then
-    oldmach=$(egrep "^MACHINE \?=" "conf/auto.conf" |
-             sed -e 's%^MACHINE ?= %%' | sed -e 's/^"//' -e 's/"$//')
-    olddisto=$(egrep "^DISTRO \?=" "conf/auto.conf" |
-             sed -e 's%^DISTRO ?= %%' | sed -e 's/^"//' -e 's/"$//')
-    eulaacpt=$(egrep '^\s*ACCEPT_FSL_EULA\s*=\s*\".*\"' conf/local.conf |
-             sed -e 's%^\s*ACCEPT_FSL_EULA\s*=\s*%%' | sed -e 's/^"//' -e 's/"$//')
-    _TDX_AUTO_CONF_CREATED=1
-fi
-
-if [ -e conf/checksum -a "${MACHINE}" = "$oldmach" -a "${DISTRO}" = "$olddisto" -a "${EULA}" = "$eulaacpt" ]; then
-    if sha512sum --quiet -c conf/checksum >/dev/null 2>&1; then
-        return 0
-    fi
-fi
-
-# Evaluate new checksum and regenerate the conf files
-sha512sum "${_TDX_SCRIPTS}"/lib/setup-devices/setup-environment-toradex 2>&1 > conf/checksum
-
-if [ ! -f "conf/local.conf" ]; then
-    cp "${_TDX_SCRIPTS}"/../conf/template/local.conf conf/local.conf
-fi
+tdx_conf_from_template local.conf
+# bblayers.conf is always regenerated fresh (unlike local.conf, which is only
+# seeded once)
 cp "${_TDX_SCRIPTS}/../conf/template/bblayers.conf" conf/bblayers.conf
 sed -i "s|@OEROOT@|${_TDX_OEROOT}|g" conf/bblayers.conf
-ln -sf "${_TDX_MANIFESTS}"/README.md README.md
-ln -sf "${_TDX_MANIFESTS}" "${_TDX_OEROOT}"/layers/
 
-_TDX_MANIFEST_FILE="${_TDX_MANIFESTS}"/../manifest.xml
-_TDX_INTEGRATION_BUILD=0
+ln -sf "${_TDX_MANIFESTS}/README.md" README.md
+ln -sf "${_TDX_MANIFESTS}" "${_TDX_OEROOT}/layers/"
 
-if [ -L "$_TDX_MANIFEST_FILE" ]; then
-    if [ "$(basename `readlink -f "$_TDX_MANIFEST_FILE"`)" == "integration.xml" ] ||
-       [ "$(basename `readlink -f "$_TDX_MANIFEST_FILE"`)" == "next.xml" ]; then
-        _TDX_INTEGRATION_BUILD=1
-    fi
-else
-    if cat $_TDX_MANIFEST_FILE | grep -q "torizon/integration.xml\|torizon/next.xml"; then
-        _TDX_INTEGRATION_BUILD=1
-    fi
+tdx_write_auto_conf "${DISTRO}" "${MACHINE}" "${SDKMACHINE}" "rm_work cyclonedx-export"
+tdx_apply_integration_override conf/auto.conf
+
+tdx_write_site_conf "${_TDX_OEROOT}" "${_TDX_BUILDDIR}"
+
+# TI does not have an EULA that needs user acceptance, so avoid showing NXP's
+# EULA for AM62/AM62P/AM69/QEMU/x86 variants.
+if ! echo "${MACHINE}" | grep -qE 'verdin-am62|aquila-am69|qemuarm64|genericx86-64'; then
+    tdx_eula_prompt ACCEPT_FSL_EULA "${_TDX_OEROOT}/layers/meta-freescale/EULA" NXP
 fi
 
-if [ "$_TDX_INTEGRATION_BUILD" = "1" ] && [ "$_TDX_AUTO_CONF_CREATED" = "0" ]; then
-    cat > conf/auto.conf <<EOF
-# This is needed when building on integration. With use-head-next you
-# always get the newest software (u-boot, kernel, aktualizr-torizon, etc).
-# Building on integration without use-head-next your build may fail.
-DISTROOVERRIDES .= ":use-head-next"
-
-EOF
-fi
-
-if [ "$_TDX_AUTO_CONF_CREATED" = "0" ]; then
-    cat >> conf/auto.conf <<EOF
-DISTRO ?= "${DISTRO}"
-MACHINE ?= "${MACHINE}"
-SDKMACHINE ?= "${SDKMACHINE}"
-
-# Extra options that can be changed by the user
-INHERIT += "rm_work cyclonedx-export"
-EOF
-else
-    sed -i "s/^DISTRO ?= \"[^\"]*\"$/DISTRO ?= \"${DISTRO}\"/" conf/auto.conf
-    sed -i "s/^MACHINE ?= \"[^\"]*\"$/MACHINE ?= \"${MACHINE}\"/" conf/auto.conf
-    sed -i "s/^SDKMACHINE ?= \"[^\"]*\"$/SDKMACHINE ?= \"${SDKMACHINE}\"/" conf/auto.conf
-fi
-
-cat > conf/site.conf <<_EOF
-SCONF_VERSION = "1"
-
-# Where to store sources
-DL_DIR ?= "${_TDX_OEROOT}/downloads"
-
-# Where to save shared state
-SSTATE_DIR ?= "${_TDX_OEROOT}/sstate-cache"
-BB_HASHSERVE_DB_DIR ?= "\${SSTATE_DIR}"
-
-# Where to save the build system work output
-TMPDIR = "${_TDX_BUILDDIR}/tmp"
-
-# Where to save the packages and images
-TI_COMMON_DEPLOY = "${_TDX_BUILDDIR}/deploy"
-DEPLOY_DIR = "\${TI_COMMON_DEPLOY}\${@'' if d.getVar('BB_CURRENT_MC') == 'default' else '/\${BB_CURRENT_MC}'}"
-
-# Go through the Firewall
-#HTTP_PROXY = "http://${PROXYHOST}:${PROXYPORT}/"
-_EOF
-
-_TDX_EULA_ACCEPTED=""
-
-# TI does not have an EULA that needs user acceptance. So in order to avoid
-# showing NXP's EULA we just say that EULA was accepted for AM62.
-# Same for QEMU and x86 variants.
-if echo "${MACHINE}" | grep -q "verdin-am62\|aquila-am69\|qemuarm64\|genericx86-64"; then
-    _TDX_EULA_ACCEPTED=1
-fi
-
-if egrep -q '^\s*ACCEPT_FSL_EULA\s*=\s*\"[^\"]*\"' conf/local.conf; then
-    _TDX_EULA_ACCEPTED=1
-fi
-
-if [ -z "$_TDX_EULA_ACCEPTED" ] && [ -n "$EULA" ]; then
-    # Freescale's EULA is not accepted int conf/local.conf but
-    # user set the EULA environment variable, so we set
-    # ACCEPT_FSL_EULA with $EULA value
-    cat >> conf/local.conf <<EOF
-
-# BSP depends on NXP packages and firmware which are covered by an
-# End User License Agreement (EULA). To have the right to use these
-# binaries in the image, ACCEPT_FSL_EULA must be set to '1'
-ACCEPT_FSL_EULA = "$EULA"
-EOF
-elif [ -n "$_TDX_EULA_ACCEPTED" ]; then
-    # Freescale's EULA has been accepted before and it is set in conf/local.conf.
-    if [ -n "$EULA" ]; then
-        # If EULA is not null, we change it to the value passed by it
-        sed -i "s/^\s*ACCEPT_FSL_EULA\s*=\s*\"[^\"]*\"$/ACCEPT_FSL_EULA = \"${EULA}\"/" conf/local.conf
-    fi
-else
-    # Freescale's EULA has not been accepted and EULA environment
-    # variable is not set. Show user the EULA and ask they accept
-    cat <<EOF
-
-The BSP for $MACHINE depends on packages and firmware which are covered by an
-End User License Agreement (EULA). To have the right to use these binaries
-in your images, you need to read and accept the following...
-
-EOF
-
-    echo
-    REPLY=
-    while [ -z "$REPLY" ]; do
-        echo -n "Would you like to read the EULA ? (y/n) "
-        read -r REPLY
-        case "$REPLY" in
-            y|Y)
-                READ_EULA=1
-                ;;
-            n|N)
-                READ_EULA=0
-                ;;
-            *)
-                REPLY=
-                ;;
-        esac
-    done
-
-    if [ "$READ_EULA" = 1 ]; then
-        more -d "${_TDX_OEROOT}/layers/meta-freescale/EULA"
-        echo
-        REPLY=
-        while [ -z "$REPLY" ]; do
-            echo -n "Do you accept the EULA you just read? (y/n) "
-            read -r REPLY
-            case "$REPLY" in
-                y|Y)
-                    echo "EULA has been accepted."
-                    cat >> conf/local.conf <<EOF
-
-# BSP depends on NXP packages and firmware which are covered by an
-# End User License Agreement (EULA). To have the right to use these
-# binaries in the image, ACCEPT_FSL_EULA must be set to '1'
-ACCEPT_FSL_EULA = "1"
-EOF
-                    ;;
-                n|N)
-                    echo "EULA has not been accepted."
-                    ;;
-                *)
-                    REPLY=
-                    ;;
-            esac
-        done
-    fi
-fi
-
-cat <<EOF
-
-Welcome to Toradex Torizon OS
-
-For more information about OpenEmbedded see their website:
-
-    http://www.openembedded.org/
-
-Your build environment has been configured with:
-
-    MACHINE = ${MACHINE}
-    SDKMACHINE = ${SDKMACHINE}
-    DISTRO = ${DISTRO}
-
-You can now run 'bitbake <target>'
-
-Some of common targets are:
-
-    torizon-docker
-    torizon-minimal
-    torizon-podman
-
-EOF
-
-if [ "${MACHINE}" = "qemuarm64" ]; then
-    cat <<EOF
+# qemuarm64/genericx86-64 get extra runqemu/VirtualBox instructions appended
+# to the welcome banner.
+_toradex_extra_trailer() {
+    case "${MACHINE}" in
+        qemuarm64)
+            cat <<'EOF'
 You can run generated qemuarm64 image with runqemu by:
 
     runqemu qemuarm64
 
 EOF
-fi
-
-if [ "${MACHINE}" = "genericx86-64" ]; then
-    cat <<EOF
+            ;;
+        genericx86-64)
+            cat <<'EOF'
 You can run generated genericx86-64 image with runqemu by:
 
     runqemu genericx86-64 ovmf
@@ -303,4 +79,9 @@ You can also run generated genericx86-64 image in VirtualBox by:
     Start the machine
 
 EOF
-fi
+            ;;
+    esac
+}
+_TDX_EXTRA_CLEANUP_FUNCS+=("_toradex_extra_trailer")
+
+tdx_print_banner "Torizon OS" yes _toradex_extra_trailer

--- a/scripts/setup-environment
+++ b/scripts/setup-environment
@@ -19,6 +19,15 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+# If called internally by NXP's imx-setup-release.sh, DISTRO is an FSL distro
+# (e.g. fsl-imx-xwayland). Delegate to the Freescale base and return early.
+case "${DISTRO}" in
+    fsl-*|fslc-*)
+        . sources/base/setup-environment "$@"
+        return
+        ;;
+esac
+
 trap "unset $(declare -p | sed -ne 's/^declare .. \(_TDX_[_a-z0-9]\+\)=.*/\1/ip' &> /dev/null; declare -fp | sed -ne 's/^\(_tdx_[-_a-z0-9]\+\) *()/\1/ip' &> /dev/null)" RETURN
 
 _tdx_usage () {

--- a/scripts/setup-environment
+++ b/scripts/setup-environment
@@ -2,25 +2,18 @@
 # -*- mode: shell-script-mode; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 #
 # Copyright (C) 2012-13 O.S. Systems Software LTDA.
+# Copyright (C) 2017 Open Source Foundries Ltd.
+# Copyright (C) 2020-2026 Toradex AG
 # Authored-by:  Otavio Salvador <otavio@ossystems.com.br>
 # Adopted to Angstrom:  Khem Raj <raj.khem@gmail.com>
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# SPDX-License-Identifier: GPL-2.0-only
 #
 
 # If called internally by NXP's imx-setup-release.sh, DISTRO is an FSL distro
 # (e.g. fsl-imx-xwayland). Delegate to the Freescale base and return early.
+# (Unrelated to the tdx_* library below - preserved as-is from before this
+# rewrite.)
 case "${DISTRO}" in
     fsl-*|fslc-*)
         . sources/base/setup-environment "$@"
@@ -28,185 +21,132 @@ case "${DISTRO}" in
         ;;
 esac
 
-trap "unset $(declare -p | sed -ne 's/^declare .. \(_TDX_[_a-z0-9]\+\)=.*/\1/ip' &> /dev/null; declare -fp | sed -ne 's/^\(_tdx_[-_a-z0-9]\+\) *()/\1/ip' &> /dev/null)" RETURN
-
-_tdx_usage () {
-    cat >&2 <<EOF
-
-Usage: [DISTRO=<DISTRO>] [MACHINE=<MACHINE>] [EULA=1] source ${BASH_SOURCE[0]} [-h] [BUILDDIR]
-
-If no MACHINE is set, list of all distros will be shown for user to choose, and then the desired machine.
-If no DISTRO is set, 'torizon|torizon-upstream|common-torizon' will be chosen depending on MACHINE.
-If no EULA is set, user will be asked to read it and to accept it (if the selected machine requires it).
-If no BUILDIR is set, it will be set to build-\$DISTRO.
-
-Options:
-  -h    Show this help message.
-EOF
-
-    echo "Distros"
-    printf "\t%s\t%s\n" "${_TDX_AVAILABLE_DISTROS[@]}"
-    echo ""
-    echo "Toradex Machines"
-    printf "\t%s\t%s\n" "${_TDX_TORADEX_MACHINES[@]}"
-    echo ""
-    echo "Common Torizon Machines"
-    printf "\t%s\t%s\n" "${_TDX_COMMON_MACHINES[@]}"
-}
-
-_TDX_AVAILABLE_DISTROS=("torizon"                 "(for Toradex devices)" \
-                   "common-torizon"          "(for 3rd party devices)" \
-                   "common-torizon-xenomai3" "(for intel-corei7-64)" \
-                   "common-torizon-xenomai4" "(for intel-corei7-64)")
-
-_TDX_TORADEX_MACHINES=("apalis-imx6"          "meta-freescale-3rdparty" \
-                  "apalis-imx8"          "meta-toradex-nxp" \
-                  "aquila-am69"          "meta-toradex-ti" \
-                  "aquila-imx95"         "meta-toradex-nxp" \
-                  "colibri-imx6"         "meta-freescale-3rdparty" \
-                  "colibri-imx6ull-emmc" "meta-toradex-nxp" \
-                  "colibri-imx7-emmc"    "meta-freescale-3rdparty" \
-                  "colibri-imx8x"        "meta-toradex-nxp" \
-                  "genericx86-64"        "meta-yocto/meta-yocto-bsp" \
-                  "lino-imx93"           "meta-toradex-nxp" \
-                  "qemuarm64"            "openembedded-core/meta" \
-                  "toradex-osm-imx93"    "meta-toradex-nxp" \
-                  "toradex-osm-imx95"    "meta-toradex-nxp" \
-                  "toradex-smarc-imx8mp" "meta-toradex-nxp" \
-                  "toradex-smarc-imx95"  "meta-toradex-nxp" \
-                  "verdin-am62"          "meta-toradex-ti" \
-                  "verdin-am62p"         "meta-toradex-ti" \
-                  "verdin-imx8mm"        "meta-toradex-nxp" \
-                  "verdin-imx8mp"        "meta-toradex-nxp" \
-                  "verdin-imx95"         "meta-toradex-nxp")
-
-_TDX_COMMON_MACHINES=("am62lxx-evm"   "meta-ti-bsp" \
-                 "am62pxx-evm"        "meta-ti-bsp" \
-                 "am62xx-evm"         "meta-ti-bsp" \
-                 "beagley-ai"         "meta-beagle" \
-                 "imx93frdm"          "meta-imx-frdm/meta-imx-bsp" \
-                 "imx95-19x19-verdin" "meta-imx" \
-                 "intel-corei7-64"    "meta-intel" \
-                 "jetson-orin-nano-devkit" "meta-tegra" \
-                 "jetson-orin-nano-devkit-nvme" "meta-tegra" \
-                 "sl1680"             "meta-synaptics" \
-                 "sl2619"             "meta-synaptics" \
-                 "smarc-rzv2l"        "rz-community-bsp" \
-                 "stm32mp15-disco"    "meta-st-stm32mp" \
-                 "stm32mp25-disco"    "meta-st-stm32mp" \
-                 "stm32mp25-eval"     "meta-st-stm32mp" \
-                 "luna-sl1680"        "meta-synaptics")
-
-if [ "$(whoami)" = "root" ]; then
-    echo "ERROR: do not build Torizon OS as root. Exiting..." >&2
-    return 1
+# Resolve where this checkout's meta-toradex-torizon layer (and therefore
+# scripts/lib/core.sh and the vendor scripts) lives, then source core.sh as
+# early as possible.
+_TDX_SOURCE_PATH=""
+if [ -n "${BASH_SOURCE:-}" ]; then
+    _TDX_SOURCE_PATH="${BASH_SOURCE[0]}"
+elif [ -n "${ZSH_VERSION:-}" ]; then
+    # shellcheck disable=SC2296
+    _TDX_SOURCE_PATH="${(%):-%N}"
 fi
 
-if [ $# -gt 1 ] || [ "$1" == "-h" ]; then
-    _tdx_usage
-    return 1
-fi
-
-_TDX_DIALOG_UTIL=""
-# check for whiptail
-if which whiptail > /dev/null 2>&1; then
-    _TDX_DIALOG_UTIL=$(which whiptail)
+if [ -n "${_TDX_SOURCE_PATH}" ]; then
+    _TDX_SOURCE_PATH=$(readlink -f "${_TDX_SOURCE_PATH}" 2>/dev/null || echo "${_TDX_SOURCE_PATH}")
+    _TDX_LAYERS_DIR=$(cd "$(dirname "${_TDX_SOURCE_PATH}")/../.." >/dev/null 2>&1 && pwd)
 else
-    # check for dialog
-    if which dialog > /dev/null 2>&1; then
-        _TDX_DIALOG_UTIL=$(which dialog)
-    fi
+    _TDX_LAYERS_DIR=$(find ~+ -maxdepth 2 -type d -name meta-toradex-torizon 2>/dev/null)
+    _TDX_LAYERS_DIR=$(dirname "${_TDX_LAYERS_DIR}")
 fi
-
-# if no dialog box util and no MACHINE specified, show usage help and quit
-if [ -z "${_TDX_DIALOG_UTIL}" ] && [ -z "${MACHINE}" ]; then
-    echo "To choose a MACHINE or DISTRO interactively please install whiptail or dialog."
-    echo "To choose a MACHINE or DISTRO non-interactively please use the following:"
-    _tdx_usage
-    return 1
-fi
-
-# if DISTRO is passed, we take the user selection
-_TDX_DISTRO_SELECT="${DISTRO}"
-
-# if no MACHINE is passed, we can not infer the distro desired
-if [ -z "${MACHINE}" ]; then
-    if [ -z "${_TDX_DISTRO_SELECT}" ]; then
-        # if not, we ask the user to select a DISTRO, to narrow down the MACHINEs available
-        _TDX_DISTRO_SELECT=$("${_TDX_DIALOG_UTIL}" --title "Distro selection" --menu \
-                        "Please choose a Torizon distribution" 0 0 20 \
-                        "${_TDX_AVAILABLE_DISTROS[@]}" \
-                        3>&1 1>&2 2>&3)
-    fi
-
-    if [ "${_TDX_DISTRO_SELECT}" == "torizon" ] || [ "${DISTRO}" == "torizon-upstream" ]; then
-        MACHINE=$("${_TDX_DIALOG_UTIL}" --title "Machine selection" --menu \
-                     "Please choose a machine to build" 0 0 20 \
-                     "${_TDX_TORADEX_MACHINES[@]}" \
-                     3>&1 1>&2 2>&3)
-    elif [ "${_TDX_DISTRO_SELECT}" == "common-torizon" ]; then
-        MACHINE=$("${_TDX_DIALOG_UTIL}" --title "Machine selection" --menu \
-                     "Please choose a machine to build" 0 80 20 \
-                     "${_TDX_COMMON_MACHINES[@]}" \
-                     3>&1 1>&2 2>&3)
-    elif [ "${_TDX_DISTRO_SELECT}" == "common-torizon-xenomai3" ] || [ "${_TDX_DISTRO_SELECT}" == "common-torizon-xenomai4" ]; then
-        # In case it is Common Xenomai, we currently only support intel-corei7-64
-        MACHINE="intel-corei7-64"
-    else
-        echo "Unknown DISTRO=\"$_TDX_DISTRO_SELECT\"!"
-        return 1
-    fi
-fi
-
-_TDX_LAYERS_DIR=$(find ~+ -maxdepth 2 -type d -name meta-toradex-torizon)
-_TDX_LAYERS_DIR=$(dirname "${_TDX_LAYERS_DIR}")
 _TDX_SCRIPTS_PATH="${_TDX_LAYERS_DIR}"/meta-toradex-torizon/scripts/lib/setup-devices
 
-if echo "${_TDX_TORADEX_MACHINES[@]}" | grep -q "$MACHINE"; then
-    # for Toradex MACHINES, we let our internal script decide which Torizon distro to use (torizon or torizon-upstream)
-    . ${_TDX_SCRIPTS_PATH}/setup-environment-toradex $@
-else
-    # Common Torizon machines
-    case "${MACHINE}" in
-        am62xx-evm|am62pxx-evm|am62lxx-evm|beagley-ai)
-            # for TI boards there's only common-torizon as possible DISTRO
-            MACHINE="${MACHINE}" DISTRO="common-torizon" . ${_TDX_SCRIPTS_PATH}/setup-environment-ti $@
-        ;;
-        imx95-19x19-verdin)
-            # for iMX95, there's only common-torizon as possible DISTRO
-            _TDX_DISTRO_SELECT="common-torizon" . ${_TDX_SCRIPTS_PATH}/setup-environment-imx $@
-        ;;
-        imx93frdm)
-            # If no distro was passed explicitly, we default to Common Torizon
-            if [ -z "${_TDX_DISTRO_SELECT}" ]; then
-                _TDX_DISTRO_SELECT="common-torizon" . ${_TDX_SCRIPTS_PATH}/setup-environment-imx $@
-            fi
-        ;;
-        intel-corei7-64)
-            # If no distro was passed explicitly, we default to Common Torizon
-            if [ -z "${_TDX_DISTRO_SELECT}" ]; then
-                _TDX_DISTRO_SELECT="common-torizon"
-            fi
-            # Both Common Torizon and Common Xenomai share the same setup script, only the Distro is different
-            DISTRO="$_TDX_DISTRO_SELECT" . ${_TDX_SCRIPTS_PATH}/setup-environment-intel $@
-        ;;
-        jetson-orin-nano-devkit|jetson-orin-nano-devkit-nvme)
-            DISTRO="common-torizon" . ${_TDX_SCRIPTS_PATH}/setup-environment-nvidia
-        ;;
-        smarc-rzv2l)
-            DISTRO="common-torizon" . ${_TDX_SCRIPTS_PATH}/setup-environment-renesas
-        ;;
-        sl1680|sl2619|luna-sl1680)
-            DISTRO="common-torizon" . ${_TDX_SCRIPTS_PATH}/setup-environment-synaptics $@
-        ;;
-        stm32mp25-eval|stm32mp15-disco|stm32mp25-disco)
-            DISTRO="common-torizon" . ${_TDX_SCRIPTS_PATH}/setup-environment-stm32mp
-        ;;
-        *)
-            echo "Unknown machine ${MACHINE}!"
-        ;;
-    esac
-fi
+. "${_TDX_LAYERS_DIR}"/meta-toradex-torizon/scripts/lib/core.sh
 
-export BUILDDIR=${_TDX_BUILDDIR}
+# Cleanup is a single explicit call at the very end (see _tdx_dispatch below),
+# NOT a `trap ... RETURN`. Bash fires a RETURN trap on the completion of
+# *every* nested `source`/`.` call for the remainder of the shell's dynamic
+# scope, not just on the dispatcher's own final return - and several vendor
+# scripts (ti, intel, imx, synaptics) internally `source` external vendor
+# tooling (poky's oe-init-build-env, NXP's imx-setup-release.sh, ...) mid-
+# script. A RETURN trap set here would fire the instant that inner `source`
+# call completes, wiping out every tdx_* function before the rest of the
+# vendor script (which still needs them) ever runs. Wrapping the whole
+# dispatch in a function and calling tdx_cleanup_internal_state exactly once
+# after it returns - regardless of which internal `return` path was taken -
+# sidesteps this entirely, since no trap is ever installed.
+_tdx_dispatch() {
+    if [ "$(whoami)" = "root" ]; then
+        echo "ERROR: do not build Torizon OS as root. Exiting..." >&2
+        return 1
+    fi
 
+    if [ $# -gt 1 ] || [ "$1" == "-h" ]; then
+        tdx_usage
+        return 1
+    fi
+
+    _TDX_DIALOG_UTIL=""
+    # check for whiptail
+    if which whiptail > /dev/null 2>&1; then
+        _TDX_DIALOG_UTIL=$(which whiptail)
+    else
+        # check for dialog
+        if which dialog > /dev/null 2>&1; then
+            _TDX_DIALOG_UTIL=$(which dialog)
+        fi
+    fi
+
+    # if no dialog box util and no MACHINE specified, show usage help and quit
+    if [ -z "${_TDX_DIALOG_UTIL}" ] && [ -z "${MACHINE}" ]; then
+        echo "To choose a MACHINE or DISTRO interactively please install whiptail or dialog."
+        echo "To choose a MACHINE or DISTRO non-interactively please use the following:"
+        tdx_usage
+        return 1
+    fi
+
+    # if DISTRO is passed, we take the user selection
+    _TDX_DISTRO_SELECT="${DISTRO}"
+
+    # if no MACHINE is passed, we can not infer the distro desired
+    if [ -z "${MACHINE}" ]; then
+        if [ -z "${_TDX_DISTRO_SELECT}" ]; then
+            # if not, we ask the user to select a DISTRO, to narrow down the MACHINEs available
+            _TDX_MENU_ARGS=()
+            while IFS=$'\t' read -r _TDX_MENU_M _TDX_MENU_D; do
+                _TDX_MENU_ARGS+=("${_TDX_MENU_M}" "${_TDX_MENU_D}")
+            done < <(tdx_distro_pairs)
+            _TDX_DISTRO_SELECT=$("${_TDX_DIALOG_UTIL}" --title "Distro selection" --menu \
+                            "Please choose a Torizon distribution" 0 0 20 \
+                            "${_TDX_MENU_ARGS[@]}" \
+                            3>&1 1>&2 2>&3)
+        fi
+
+        if [ "${_TDX_DISTRO_SELECT}" == "torizon" ] || [ "${DISTRO}" == "torizon-upstream" ]; then
+            _TDX_MENU_ARGS=()
+            while IFS=$'\t' read -r _TDX_MENU_M _TDX_MENU_D; do
+                _TDX_MENU_ARGS+=("${_TDX_MENU_M}" "${_TDX_MENU_D}")
+            done < <(tdx_menu_pairs '^toradex$')
+            MACHINE=$("${_TDX_DIALOG_UTIL}" --title "Machine selection" --menu \
+                         "Please choose a machine to build" 0 0 20 \
+                         "${_TDX_MENU_ARGS[@]}" \
+                         3>&1 1>&2 2>&3)
+        elif [ "${_TDX_DISTRO_SELECT}" == "common-torizon" ]; then
+            _TDX_MENU_ARGS=()
+            while IFS=$'\t' read -r _TDX_MENU_M _TDX_MENU_D; do
+                _TDX_MENU_ARGS+=("${_TDX_MENU_M}" "${_TDX_MENU_D}")
+            done < <(tdx_menu_pairs -v '^toradex$')
+            MACHINE=$("${_TDX_DIALOG_UTIL}" --title "Machine selection" --menu \
+                         "Please choose a machine to build" 0 80 20 \
+                         "${_TDX_MENU_ARGS[@]}" \
+                         3>&1 1>&2 2>&3)
+        elif [ "${_TDX_DISTRO_SELECT}" == "common-torizon-xenomai3" ] || [ "${_TDX_DISTRO_SELECT}" == "common-torizon-xenomai4" ]; then
+            # In case it is Common Xenomai, we currently only support intel-corei7-64
+            MACHINE="intel-corei7-64"
+            DISTRO="${_TDX_DISTRO_SELECT}"
+        else
+            echo "Unknown DISTRO=\"$_TDX_DISTRO_SELECT\"!"
+            return 1
+        fi
+    fi
+
+    tdx_compute_oeroot
+
+    _TDX_VENDOR=$(tdx_vendor_for_machine "${MACHINE}") || { echo "Unknown machine ${MACHINE}!" >&2; return 1; }
+    tdx_apply_distro_policy "${MACHINE}"
+
+    . "${_TDX_SCRIPTS_PATH}/setup-environment-${_TDX_VENDOR}" "$@"
+}
+
+# Capture _tdx_dispatch's exit status, run cleanup exactly once, then return
+# it to the caller. This is the only place tdx_cleanup_internal_state is called,
+# so that no RETURN trap is ever needed (see the comment above _tdx_dispatch).
+_tdx_run_dispatch() {
+    local _tdx_rc
+    _tdx_dispatch "$@"
+    _tdx_rc=$?
+    tdx_cleanup_internal_state
+    return "${_tdx_rc}"
+}
+
+_tdx_run_dispatch "$@"


### PR DESCRIPTION
Refactor setup-environment scripts, so that we standardize the configuration files generated and avoid duplication of code on the various vendor scripts.

In this task I noticed that some changes were missing on `master` so I cherry-picked those commits as well:

- https://github.com/torizon/meta-toradex-torizon/commit/3f398398c52a24c966ef08d57648e74e905e5c4c
- https://github.com/torizon/meta-toradex-torizon/commit/b8bef4c908ce70dccedbf59dc64c037c710cfab5
- https://github.com/torizon/meta-toradex-torizon/commit/ba234f18bd59545b0678bc4447749661bef22500
- https://github.com/torizon/meta-toradex-torizon/commit/e93500150d61b543f211cd6fbea9371c95ef96ac