### PR TITLE
Master build fix

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -37,4 +37,6 @@ BBFILES_DYNAMIC += "\
     toradex-bsp-common-layer:${LAYERDIR}/dynamic-layers/meta-toradex-bsp-common/*/*/*.bbappend \
     toradex-ti-layer:${LAYERDIR}/dynamic-layers/meta-toradex-ti/*/*/*.bb \
     toradex-ti-layer:${LAYERDIR}/dynamic-layers/meta-toradex-ti/*/*/*.bbappend \
+    virtualization-layer:${LAYERDIR}/dynamic-layers/meta-virtualization/*/*/*.bb \
+    virtualization-layer:${LAYERDIR}/dynamic-layers/meta-virtualization/*/*/*.bbappend \
 "

--- a/dynamic-layers/meta-toradex-bsp/meta-toradex-bsp-common/recipes-bsp/u-boot/u-boot-toradex-secboot-ota.inc
+++ b/dynamic-layers/meta-toradex-bsp/meta-toradex-bsp-common/recipes-bsp/u-boot/u-boot-toradex-secboot-ota.inc
@@ -4,8 +4,6 @@ require recipes-bsp/u-boot/u-boot-tcb-sign.inc
 
 # Path for the include file that genreates U-Boot OTA necessary JSON file
 U_BOOT_OTA_INCLUDE = "recipes-bsp/u-boot/u-boot-ota.inc"
-# Since U-Boot OTA is not available for TI devices, we can't include this file
-# otherwise we get a build error.
-U_BOOT_OTA_INCLUDE:ti-soc = ""
+U_BOOT_OTA_INCLUDE:k3r5 = ""
 
 require ${U_BOOT_OTA_INCLUDE}

--- a/dynamic-layers/meta-virtualization/recipes-kernel/linux/linux-%.bbappend
+++ b/dynamic-layers/meta-virtualization/recipes-kernel/linux/linux-%.bbappend
@@ -1,0 +1,3 @@
+do_kernel_metadata:prepend () {
+    includes="$includes -I${WORKDIR}/recipe-sysroot-native/kcfg"
+}

--- a/files/torizon-static-group
+++ b/files/torizon-static-group
@@ -47,6 +47,7 @@ render:x:103:
 sgx:x:104:
 ptest:x:529:
 empower:x:533:
+systemd-coredump:x:980:
 teeclnt:x:982:
 tss:x:983:
 systemd-bus-proxy:x:984:

--- a/files/torizon-static-passwd
+++ b/files/torizon-static-passwd
@@ -16,6 +16,7 @@ list:x:38:38:Mailing List Manager:/var/list:/bin/sh
 irc:x:39:39:ircd:/var/run/ircd:/bin/sh
 gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/bin/sh
 ptest:x:529:529::/:/bin/nologin
+systemd-coredump:x:980:980::/:/bin/nologin
 tss:x:983:983::/var/lib/tpm:/bin/false
 distcc:x:986:65534::/:/bin/nologin
 avahi:x:987:989::/run/avahi-daemon:/bin/false

--- a/recipes-containers/docker-integrity-checker/docker-integrity-checker_1.0.bb
+++ b/recipes-containers/docker-integrity-checker/docker-integrity-checker_1.0.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
     file://docker-integrity-checker.sh \
 "
 
-S = "${UNPACKDIR}/sources"
+S = "${UNPACKDIR}"
 
 inherit systemd
 

--- a/recipes-containers/docker-watchdog/docker-watchdog_1.0.bb
+++ b/recipes-containers/docker-watchdog/docker-watchdog_1.0.bb
@@ -8,7 +8,7 @@ SRC_URI = " \
     file://docker-watchdog.sh \
 "
 
-S = "${UNPACKDIR}/sources"
+S = "${UNPACKDIR}"
 
 inherit systemd
 

--- a/recipes-core/initramfs-framework/initramfs-graphics.inc
+++ b/recipes-core/initramfs-framework/initramfs-graphics.inc
@@ -26,8 +26,14 @@ INITRAMFS_EXTRA_KMODS:ti-soc = "\
     tc358768 \
     ti_sn65dsi83 \
     lontium_lt8912b \
-    sii902x \
 "
