### PR TITLE
docker-moby: fix silent drop of per-device block-I/O options

### DIFF
--- a/recipes-containers/docker/docker-moby/0002-opts-fix-ThrottledeviceOpt-GetList-returning-an-empty.patch
+++ b/recipes-containers/docker/docker-moby/0002-opts-fix-ThrottledeviceOpt-GetList-returning-an-empty.patch
@@ -1,0 +1,50 @@
+From 73e78a5822224bd7640888b6b5c2ab6b3f35bd13 Mon Sep 17 00:00:00 2001
+From: Jianyong Wu <wujianyong@hygon.cn>
+Date: Wed, 7 Aug 2024 10:27:21 +0800
+Subject: [PATCH] run: fix GetList return empty issue for throttledevice
+
+Test "--device-read-bps" "--device-write-bps" will fail. The root
+cause is that GetList helper return empty as its local variable
+initialized to zero size.
+
+This patch fix it by setting the related slice size to non-zero.
+
+Signed-off-by: Jianyong Wu <wujianyong@hygon.cn>
+Fixes: #5321
+
+Upstream-Status: Backport [https://github.com/docker/cli/commit/73e78a5822224bd7640888b6b5c2ab6b3f35bd13]
+Signed-off-by: Vladimir Khusainov <vlad@emcraft.com>
+---
+Adapted for this recipe: re-rooted from opts/ to cli/opts/, because the
+client is fetched with destsuffix=git/cli and patches apply at ${S}.
+
+Without it the client accepts --device-read-bps, --device-write-bps,
+--device-read-iops and --device-write-iops, then sends an empty list to
+the daemon: no error, no warning, and no limit on the container. The
+kernel capability underneath is unaffected.
+
+Upstream released the fix in docker/cli v25.0.7 (25.0 branch cherry-pick
+a73610dc4fe8876c4e38f0feab2b629c11a4f244) and v27.1.2. Drop this patch
+once meta-virtualization carries a docker/cli at v25.0.7 / v27.1.2 or
+later -- its scarthgap tip already does. A client that already has the
+fix makes do_patch fail rather than silently reverting it.
+
+ cli/opts/throttledevice.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cli/opts/throttledevice.go b/cli/opts/throttledevice.go
+index bdf454eb27..8bf1288047 100644
+--- a/cli/opts/throttledevice.go
++++ b/cli/opts/throttledevice.go
+@@ -94,7 +94,7 @@ func (opt *ThrottledeviceOpt) String() string {
+ 
+ // GetList returns a slice of pointers to ThrottleDevices.
+ func (opt *ThrottledeviceOpt) GetList() []*blkiodev.ThrottleDevice {
+-	out := make([]*blkiodev.ThrottleDevice, 0, len(opt.values))
++	out := make([]*blkiodev.ThrottleDevice, len(opt.values))
+ 	copy(out, opt.values)
+ 	return out
+ }
+-- 
+2.34.1
+

--- a/recipes-containers/docker/docker-moby_git.bbappend
+++ b/recipes-containers/docker/docker-moby_git.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI:append = " \
     file://0001-dockerd-daemon-use-default-system-config-when-none-i.patch \
+    file://0002-opts-fix-ThrottledeviceOpt-GetList-returning-an-empty.patch \
     file://daemon.json \
     file://docker.service \
     file://chrome.json \


### PR DESCRIPTION
The Docker client shipped by meta-virtualization on this branch (Docker
25.0.3) is affected by docker/cli #5321:
`ThrottledeviceOpt.GetList()` allocates its result slice with length 0 and
capacity `len(values)`, so the `copy()` into it copies nothing.
`--device-read-bps`, `--device-write-bps`, `--device-read-iops` and
`--device-write-iops` are parsed and validated, then handed to the daemon
as an empty list and silently dropped, with no error, no warning, and no
limit applied to the container. The kernel capability underneath is
unaffected; `--blkio-weight-device` takes a different code path and is not
affected.

Affects every board on this branch's meta-virtualization pin (`f92518e2`),
not just one platform - the pin predates the affected range's exit
(fixed upstream in v25.0.7 and v27.1.2).

Commit:

- docker-moby: fix silent drop of per-device block-I/O options
  Backport docker/cli `73e78a582222` as a source patch, instead of
  advancing `SRCREV_cli`, which would pull in 104 commits across 183 files.
  Drop this patch once the meta-virtualization revision advances past
  `f92518e2`.

Validation: confirmed the four options are silently dropped on unpatched
25.0.3 and correctly applied to the container's block-I/O cgroup with
this patch, on the ADLINK LEC-MTK-i1200 (MediaTek Genio 1200).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker device throttling configuration so configured throttle devices are correctly returned and applied instead of appearing as an empty list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->