### PR TITLE
linux-syna: change git am for git apply command into do_patch

### DIFF
--- a/dynamic-layers/meta-synaptics/recipes-kernel/linux/linux-syna_%.bbappend
+++ b/dynamic-layers/meta-synaptics/recipes-kernel/linux/linux-syna_%.bbappend
@@ -25,7 +25,7 @@ SRC_URI:append:luna-sl1680 = " \
 # patchdir parameter above only serves to keep it out of that automatic series;
 # apply it for real here, directly against the nested repo.
 do_patch:append:luna-sl1680() {
-    ( cd ${S}/drivers/synaptics && git am ${WORKDIR}/0001-dhd_linux-fix-issue-which-freezes-sl1680-chips-board.patch )
+    ( cd ${S}/drivers/synaptics && git apply ${WORKDIR}/0001-dhd_linux-fix-issue-which-freezes-sl1680-chips-board.patch )
 }
 
 # Synaptics kernel recipe is overwriting INITRAMFS_IMAGE


### PR DESCRIPTION
Since git am needs the committer to create a new commit, jenkins environment does not have those variables set, therefore the patch cannot be applied and the build crashes. However, using git apply, there is no need of author or committer assigned, it just apply the diff in the working tree.

Related-to: TOR-4220
Signed-off-by: Matheus Rodrigues <matheus.rodrigues@toradex.com>