### PR TITLE
Master tor 4541 own versioning

### DIFF
--- a/conf/distro/include/tdx-bsp.inc
+++ b/conf/distro/include/tdx-bsp.inc
@@ -1,0 +1,53 @@
+# Vendor identity (was inherited from meta-toradex-distro's tdx-base.inc)
+TARGET_VENDOR = "-tdx"
+SDK_VENDOR = "-tdxsdk"
+
+# Poky defaults to sysvinit (its own weak default beats OE-core's even
+# weaker ??= fallback); pin Torizon OS to systemd explicitly.
+INIT_MANAGER = "systemd"
+
+# Distro features Torizon OS needs beyond base-distro.inc's own set
+DISTRO_FEATURES:append = " opencl pam systemd-resolved tpm2 pni-names"
+
+PREFERRED_PROVIDER_u-boot-fw-utils = "libubootenv"
+PREFERRED_RPROVIDER_u-boot-fw-utils = "libubootenv"
+
+# Default virtual/dtb provider for NXP i.MX8/i.MX9 vendor-BSP builds.
+PREFERRED_PROVIDER_virtual/dtb ?= "device-tree-overlays-imx"
+
+PREFERRED_PROVIDER_opencl-headers:imxgpu      = "imx-gpu-viv"
+PREFERRED_PROVIDER_opencl-clhpp:imxgpu        = "imx-gpu-viv"
+PREFERRED_PROVIDER_opencl-icd-loader:imxgpu   = "imx-gpu-viv"
+PREFERRED_RPROVIDER_opencl-icd-loader:imxgpu  = "libopencl-imx"
+
+PREFERRED_RPROVIDER_libnss-mdns = "avahi-libnss-mdns"
+
+PACKAGECONFIG:append:pn-systemd = " serial-getty-generator"
+PACKAGECONFIG:append:pn-qemu-native = " libusb"
+
+# Show Tezi EULA license
+TEZI_SHOW_EULA_LICENSE ?= "1"
+TEZI_SHOW_EULA_LICENSE:use-mainline-bsp ?= "0"
+TEZI_SHOW_EULA_LICENSE:colibri-imx6:use-mainline-bsp ?= "1"
+TEZI_SHOW_EULA_LICENSE:apalis-imx6:use-mainline-bsp ?= "1"
+
+# create etc/build in the rootfs
+INHERIT += "image-buildinfo"
+
+# Log information on images and packages
+INHERIT += "buildhistory"
+BUILDHISTORY_COMMIT = "1"
+
+IMAGE_LINGUAS ?= "en-us"
+
+# Some Toradex recipes like linux-toradex, u-boot-toradex,
+# device-tree-overlays are appending SCM hashes to PV, version
+# numbers going backwards are not a problem as we don't provide
+# binary feeds.
+#
+# This avoids some annoying errors as follows:
+# | QA Issue: Package version went backwards which would break package feeds
+ERROR_QA:remove = "version-going-backwards"
+
+# keep the dtb vendor directories in fitimage node names
+KERNEL_DTBVENDORED = "1"

--- a/conf/distro/include/torizon.inc
+++ b/conf/distro/include/torizon.inc
@@ -1,9 +1,15 @@
-require conf/distro/include/tdx-base.inc
+# Set the default package class before requiring Poky as it also
+# specifies a default. This allows us to keep the override semantics.
+PACKAGE_CLASSES ?= "package_ipk"
+
+require conf/distro/poky.conf
+require conf/distro/include/arm-defaults.inc
+
 require base-distro.inc
 
-# Required after tdx-base.inc so Torizon's own version identity (hard
-# assignments in versioning.inc) wins over the BSP's tdx-base.inc defaults.
 require conf/distro/include/versioning.inc
+
+require tdx-bsp.inc
 
 IMAGE_CLASSES:append = " image_type_torizon"
 IMAGE_CLASSES:remove = "image_type_tezi"

--- a/conf/distro/include/torizon.inc
+++ b/conf/distro/include/torizon.inc
@@ -1,6 +1,10 @@
 require conf/distro/include/tdx-base.inc
 require base-distro.inc
 
+# Required after tdx-base.inc so Torizon's own version identity (hard
+# assignments in versioning.inc) wins over the BSP's tdx-base.inc defaults.
+require conf/distro/include/versioning.inc
+
 IMAGE_CLASSES:append = " image_type_torizon"
 IMAGE_CLASSES:remove = "image_type_tezi"
 

--- a/conf/distro/include/versioning.inc
+++ b/conf/distro/include/versioning.inc
@@ -3,13 +3,9 @@
 TDX_BUILDNBR ?= "0"
 TDX_PURPOSE ?= "Testing"
 
-# Hard assignments below: this file is the single source of truth for
-# Torizon's own version identity. Distro includes (e.g. torizon.inc) that
-# also pull in BSP config (tdx-base.inc) require this file last, so these
-# values always win regardless of what the BSP sets for its own versioning.
-TDX_MAJOR = "0"
-TDX_MINOR = "0"
-TDX_PATCH = "0"
+TDX_MAJOR ?= "0"
+TDX_MINOR ?= "0"
+TDX_PATCH ?= "0"
 
 def get_tdx_prerelease(purpose, datetime):
     if purpose == "Testing":
@@ -23,15 +19,15 @@ def get_tdx_prerelease(purpose, datetime):
     else:
         return '-devel-%s' % (datetime)
 
