### PR TITLE
Master build fix

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,6 +12,8 @@ LAYERDEPENDS_meta-toradex-torizon = "sota virtualization-layer"
 LAYERSERIES_COMPAT_meta-toradex-torizon = "wrynose"
 
 BBFILES_DYNAMIC += "\
+    freescale-layer:${LAYERDIR}/dynamic-layers/meta-freescale/*/*/*.bb \
+    freescale-layer:${LAYERDIR}/dynamic-layers/meta-freescale/*/*/*.bbappend \
     fsl-bsp-release:${LAYERDIR}/dynamic-layers/meta-imx-bsp/*/*/*.bb \
     fsl-bsp-release:${LAYERDIR}/dynamic-layers/meta-imx-bsp/*/*/*.bbappend \
     imx-frdm-release:${LAYERDIR}/dynamic-layers/meta-imx-frdm/*/*/*.bbappend \

--- a/dynamic-layers/meta-freescale/recipes-libraries/ethos-u-driver-stack/ethos-u-driver-stack_%.bbappend
+++ b/dynamic-layers/meta-freescale/recipes-libraries/ethos-u-driver-stack/ethos-u-driver-stack_%.bbappend
@@ -1,0 +1,3 @@
+# Upstream is unmaintained (last commit 2022) and declares
+# cmake_minimum_required(VERSION 3.0.2), which CMake >= 4.0 rejects outright.
+EXTRA_OECMAKE += "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"

--- a/dynamic-layers/meta-ti-bsp/recipes-tisdk/ti-psdk-rtos/ti-edgeai-firmware.bb
+++ b/dynamic-layers/meta-ti-bsp/recipes-tisdk/ti-psdk-rtos/ti-edgeai-firmware.bb
@@ -27,8 +27,6 @@ SRC_URI = " \
     git://git.ti.com/git/processor-sdk/psdk_fw.git;protocol=https;branch=${BRANCH} \
 "
 
-S = "${WORKDIR}/git"
-
 PV = "1.0.0"
 
 # Secure Build

--- a/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_%.bbappend
+++ b/recipes-sota/ostree-kernel-initramfs/ostree-kernel-initramfs_%.bbappend
@@ -43,4 +43,5 @@ do_install:append () {
         fi
     fi
 }
-do_install[depends] += "${@'virtual/dtb:do_deploy' if '${PREFERRED_PROVIDER_virtual/dtb}' else ''}"
+OSTREE_DTB_DEPENDS ?= "${@'virtual/dtb:do_deploy' if d.getVar('PREFERRED_PROVIDER_virtual/dtb') else ''}"
+do_install[depends] += "${OSTREE_DTB_DEPENDS}"


### PR DESCRIPTION
## Summary

Three unrelated recipe-parsing/build breakages found while building on `master` for multiple machines.

## Fixes included

- **ti-edgeai-firmware**: fix `S` pointing at a stale `${WORKDIR}/git` path — the pre-`UNPACKDIR` convention for git fetches, which never gets created since bitbake now unpacks `SRC_URI` content into `UNPACKDIR` instead. Dropped the override to fall back to the default.

- **ostree-kernel-initramfs**: fix `do_install[depends]` halting the whole build's parse. The flag embedded a python ternary referencing `${PREFERRED_PROVIDER_virtual/dtb}` as a nested substitution inside `${@...}`; when that variable is genuinely unset (as on `toradex-osm-imx93`), bitbake leaves the block unexpanded, and the raw `if`/`else` text gets shattered by `[depends]`'s whitespace split, aborting the parse. Moved the check into an intermediate variable computed via `d.getVar()`, which always resolves to a plain string first.

- **ethos-u-driver-stack**: fix `do_configure` failing against CMake >= 4.0. Upstream (unmaintained since 2022) declares `cmake_minimum_required(VERSION 3.0.2)`, which CMake has rejected outright since it dropped compatibility with versions below 3.5. Pass `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` via `EXTRA_OECMAKE` (CMake's own documented workaround), and add the missing `freescale-layer` `dynamic-layers` mapping in `meta-toradex-torizon` — this recipe's collection had no bbappend path wired up yet, only `fsl-bsp-release`, which isn't always present alongside bare `meta-freescale`.

Related-to: TOR-4509