+# TI's AM62x/AM62P/AM62L Starter Kit EVMs use a SiI9022A bridge chip for
+# HDMI, unlike our Verdin/Aquila carrier boards (which use lt8912b) - so
+# this is only needed on the EVMs, not the whole ti-soc class.
+INITRAMFS_EXTRA_KMODS:append:am62xx-evm = " sii902x"
+INITRAMFS_EXTRA_KMODS:append:am62pxx-evm = " sii902x"
+INITRAMFS_EXTRA_KMODS:append:am62lxx-evm = " sii902x"
+
 # On BeagleY AI we need this extra module on top of TI modules
 INITRAMFS_EXTRA_KMODS:append:beagley-ai = " ite_it66121"
 

--- a/recipes-core/nss-altfiles/nss-altfiles_git.bb
+++ b/recipes-core/nss-altfiles/nss-altfiles_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "NSS module which can read user information from files in the same format \
 as /etc/passwd and /etc/group stored in an alternate location"
 LICENSE = "LGPL-2.1-or-later"
-LIC_FILES_CHKSUM = "file://COPYING;md5=fb1949d8d807e528c1673da700aff41f"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=4bf661c1e3793e55c8d1051bc5e0ae21"
 
 SRC_URI = "git://github.com/flatcar-linux/nss-altfiles.git;protocol=https;branch=main"
 
@@ -18,5 +18,10 @@ python __anonymous () {
 
 # The .so has to be installed under /lib for the libc to use it.
 EXTRA_OECONF = "--datadir=${libdir} --prefix=${libdir} --with-types=pwd,grp,spwd"
+
+# nss-altfiles-config is a pkg-config-style helper for querying build flags;
+# introduced upstream in 67441f9506 ("Update to glibc-2.43"), it wasn't
+# installed by older versions. Package it in -dev since it's a build-time tool.
+FILES:${PN}-dev += "${libdir}/bin/nss-altfiles-config"
 
 inherit autotools-brokensep

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -35,7 +35,7 @@ EXTRA_OEMESON += ' \
 	-Dntp-servers="${DEF_FALLBACK_NTP_SERVERS}" \
 '
 
-PACKAGE_WRITE_DEPS:append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-systemctl-native','',d)}"
+PACKAGE_WRITE_DEPS:append = " ${@bb.utils.contains('DISTRO_FEATURES','systemd','systemd-tools-native','',d)}"
 pkg_postinst:${PN}:append () {
 	if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
 		if [ -n "$D" ]; then

--- a/recipes-support/docker-auto-prune/docker-auto-prune_0.1.bb
+++ b/recipes-support/docker-auto-prune/docker-auto-prune_0.1.bb
@@ -8,7 +8,7 @@ SRC_URI = "file://docker-auto-prune.service \
     file://docker-auto-prune.timer.in \
 "
 
-S = "${UNPACKDIR}/sources"
+S = "${UNPACKDIR}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 

--- a/recipes-support/resize-helper/resize-helper_0.1.bb
+++ b/recipes-support/resize-helper/resize-helper_0.1.bb
@@ -11,8 +11,7 @@ SRC_URI = "file://resize-helper \
     file://resize-helper.service \
 "
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 


### PR DESCRIPTION
## Summary

Ongoing fixes to keep the `master` build green across several unrelated
recipe/layer issues found while investigating build breakages — mostly
caused by upstream version bumps exposing assumptions in
Toradex-side recipes/bbappends that no longer hold.

## Fixes included

- **nss-altfiles**: update `LIC_FILES_CHKSUM` for the renamed license file
  and package the new `nss-altfiles-config` build-time helper (both from
  the 2.43.0 bump).
- **image_type_torizon**: deploy `u-boot-version.json` for verdin-am62
  again (was being skipped due to a `ti-soc` machine override).
- **ostree-kernel-initramfs**: fix `do_install` parsing broken by a
  BitBake ternary expression getting split on whitespace.
- **resize-helper** / **recipes-containers**: fix `S` pointing at
  nonexistent source paths.
- **linux-toradex-kmeta**: fix `do_kernel_metadata` failing to find
  meta-virtualization's kernel-cache `.scc` fragments for `linux-toradex-ti`.
  Landed as an initial recipe-scoped fix, then swapped for a more generic
  fix (porting TOR-4190 forward) once confirmed to cover the same case
  without being limited to one recipe — hence the add → revert → re-add
  sequence in the history.
- **initramfs-framework**: stop hard-failing QA when a `ti-soc` splash
  kmod (`sii902x`) isn't built for a given machine.
- **systemd** (x2): follow an upstream rename
  (`systemd-systemctl-native` → `systemd-tools-native`), and reserve a
  static UID/GID for the new `systemd-coredump` system user (`coredump`
  got enabled by default upstream).

Related-to: TOR-4509