-TDX_BUILD = "+build.${TDX_BUILDNBR}"
-TDX_MATRIX_BUILD_TIME = "${DATETIME}"
+TDX_BUILD ?= "+build.${TDX_BUILDNBR}"
+TDX_MATRIX_BUILD_TIME ?= "${DATETIME}"
 TDX_MATRIX_BUILD_TIME[vardepsexclude] = "DATETIME"
-TDX_PRERELEASE = "${@get_tdx_prerelease(d.getVar('TDX_PURPOSE'), d.getVar('TDX_MATRIX_BUILD_TIME'))}"
-TDX_RELEASE = "${TDX_MAJOR}.${TDX_MINOR}.${TDX_PATCH}"
+TDX_PRERELEASE ?= "${@get_tdx_prerelease(d.getVar('TDX_PURPOSE'), d.getVar('TDX_MATRIX_BUILD_TIME'))}"
+TDX_RELEASE ?= "${TDX_MAJOR}.${TDX_MINOR}.${TDX_PATCH}"
 
 # Toradex Version number without date for U-Boot/Kernel and other Toradex
 # specific software artifacts.
-TDX_VERSION = "${TDX_RELEASE}${@'' if d.getVar('TDX_PURPOSE') == 'Release' else '-devel'}"
+TDX_VERSION ?= "${TDX_RELEASE}${@'' if d.getVar('TDX_PURPOSE') == 'Release' else '-devel'}"
 
 # Complete image version with date and build number
 DISTRO_VERSION = "${TDX_RELEASE}${TDX_PRERELEASE}${TDX_BUILD}"

--- a/conf/distro/include/versioning.inc
+++ b/conf/distro/include/versioning.inc
@@ -1,9 +1,15 @@
+# TDX_BUILDNBR/TDX_PURPOSE stay as weak defaults since CI overrides them
+# per-build via local.conf.
 TDX_BUILDNBR ?= "0"
 TDX_PURPOSE ?= "Testing"
 
-TDX_MAJOR ?= "7"
-TDX_MINOR ?= "0"
-TDX_PATCH ?= "0"
+# Hard assignments below: this file is the single source of truth for
+# Torizon's own version identity. Distro includes (e.g. torizon.inc) that
+# also pull in BSP config (tdx-base.inc) require this file last, so these
+# values always win regardless of what the BSP sets for its own versioning.
+TDX_MAJOR = "0"
+TDX_MINOR = "0"
+TDX_PATCH = "0"
 
 def get_tdx_prerelease(purpose, datetime):
     if purpose == "Testing":
@@ -17,15 +23,15 @@ def get_tdx_prerelease(purpose, datetime):
     else:
         return '-devel-%s' % (datetime)
 
-TDX_BUILD ?= "+build.${TDX_BUILDNBR}"
-TDX_MATRIX_BUILD_TIME ?= "${DATETIME}"
+TDX_BUILD = "+build.${TDX_BUILDNBR}"
+TDX_MATRIX_BUILD_TIME = "${DATETIME}"
 TDX_MATRIX_BUILD_TIME[vardepsexclude] = "DATETIME"
-TDX_PRERELEASE ?= "${@get_tdx_prerelease(d.getVar('TDX_PURPOSE'), d.getVar('TDX_MATRIX_BUILD_TIME'))}"
-TDX_RELEASE ?= "${TDX_MAJOR}.${TDX_MINOR}.${TDX_PATCH}"
+TDX_PRERELEASE = "${@get_tdx_prerelease(d.getVar('TDX_PURPOSE'), d.getVar('TDX_MATRIX_BUILD_TIME'))}"
+TDX_RELEASE = "${TDX_MAJOR}.${TDX_MINOR}.${TDX_PATCH}"
 
 # Toradex Version number without date for U-Boot/Kernel and other Toradex
 # specific software artifacts.
-TDX_VERSION ?= "${TDX_RELEASE}${@'' if d.getVar('TDX_PURPOSE') == 'Release' else '-devel'}"
+TDX_VERSION = "${TDX_RELEASE}${@'' if d.getVar('TDX_PURPOSE') == 'Release' else '-devel'}"
 
 # Complete image version with date and build number
 DISTRO_VERSION = "${TDX_RELEASE}${TDX_PRERELEASE}${TDX_BUILD}"


### PR DESCRIPTION
torizon.inc required meta-toradex-distro's tdx-base.inc, which defines its own TDX_MAJOR/MINOR/PATCH and prerelease/version logic — separate from and out of sync with the versioning this repo already owns for Common Torizon (versioning.inc). Torizon OS ended up versioned by the BSP layer instead of by us, and could silently produce a bogus release depending on how far tdx-base.inc had drifted.

- torizon.inc now requires its own versioning.inc instead of inheriting the BSP's tdx-base.inc.
- Everything else torizon.inc still needed from tdx-base.inc (vendor identity, INIT_MANAGER, DISTRO_FEATURES additions, PREFERRED_PROVIDER defaults, TEZI_SHOW_EULA_LICENSE, etc.) moved into a new tdx-bsp.inc, required after poky.conf/base-distro.inc/versioning.inc so hard-assigned vars (TARGET_VENDOR, SDK_VENDOR) still win over Poky's own defaults.

Verified with bitbake-getvar against torizon-distro/verdin-imx8mm: TDX_RELEASE/DISTRO_VERSION now resolve from this repo's versioning.inc; TARGET_VENDOR/SDK_VENDOR still resolve to -tdx/-tdxsdk.

Related-to: TOR-4541