### PR TITLE
aktualizr-default-sec: fix files creation when they're empty

### DIFF
--- a/recipes-sota/config/files/fuse_actions-in.sh
+++ b/recipes-sota/config/files/fuse_actions-in.sh
@@ -186,22 +186,26 @@ EOF
 
 # Creates target_name file if it does not already exist
 create_target_file () {
-    local fuse_dir
-    fuse_dir=$(DIRNAME "$SECONDARY_FIRMWARE_PATH")
-
-    target_file="${fuse_dir}/target_name"
-    if [ ! -e "${target_file}" ]; then
-        log "Generating target_name file"
-	echo "fuse.yml" > "$target_file"
-    fi
+    log "Generating target_name file"
+    printf '%s' "fuse.yml" > "$1"
 }
 
 # Create firmware file from information available from U-boot if file does not exist
 do_create_firmware() {
     log "Generating firmware file based on information in U-Boot"
+    local target_file
 
-    create_yaml_content
-    create_target_file
+    if [ ! -s "${SECONDARY_FIRMWARE_PATH}" ]; then
+        create_yaml_content
+    fi
+
+    local fuse_dir
+    fuse_dir=$(DIRNAME "$SECONDARY_FIRMWARE_PATH")
+    target_file="${fuse_dir}/target_name"
+    if [ ! -s "${target_file}" ]; then
+        create_target_file "${target_file}"
+    fi
+
     return 0
 }
 
@@ -295,7 +299,7 @@ log_action "$@"
 
 case "$1" in
     get-firmware-info)
-        if [ -n "${SECONDARY_FIRMWARE_PATH}" ] && [ ! -e "${SECONDARY_FIRMWARE_PATH}" ]; then
+        if [ -n "${SECONDARY_FIRMWARE_PATH}" ]; then
             # Try to create firmware file so some hash can be sent to server
             do_create_firmware
         fi


### PR DESCRIPTION
There was an issue that fuse.yml and target_name files were supposed to be regenerated whether they were missing or they were empty and the second condition was not covered by the "-e" option from the "if" condition. The "-n" option checks if the variable is set, and "-e" checks if the file exists. Therefore if the file is there but with no content, it is not regenerated, so the use of "-s" covers this condition as well.

Besides that, there is no condition that verifies if the target_name file exists or if it is empty. Thus, in this scenario that target_name doesn't exist and fuse.yml does, it will be missing and not regenerated.

Related-to: TOR-4461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware information handling when firmware files are missing or empty.
  * Firmware metadata and target files are now generated when unavailable or empty.
  * Improved firmware information retrieval for configured secondary firmware paths, including when files already exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->