### PR TITLE
sota: fuse_actions: fix inverted fallback check

### DIFF
--- a/recipes-sota/config/files/fuse_actions-in.sh
+++ b/recipes-sota/config/files/fuse_actions-in.sh
@@ -234,8 +234,7 @@ do_install() {
     if  [ "$?" -ne 0 ]; then
         log "Could not create reboot sentinel file; falling back to normal reboot"
         # Fall back to using reboot.
-        REBOOT 2>/dev/null
-        if [ "$?" -eq 0 ]; then
+        if ! REBOOT 2>/dev/null; then
             clear_uboot_vars
             die "Failed to reboot device"
         fi


### PR DESCRIPTION
The fallback reboot handling checked the result of `REBOOT` in the wrong direction. This path is entered when creation of `REBOOT_SENTINEL_FILE` fails; the script then calls `REBOOT` but treated an exit status of 0 as a failure.

Now, if the reboot fails, clear the pending U-Boot variables and terminate with `Failed to reboot device`.

Related-to: TOR-4581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reboot fallback failure detection during installation, making recovery behavior more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->