### PR TITLE
grub-ota-fallback_1.0: fix S referencing WORKDIR instead of UNPACKDIR

### DIFF
--- a/recipes-sota/grub-ota-fallback/grub-ota-fallback_1.0.bb
+++ b/recipes-sota/grub-ota-fallback/grub-ota-fallback_1.0.bb
@@ -10,8 +10,7 @@ SRC_URI = "\
     file://fw_setenv \
 "
 
-S = "${WORKDIR}/sources"
-UNPACKDIR = "${S}"
+S = "${UNPACKDIR}"
 
 inherit systemd
 


### PR DESCRIPTION
S was set to "${WORKDIR}/sources" with UNPACKDIR then redefined to "${S}". insane.bbclass's do_qa_unpack rejects any S value whose unexpanded text still references WORKDIR, requiring it to be expressed relative to UNPACKDIR instead [1].

[1] https://github.com/openembedded/openembedded-core/blob/master/meta/classes-global/insane.bbclass

Related-to: TOR-4550