### PR TITLE
Export TCB re-signing tarball for the verdin-am62 and refactoring of the tarball generation

### DIFF
--- a/classes/image_type_torizon.bbclass
+++ b/classes/image_type_torizon.bbclass
@@ -22,18 +22,8 @@ python adjust_tezi_artifacts() {
     d.setVar('TEZI_ARTIFACTS', artifacts)
 }
 
-def is_hab_signed_bootloader_and_fit_enabled(d):
-    if d.getVar('TDX_IMX_HAB_ENABLE') == '1' and d.getVar('UBOOT_SIGN_ENABLE') == '1':
-        return '1'
-
-    return '0'
-
-TCB_SIGNING_FILES_TARBALL = "tcb_signing_files.tar.gz"
-TCB_SIGNING_SUPPORT ?= "0"
-TCB_SIGNING_SUPPORT:verdin-imx8mp ?= "${@is_hab_signed_bootloader_and_fit_enabled(d)}"
-TCB_SIGNING_FILELIST:verdin-imx8mp ?= "uboot_config bl31* lpddr4_pmu_train_* u-boot.dtb u-boot-nodtb.bin spl/ u-boot-dtbs/"
-TCB_SIGNING_SUPPORT:verdin-imx8mm ?= "${@is_hab_signed_bootloader_and_fit_enabled(d)}"
-TCB_SIGNING_FILELIST:verdin-imx8mm ?= "uboot_config bl31* lpddr4_pmu_train_* u-boot.dtb u-boot-nodtb.bin spl/ u-boot-dtbs/"
+# Definitions shared with the recipe that builds the "TCB signing files" tarball.
+require recipes-bsp/tcb-signing-files/tcb-signing-files.inc
 
 pack_tcb_signing_binaries_in_teziimg() {
     if [ "${TCB_SIGNING_SUPPORT}" != "1" ]; then

--- a/classes/image_type_torizon.bbclass
+++ b/classes/image_type_torizon.bbclass
@@ -25,45 +25,23 @@ python adjust_tezi_artifacts() {
 # Definitions shared with the recipe that builds the "TCB signing files" tarball.
 require recipes-bsp/tcb-signing-files/tcb-signing-files.inc
 
-pack_tcb_signing_binaries_in_teziimg() {
-    if [ "${TCB_SIGNING_SUPPORT}" != "1" ]; then
-        # TorizonCore Builder signing support feature not enabled
-        return 0
-    fi
-
-    if [ "${TDX_IMX_HAB_ENABLE}" != "1" ]; then
-        bbwarn "TCB signing support enabled but HAB support is disabled. Skipping."
-        return 0
-    fi
-
-    if [ "${UBOOT_SIGN_ENABLE}" != "1" ]; then
-        bbwarn "TCB signing support enabled but signed kernel FIT image generation is disabled. Skipping."
-        return 0
-    fi
-
-    if [ -z "${TCB_SIGNING_FILELIST}" ]; then
-        bbwarn "TCB signing support enabled but TCB_SIGNING_FILELIST is empty (MACHINE likely not supported). Skipping."
-        return 0
-    fi
-
-    bbnote "Packing TorizonCore Builder signing files"
-
-    # Here we explicitly change to DEPLOY_DIR_IMAGE because the shell tries to expand filenames
-    # with wildcards (e.g. with asterisk) before running the tar command, so they're relative
-    # to the directory the tar command was called (the shell doesn't know that tar will grab
-    # the files from somewhere else)
-    (cd "${DEPLOY_DIR_IMAGE}" && tar --preserve-permissions --dereference \
-        -czf "${WORKDIR}/${TCB_SIGNING_FILES_TARBALL}" ${TCB_SIGNING_FILELIST})
-
-    cp "${WORKDIR}/${TCB_SIGNING_FILES_TARBALL}" \
-       "${IMGDEPLOYDIR}/${TCB_SIGNING_FILES_TARBALL}"
-}
+# Pull the tarball into the build only when this image is meant to carry it.
+do_image_teziimg[depends] += "${@d.getVar('TCB_SIGNING_FILES_RECIPE') + ':do_deploy' if d.getVar('TCB_SIGNING_SUPPORT') == '1' else ''}"
 
 python add_signing_files_to_tezi_artifacts() {
-    signing_files_path = d.getVar('WORKDIR') + '/' + d.getVar('TCB_SIGNING_FILES_TARBALL')
+    if d.getVar('TCB_SIGNING_SUPPORT') != '1':
+        return
 
-    if os.path.isfile(signing_files_path):
-        d.appendVar('TEZI_ARTIFACTS', ' ' + signing_files_path)
+    # rootfs_tezi_run_json() sets TEZI_ARTIFACTS instead of appending to it, so
+    # this prefunc has to run after it or the tarball is dropped without a trace.
+    if not d.getVar('TEZI_ARTIFACTS'):
+        bb.fatal('TEZI_ARTIFACTS is empty when adding the TCB signing files: '
+                 'add_signing_files_to_tezi_artifacts must run after '
+                 'rootfs_tezi_run_json, which sets that variable. Check the '
+                 'ordering of TEZI_IMAGE_TEZIIMG_PREFUNCS.')
+
+    tarball = os.path.join(d.getVar('DEPLOY_DIR_IMAGE'), d.getVar('TCB_SIGNING_FILES_TARBALL'))
+    d.appendVar('TEZI_ARTIFACTS', ' ' + tarball)
 }
 
 TEZI_IMAGE_TEZIIMG_PREFUNCS:append = " add_signing_files_to_tezi_artifacts adjust_tezi_artifacts"
@@ -103,7 +81,7 @@ UBOOT_BINARY_OTA_IGNORE:genericx86-64 = "1"
 UBOOT_BINARY_OTA_IGNORE:lino-imx93 = "1"
 UBOOT_BINARY_OTA_IGNORE:toradex-osm-imx93 = "1"
 
-TEZI_IMAGE_TEZIIMG_PREFUNCS:prepend = "gen_torizon_prov_data pack_tcb_signing_binaries_in_teziimg "
+TEZI_IMAGE_TEZIIMG_PREFUNCS:prepend = "gen_torizon_prov_data "
 
 do_image_teziimg[cleandirs] += "${WORKDIR}/prov-data"
 do_image_teziimg[vardeps] += "${TORIZON_IMG_VARDEPS}"

--- a/dynamic-layers/meta-toradex-ti/recipes-bsp/u-boot/u-boot-toradex-ti_%.bbappend
+++ b/dynamic-layers/meta-toradex-ti/recipes-bsp/u-boot/u-boot-toradex-ti_%.bbappend
@@ -1,5 +1,6 @@
 require recipes-bsp/u-boot/u-boot-ota.inc
 require recipes-bsp/u-boot/u-boot-rollback.inc
+require recipes-bsp/u-boot/u-boot-tcb-sign.inc
 
 FILESEXTRAPATHS:prepend:aquila-am69 := "${THISDIR}/aquila-am69:"
 

--- a/recipes-bsp/tcb-signing-files/tcb-signing-files.bb
+++ b/recipes-bsp/tcb-signing-files/tcb-signing-files.bb
@@ -1,0 +1,76 @@
+SUMMARY = "Bootloader artifacts needed by TorizonCore Builder to re-sign an image"
+DESCRIPTION = "Packs the intermediate, pre-signing bootloader artifacts that \
+TorizonCore Builder needs to recreate and re-sign the bootloader of a pre-built \
+Torizon OS image. This recipe aggregates output deployed by other recipes; it \
+builds nothing of its own."
+SECTION = "BSP"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+require recipes-bsp/tcb-signing-files/tcb-signing-files.inc
+
+inherit deploy nopackages
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "(verdin-imx8mp|verdin-imx8mm)"
+
+# bitbake world would otherwise build this on machines where the feature is off
+# and nothing ever deploys the files below.
+EXCLUDE_FROM_WORLD = "${@'0' if d.getVar('TCB_SIGNING_SUPPORT') == '1' else '1'}"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+do_fetch[noexec] = "1"
+do_unpack[noexec] = "1"
+do_patch[noexec] = "1"
+do_configure[noexec] = "1"
+do_install[noexec] = "1"
+
+B = "${WORKDIR}/build"
+
+# DEPLOY_DIR_IMAGE is otherwise just a directory that may not have been filled
+# in yet, so wait on the deploy tasks of the recipes that fill it.
+do_compile[depends] += "${@' '.join('%s:do_deploy' % r for r in d.getVar('TCB_SIGNING_INPUT_DEPENDS').split())}"
+
+# The filelist decides the archive's contents, and the enable condition decides
+# whether anything downstream uses it.
+do_compile[vardeps] += "TCB_SIGNING_FILELIST TCB_SIGNING_SUPPORT"
+
+do_compile() {
+    # The inputs are deployed only when the feature is on; without this the tar
+    # below fails on its own with a bare "Cannot stat".
+    if [ "${TCB_SIGNING_SUPPORT}" != "1" ]; then
+        bbfatal "TCB_SIGNING_SUPPORT is not \"1\" for MACHINE \"${MACHINE}\", so" \
+                "nothing deploys the files this recipe packs. Build it only in a" \
+                "configuration that enables the signing feature."
+    fi
+
+    if [ -z "${TCB_SIGNING_FILELIST}" ]; then
+        bbfatal "TCB_SIGNING_FILELIST is empty for MACHINE \"${MACHINE}\", so there" \
+                "is nothing to pack. Either define it or keep this recipe out of the" \
+                "build (see TCB_SIGNING_SUPPORT)."
+    fi
+
+    # Without the flags below, member mtimes, ownership and order track the
+    # build, so the same sources would not produce the same archive twice.
+    tar_timestamp_args=""
+    if [ -n "${SOURCE_DATE_EPOCH}" ]; then
+        tar_timestamp_args="--mtime=@${SOURCE_DATE_EPOCH} --clamp-mtime"
+    fi
+
+    # The shell expands the filelist's globs where the command runs, not where
+    # tar reads. --format is pinned so a new tar default cannot move the bytes.
+    (cd "${DEPLOY_DIR_IMAGE}" && tar \
+        --dereference --hard-dereference \
+        --sort=name --format=gnu \
+        ${tar_timestamp_args} \
+        --owner=0 --group=0 --numeric-owner \
+        -czf "${B}/${TCB_SIGNING_FILES_TARBALL}" ${TCB_SIGNING_FILELIST})
+}
+do_compile[dirs] = "${B}"
+do_compile[cleandirs] = "${B}"
+
+do_deploy() {
+    install -m 0644 "${B}/${TCB_SIGNING_FILES_TARBALL}" "${DEPLOYDIR}/${TCB_SIGNING_FILES_TARBALL}"
+}
+addtask deploy after do_compile before do_build

--- a/recipes-bsp/tcb-signing-files/tcb-signing-files.bb
+++ b/recipes-bsp/tcb-signing-files/tcb-signing-files.bb
@@ -12,7 +12,9 @@ require recipes-bsp/tcb-signing-files/tcb-signing-files.inc
 inherit deploy nopackages
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
-COMPATIBLE_MACHINE = "(verdin-imx8mp|verdin-imx8mm)"
+# Anchored: unanchored, "verdin-am62" would also match verdin-am62p and the
+# k3r5 multiconfig's verdin-am62-k3r5, neither of which this recipe packs for.
+COMPATIBLE_MACHINE = "^(verdin-imx8mp|verdin-imx8mm|verdin-am62)$"
 
 # bitbake world would otherwise build this on machines where the feature is off
 # and nothing ever deploys the files below.
@@ -31,6 +33,10 @@ B = "${WORKDIR}/build"
 # DEPLOY_DIR_IMAGE is otherwise just a directory that may not have been filled
 # in yet, so wait on the deploy tasks of the recipes that fill it.
 do_compile[depends] += "${@' '.join('%s:do_deploy' % r for r in d.getVar('TCB_SIGNING_INPUT_DEPENDS').split())}"
+
+# Some machines build part of their input in another multiconfig, which needs an
+# edge of its own; see TCB_SIGNING_INPUT_MCDEPENDS.
+do_compile[mcdepends] += "${TCB_SIGNING_INPUT_MCDEPENDS}"
 
 # The filelist decides the archive's contents, and the enable condition decides
 # whether anything downstream uses it.

--- a/recipes-bsp/tcb-signing-files/tcb-signing-files.inc
+++ b/recipes-bsp/tcb-signing-files/tcb-signing-files.inc
@@ -1,0 +1,35 @@
+# Definitions shared by both sides of the "TCB signing files" tarball: the
+# intermediate, pre-signing bootloader artifacts that TorizonCore Builder needs
+# to re-sign a pre-built Torizon OS image. The tcb-signing-files recipe builds
+# and deploys it; classes/image_type_torizon.bbclass puts it in the Tezi image.
+
+# Name of the tarball, as deployed and as seen inside the Tezi image.
+TCB_SIGNING_FILES_TARBALL = "tcb_signing_files.tar.gz"
+
+TCB_SIGNING_FILES_RECIPE = "tcb-signing-files"
+
+def is_hab_signed_bootloader_and_fit_enabled(d):
+    if d.getVar('TDX_IMX_HAB_ENABLE') == '1' and d.getVar('UBOOT_SIGN_ENABLE') == '1':
+        return '1'
+
+    return '0'
+
+# Whether this build exports the TCB signing files at all. What the condition
+# reads comes from the globally inherited signing class, so a recipe and an
+# image resolve it the same way.
+TCB_SIGNING_SUPPORT ?= "0"
+TCB_SIGNING_SUPPORT:verdin-imx8mp ?= "${@is_hab_signed_bootloader_and_fit_enabled(d)}"
+TCB_SIGNING_SUPPORT:verdin-imx8mm ?= "${@is_hab_signed_bootloader_and_fit_enabled(d)}"
+
+# What goes into the tarball, relative to DEPLOY_DIR_IMAGE. The shell expands
+# these in that directory, so globs work and an entry matching nothing fails
+# the build rather than producing a short tarball.
+TCB_SIGNING_FILELIST ?= ""
+TCB_SIGNING_FILELIST:verdin-imx8mp ?= "uboot_config bl31* lpddr4_pmu_train_* u-boot.dtb u-boot-nodtb.bin spl/ u-boot-dtbs/"
+TCB_SIGNING_FILELIST:verdin-imx8mm ?= "uboot_config bl31* lpddr4_pmu_train_* u-boot.dtb u-boot-nodtb.bin spl/ u-boot-dtbs/"
+
+# The do_deploy tasks that put those files in DEPLOY_DIR_IMAGE. Keep this in
+# step with TCB_SIGNING_FILELIST: a file packed but not depended upon is a race.
+TCB_SIGNING_INPUT_DEPENDS ?= ""
+TCB_SIGNING_INPUT_DEPENDS:verdin-imx8mp ?= "virtual/bootloader ${IMX_DEFAULT_ATF_PROVIDER} ${IMX_EXTRA_FIRMWARE}"
+TCB_SIGNING_INPUT_DEPENDS:verdin-imx8mm ?= "virtual/bootloader ${IMX_DEFAULT_ATF_PROVIDER} ${IMX_EXTRA_FIRMWARE}"

--- a/recipes-bsp/tcb-signing-files/tcb-signing-files.inc
+++ b/recipes-bsp/tcb-signing-files/tcb-signing-files.inc
@@ -20,9 +20,8 @@ def is_hab_signed_bootloader_and_fit_enabled(d):
 
     return '0'
 
-# The TI K3 counterpart of the above, kept separate: TCB_SIGNING_SUPPORT is in
-# the packing task's vardeps, so rewording the iMX helper would repack the
-# tarball on machines that ship today.
+# The TI K3 counterpart of the above. A separate function so that each names the
+# condition it tests, and the k3r5 multiconfig needs a third form anyway.
 def is_k3_secboot_and_fit_enabled(d):
     if d.getVar('TDX_K3_SECBOOT_ENABLE') == '1' and d.getVar('UBOOT_SIGN_ENABLE') == '1':
         return '1'
@@ -47,6 +46,11 @@ TCB_SIGNING_SUPPORT:verdin-imx8mp ?= "${@is_hab_signed_bootloader_and_fit_enable
 TCB_SIGNING_SUPPORT:verdin-imx8mm ?= "${@is_hab_signed_bootloader_and_fit_enabled(d)}"
 TCB_SIGNING_SUPPORT:verdin-am62 ?= "${@is_k3_secboot_and_fit_enabled(d)}"
 TCB_SIGNING_SUPPORT:verdin-am62-k3r5 ?= "${@is_k3_secboot_enabled(d)}"
+
+# Hash by the value this resolves to: otherwise every task reading it also
+# depends on the helper's text, which BitBake captures down to the comments
+# that follow it.
+TCB_SIGNING_SUPPORT[vardepvalue] = "${TCB_SIGNING_SUPPORT}"
 
 # What goes into the tarball, relative to DEPLOY_DIR_IMAGE. The shell expands
 # these in that directory, so globs work and an entry matching nothing fails

--- a/recipes-bsp/tcb-signing-files/tcb-signing-files.inc
+++ b/recipes-bsp/tcb-signing-files/tcb-signing-files.inc
@@ -1,12 +1,18 @@
-# Definitions shared by both sides of the "TCB signing files" tarball: the
-# intermediate, pre-signing bootloader artifacts that TorizonCore Builder needs
-# to re-sign a pre-built Torizon OS image. The tcb-signing-files recipe builds
-# and deploys it; classes/image_type_torizon.bbclass puts it in the Tezi image.
+# Definitions shared by everything that handles the "TCB signing files" tarball:
+# the intermediate, pre-signing bootloader artifacts that TorizonCore Builder
+# needs to re-sign a pre-built Torizon OS image. The tcb-signing-files recipe
+# builds and deploys it, image_type_torizon.bbclass puts it in the Tezi image,
+# and u-boot-tcb-sign.inc deploys what it packs.
 
 # Name of the tarball, as deployed and as seen inside the Tezi image.
 TCB_SIGNING_FILES_TARBALL = "tcb_signing_files.tar.gz"
 
 TCB_SIGNING_FILES_RECIPE = "tcb-signing-files"
+
+# Root of the export tree, for machines that export a tree instead of loose
+# files. The U-Boot recipe installs into it and the file list packs it, so the
+# name lives here rather than being repeated on both sides.
+TCB_SIGNING_EXPORT_DIR ?= "tcb-signing"
 
 def is_hab_signed_bootloader_and_fit_enabled(d):
     if d.getVar('TDX_IMX_HAB_ENABLE') == '1' and d.getVar('UBOOT_SIGN_ENABLE') == '1':

--- a/recipes-bsp/tcb-signing-files/tcb-signing-files.inc
+++ b/recipes-bsp/tcb-signing-files/tcb-signing-files.inc
@@ -20,12 +20,33 @@ def is_hab_signed_bootloader_and_fit_enabled(d):
 
     return '0'
 
+# The TI K3 counterpart of the above, kept separate: TCB_SIGNING_SUPPORT is in
+# the packing task's vardeps, so rewording the iMX helper would repack the
+# tarball on machines that ship today.
+def is_k3_secboot_and_fit_enabled(d):
+    if d.getVar('TDX_K3_SECBOOT_ENABLE') == '1' and d.getVar('UBOOT_SIGN_ENABLE') == '1':
+        return '1'
+
+    return '0'
+
+# The same condition as the k3r5 multiconfig sees it. That multiconfig builds no
+# FIT, so requiring UBOOT_SIGN_ENABLE would switch its half of the export off
+# for good. When the two disagree, its artifacts are deployed and packed by
+# nobody, which wastes a few files in the deploy directory and nothing else.
+def is_k3_secboot_enabled(d):
+    if d.getVar('TDX_K3_SECBOOT_ENABLE') == '1':
+        return '1'
+
+    return '0'
+
 # Whether this build exports the TCB signing files at all. What the condition
 # reads comes from the globally inherited signing class, so a recipe and an
 # image resolve it the same way.
 TCB_SIGNING_SUPPORT ?= "0"
 TCB_SIGNING_SUPPORT:verdin-imx8mp ?= "${@is_hab_signed_bootloader_and_fit_enabled(d)}"
 TCB_SIGNING_SUPPORT:verdin-imx8mm ?= "${@is_hab_signed_bootloader_and_fit_enabled(d)}"
+TCB_SIGNING_SUPPORT:verdin-am62 ?= "${@is_k3_secboot_and_fit_enabled(d)}"
+TCB_SIGNING_SUPPORT:verdin-am62-k3r5 ?= "${@is_k3_secboot_enabled(d)}"
 
 # What goes into the tarball, relative to DEPLOY_DIR_IMAGE. The shell expands
 # these in that directory, so globs work and an entry matching nothing fails
@@ -34,8 +55,21 @@ TCB_SIGNING_FILELIST ?= ""
 TCB_SIGNING_FILELIST:verdin-imx8mp ?= "uboot_config bl31* lpddr4_pmu_train_* u-boot.dtb u-boot-nodtb.bin spl/ u-boot-dtbs/"
 TCB_SIGNING_FILELIST:verdin-imx8mm ?= "uboot_config bl31* lpddr4_pmu_train_* u-boot.dtb u-boot-nodtb.bin spl/ u-boot-dtbs/"
 
+# The AM62 packs the tree whole: its two multiconfigs contribute artifacts with
+# the same basenames, so a glob list of loose files cannot separate them.
+TCB_SIGNING_FILELIST:verdin-am62 ?= "${TCB_SIGNING_EXPORT_DIR}/"
+
 # The do_deploy tasks that put those files in DEPLOY_DIR_IMAGE. Keep this in
 # step with TCB_SIGNING_FILELIST: a file packed but not depended upon is a race.
 TCB_SIGNING_INPUT_DEPENDS ?= ""
 TCB_SIGNING_INPUT_DEPENDS:verdin-imx8mp ?= "virtual/bootloader ${IMX_DEFAULT_ATF_PROVIDER} ${IMX_EXTRA_FIRMWARE}"
 TCB_SIGNING_INPUT_DEPENDS:verdin-imx8mm ?= "virtual/bootloader ${IMX_DEFAULT_ATF_PROVIDER} ${IMX_EXTRA_FIRMWARE}"
+
+# One producer for the AM62, not the four its artifacts come from: the U-Boot
+# recipe installs the whole export tree out of its own workdir and sysroot.
+TCB_SIGNING_INPUT_DEPENDS:verdin-am62 ?= "virtual/bootloader"
+
+# Inputs built in another multiconfig, which TCB_SIGNING_INPUT_DEPENDS cannot
+# express: an mcdepends entry has to name the multiconfigs it crosses.
+TCB_SIGNING_INPUT_MCDEPENDS ?= ""
+TCB_SIGNING_INPUT_MCDEPENDS:verdin-am62 ?= "mc::k3r5:virtual/bootloader:do_deploy"

--- a/recipes-bsp/u-boot/u-boot-tcb-sign.inc
+++ b/recipes-bsp/u-boot/u-boot-tcb-sign.inc
@@ -154,8 +154,12 @@ tcbsgn_deploy_pristine_dtb() {
                     "${DEPLOYDIR}/${TCB_SIGNING_UBOOT_DTB_NOKEYS}"
 }
 
+# Gated: oe-core calls concat_dtb() for every K3 machine with FIT signing on,
+# and the snapshot's guards would fail builds that export nothing.
 concat_dtb:prepend:verdin-am62() {
-    tcbsgn_snapshot_pristine_dtb "$@"
+    if [ "${TCB_SIGNING_SUPPORT}" = "1" ]; then
+        tcbsgn_snapshot_pristine_dtb "$@"
+    fi
 }
 
 # TCB signing export tree, for the AM62. Its two multiconfigs produce files with
@@ -364,21 +368,18 @@ tcbsgn_deploy_am62_export_k3r5() {
 }
 
 do_deploy:append:verdin-am62-k3r5() {
-    # MACHINE gains a "-k3r5" suffix here, so a :verdin-am62 override does not
-    # reach this task. No FIT is built, so there is no condition to mirror.
-    #
-    # TODO: gate this on the K3 counterpart of TCB_SIGNING_SUPPORT once the
-    # tarball export defines it.
-    tcbsgn_deploy_am62_export_k3r5
+    # MACHINE gains a "-k3r5" suffix here, so :verdin-am62 overrides do not
+    # reach this task, TCB_SIGNING_SUPPORT included, hence its own value for it.
+    if [ "${TCB_SIGNING_SUPPORT}" = "1" ]; then
+        tcbsgn_deploy_am62_export_k3r5
+    fi
 }
 
 do_deploy:append:verdin-am62() {
-    # Mirrors the condition under which uboot_assemble_fitimage_helper() calls
-    # concat_dtb(): without the snapshot the export tree is incomplete anyway.
-    #
-    # TODO: gate this on the K3 counterpart of TCB_SIGNING_SUPPORT once the
-    # tarball export defines it, instead of repeating the condition here.
-    if [ "${UBOOT_SIGN_ENABLE}" = "1" -a -n "${UBOOT_DTB_BINARY}" ]; then
+    # TCB_SIGNING_SUPPORT already requires FIT signing here, which is what
+    # leaves the snapshot behind; the second test completes the condition under
+    # which uboot_assemble_fitimage_helper() calls concat_dtb().
+    if [ "${TCB_SIGNING_SUPPORT}" = "1" -a -n "${UBOOT_DTB_BINARY}" ]; then
         tcbsgn_deploy_pristine_dtb
         tcbsgn_deploy_am62_export_a53
         tcbsgn_write_am62_manifest

--- a/recipes-bsp/u-boot/u-boot-tcb-sign.inc
+++ b/recipes-bsp/u-boot/u-boot-tcb-sign.inc
@@ -19,6 +19,18 @@ tcbsgn_uboot_set_config_dir() {
     fi
 }
 
+# Set ${tcbsgn_cfgtype} to the UBOOT_CONFIG entry U-Boot was built for, which
+# names the per-type files left in the build directory. More than one entry is
+# fatal, and the result comes back in a variable, as above.
+tcbsgn_uboot_set_config_type() {
+    set -- ${UBOOT_CONFIG}
+    if [ $# -ne 1 ]; then
+        bbfatal "Expected a single U-Boot config type in UBOOT_CONFIG" \
+                "(\"${UBOOT_CONFIG}\"); do_deploy() must be reviewed."
+    fi
+    tcbsgn_cfgtype="$1"
+}
+
 tcbsgn_check_config() {
     local cfg="${1?property name in the U-Boot config}"
     local exp="${2?property value}"
@@ -152,6 +164,11 @@ TCB_SIGNING_EXPORT_DIR ?= "tcb-signing"
 TCB_SIGNING_EXPORT_DIR_A53 ?= "${TCB_SIGNING_EXPORT_DIR}/a53"
 TCB_SIGNING_EXPORT_DIR_K3R5 ?= "${TCB_SIGNING_EXPORT_DIR}/k3r5"
 
+# Bump the format version only for a change consumers have to notice; the roots
+# list must name every root the deploy code produces.
+TCB_SIGNING_MANIFEST_VERSION ?= "1"
+TCB_SIGNING_MANIFEST_ROOTS ?= "k3r5 a53"
+
 # Where the A53 binman descriptor's include path looks for firmware. Fixed, so
 # distro configuration cannot move it; the k3r5 one names ti-sysfw/ instead.
 TCB_SIGNING_EXPORT_FWDIR ?= "usr/lib/firmware"
@@ -245,6 +262,52 @@ tcbsgn_deploy_am62_export_a53() {
     done
 }
 
+# Manifest at the root of the export tree: which layout to expect, and which
+# U-Boot produced the artifacts, so that a consumer whose binman comes from
+# another revision is detectable instead of silently producing different output.
+# The A53 side writes it alone, since everything in it is build-wide and both
+# multiconfigs build one recipe at one SRCREV.
+tcbsgn_write_am62_manifest() {
+    local outdir="${DEPLOYDIR}/${TCB_SIGNING_EXPORT_DIR}"
+    local verfile ubootversion ubootrelease roots sep r
+
+    tcbsgn_uboot_set_config_dir
+    tcbsgn_uboot_set_config_type
+
+    # Read the version from the file u-boot-ota.inc already generates in
+    # do_compile, so the two cannot disagree and no second make run is needed.
+    verfile="${tcbsgn_cfgdir}/u-boot-version.json-${tcbsgn_cfgtype}"
+    if [ ! -f "${verfile}" ]; then
+        bbfatal "\"${verfile}\" not found; the TCB signing manifest takes the" \
+                "U-Boot version from it. Check whether u-boot-ota.inc still" \
+                "generates it in do_compile()."
+    fi
+
+    ubootversion=$(sed -ne 's/^[[:space:]]*"ubootversion"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' "${verfile}")
+    ubootrelease=$(sed -ne 's/^[[:space:]]*"ubootrelease"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p' "${verfile}")
+    if [ -z "${ubootversion}" -o -z "${ubootrelease}" ]; then
+        bbfatal "Could not read ubootversion/ubootrelease out of" \
+                "\"${verfile}\"; its format must have changed."
+    fi
+
+    roots=""
+    sep=""
+    for r in ${TCB_SIGNING_MANIFEST_ROOTS}; do
+        roots="${roots}${sep}\"${r}\""
+        sep=", "
+    done
+
+    install -d "${outdir}"
+    printf '{\n  "format_version": %s,\n  "machine": "%s",\n  "uboot": {\n    "version": "%s",\n    "release": "%s"\n  },\n  "roots": [%s]\n}\n' \
+           "${TCB_SIGNING_MANIFEST_VERSION}" "${MACHINE}" \
+           "${ubootversion}" "${ubootrelease}" "${roots}" \
+           > "${outdir}/manifest.json"
+
+    # Explicit mode: the tarball preserves it, and a umask-dependent one would
+    # make the archive differ between builds.
+    chmod 0644 "${outdir}/manifest.json"
+}
+
 # Everything binman needs to rebuild and re-sign the tiboot3-am62x-*-verdin
 # containers, sourced from this recipe's own workdir as in the A53 root above.
 tcbsgn_deploy_am62_export_k3r5() {
@@ -313,5 +376,6 @@ do_deploy:append:verdin-am62() {
     if [ "${UBOOT_SIGN_ENABLE}" = "1" -a -n "${UBOOT_DTB_BINARY}" ]; then
         tcbsgn_deploy_pristine_dtb
         tcbsgn_deploy_am62_export_a53
+        tcbsgn_write_am62_manifest
     fi
 }

--- a/recipes-bsp/u-boot/u-boot-tcb-sign.inc
+++ b/recipes-bsp/u-boot/u-boot-tcb-sign.inc
@@ -150,9 +150,10 @@ concat_dtb:prepend:verdin-am62() {
 # name the same directory; keep the two in step.
 TCB_SIGNING_EXPORT_DIR ?= "tcb-signing"
 TCB_SIGNING_EXPORT_DIR_A53 ?= "${TCB_SIGNING_EXPORT_DIR}/a53"
+TCB_SIGNING_EXPORT_DIR_K3R5 ?= "${TCB_SIGNING_EXPORT_DIR}/k3r5"
 
-# Where the binman descriptor's include path looks for firmware. Fixed, so that
-# distro configuration cannot move it out from under a consumer.
+# Where the A53 binman descriptor's include path looks for firmware. Fixed, so
+# distro configuration cannot move it; the k3r5 one names ti-sysfw/ instead.
 TCB_SIGNING_EXPORT_FWDIR ?= "usr/lib/firmware"
 
 # Install a regular file into the export tree, creating its directory. Symlinks
@@ -242,6 +243,65 @@ tcbsgn_deploy_am62_export_a53() {
     for f in gp hs hs-fs; do
         tcbsgn_export_install "${srcfw}/tiboot3-am62x-${f}-verdin.bin" "${root}"
     done
+}
+
+# Everything binman needs to rebuild and re-sign the tiboot3-am62x-*-verdin
+# containers, sourced from this recipe's own workdir as in the A53 root above.
+tcbsgn_deploy_am62_export_k3r5() {
+    local def_dt="k3-am625-verdin-r5"
+    local boarddir="board/toradex/verdin-am62"
+    local root="${DEPLOYDIR}/${TCB_SIGNING_EXPORT_DIR_K3R5}"
+    local srcfw="${RECIPE_SYSROOT}${nonarch_base_libdir}/firmware"
+    local f
+
+    tcbsgn_uboot_set_config_dir
+
+    # Same checks as the A53 root, against this multiconfig's own values.
+    tcbsgn_check_config "CONFIG_SYS_VENDOR" "toradex"
+    tcbsgn_check_config "CONFIG_SYS_BOARD" "verdin-am62"
+    tcbsgn_check_config "CONFIG_DEFAULT_DEVICE_TREE" "${def_dt}"
+    tcbsgn_check_config "CONFIG_OF_LIST" "${def_dt}"
+    tcbsgn_check_config "CONFIG_SPL_OF_LIST" "${def_dt}"
+
+    # The binman image descriptor. No snapshot is needed: FIT signing is off in
+    # this multiconfig, so u-boot.dtb never receives a key.
+    tcbsgn_export_install "${tcbsgn_cfgdir}/${UBOOT_DTB_BINARY}" "${root}"
+
+    # u-boot-spl.bin is the payload; binman reads the unstripped ELF and
+    # u-boot-spl.sym to resolve SPL symbols.
+    for f in u-boot-spl u-boot-spl.bin u-boot-spl-dtb.bin u-boot-spl-nodtb.bin \
+             u-boot-spl.sym; do
+        tcbsgn_export_install "${tcbsgn_cfgdir}/spl/${f}" "${root}/spl"
+    done
+
+    # of-list DTB. Same basename as the A53 root's, different content, which is
+    # why each multiconfig gets a root of its own.
+    tcbsgn_export_install "${tcbsgn_cfgdir}/arch/arm/dts/${def_dt}.dtb" \
+                          "${root}/arch/arm/dts"
+
+    # binman regenerates the TIFS and DM config blobs from these rather than
+    # reusing the built ones; each root keeps its own copy to stay independent.
+    for f in board pm rm sec; do
+        tcbsgn_export_install "${S}/${boarddir}/${f}-cfg.yaml" "${root}/${boarddir}"
+    done
+    tcbsgn_export_install "${S}/arch/arm/mach-k3/schema.yaml" \
+                          "${root}/arch/arm/mach-k3"
+
+    # All five TIFS blobs: the descriptor declares gp, hs and hs-fs whatever
+    # the device type, and --allow-missing turns a gap into an invalid container.
+    for f in gp hs-cert hs-enc hs-fs-cert hs-fs-enc; do
+        tcbsgn_export_install "${srcfw}/ti-sysfw/ti-fs-firmware-am62x-${f}.bin" \
+                              "${root}/ti-sysfw"
+    done
+}
+
+do_deploy:append:verdin-am62-k3r5() {
+    # MACHINE gains a "-k3r5" suffix here, so a :verdin-am62 override does not
+    # reach this task. No FIT is built, so there is no condition to mirror.
+    #
+    # TODO: gate this on the K3 counterpart of TCB_SIGNING_SUPPORT once the
+    # tarball export defines it.
+    tcbsgn_deploy_am62_export_k3r5
 }
 
 do_deploy:append:verdin-am62() {

--- a/recipes-bsp/u-boot/u-boot-tcb-sign.inc
+++ b/recipes-bsp/u-boot/u-boot-tcb-sign.inc
@@ -1,5 +1,5 @@
-# Deploy additional files needed by TorizonCore Builder to recreate the bootloader container from its constituent parts
-# This is needed by TCB for its signing feature
+# Deploy additional files needed by TorizonCore Builder to recreate the
+# bootloader container from its constituent parts, for TCB's signing feature.
 
 # Set ${tcbsgn_cfgdir} to the directory U-Boot was built in, following the same
 # two branches as oe-core's do_uboot_assemble_fitimage(). More than one
@@ -80,4 +80,73 @@ do_deploy:append:verdin-imx8mm() {
     install -d "${DEPLOYDIR}/u-boot-dtbs/freescale"
     install -m 0644 "${tcbsgn_cfgdir}/dts/upstream/src/arm64/${def_dt}.dtb" \
                     "${DEPLOYDIR}/u-boot-dtbs/freescale/"
+}
+
+# Key-free u-boot.dtb, for the K3 machines. With UBOOT_SIGN_ENABLE = "1",
+# oe-core's uboot-sign.bbclass injects the build's own FIT signing key into
+# u-boot.dtb in place, so no copy without it survives. TCB needs one to install
+# the user's key into, or it cannot reproduce what Yocto built. concat_dtb() is
+# where the injection happens, so a prepend there catches the file in time.
+
+TCB_SIGNING_UBOOT_DTB_NOKEYS ?= "${UBOOT_DTB_BINARY}-nokeys"
+
+tcbsgn_snapshot_pristine_dtb() {
+    # Called with (type, binary), both unused. cwd is ${B}/${config}, set by
+    # do_uboot_assemble_fitimage().
+    if [ ! -e "${UBOOT_DTB_BINARY}" ]; then
+        bbfatal "\"${UBOOT_DTB_BINARY}\" not found in \"$(pwd)\"; it is required" \
+                "to export a pristine DTB for re-signing (and without it the" \
+                "build could not embed its own FIT key either)."
+    fi
+
+    if ! fdtget -l "${UBOOT_DTB_BINARY}" / >/dev/null 2>&1; then
+        bbfatal "\"$(pwd)/${UBOOT_DTB_BINARY}\" is not a readable device tree blob."
+    fi
+
+    if fdtget -l "${UBOOT_DTB_BINARY}" /signature >/dev/null 2>&1; then
+        bbfatal "\"$(pwd)/${UBOOT_DTB_BINARY}\" already contains a /signature node," \
+                "so it is not a pristine DTB. This usually means" \
+                "do_uboot_assemble_fitimage() ran again without do_compile();" \
+                "clean the recipe and rebuild."
+    fi
+
+    bbdebug 1 "Snapshotting pristine ${UBOOT_DTB_BINARY} as ${TCB_SIGNING_UBOOT_DTB_NOKEYS}"
+    install -m 0644 "${UBOOT_DTB_BINARY}" "${TCB_SIGNING_UBOOT_DTB_NOKEYS}"
+}
+
+tcbsgn_deploy_pristine_dtb() {
+    local srcdir
+
+    # concat_dtb() runs with cwd set to the U-Boot build directory, so that is
+    # where the snapshot was left.
+    tcbsgn_uboot_set_config_dir
+    srcdir="${tcbsgn_cfgdir}"
+
+    if [ ! -e "${srcdir}/${TCB_SIGNING_UBOOT_DTB_NOKEYS}" ]; then
+        bbfatal "\"${srcdir}/${TCB_SIGNING_UBOOT_DTB_NOKEYS}\" not found, but FIT" \
+                "signing is enabled and this machine exports a pristine DTB for" \
+                "TCB re-signing. The concat_dtb:prepend that produces it did not" \
+                "run -- check whether oe-core's uboot-sign.bbclass still calls" \
+                "concat_dtb()."
+    fi
+
+    # Deployed under its build-directory name, without the versioned file and
+    # symlink deploy_dtb() makes, for consumers with no binman tree to read.
+    install -m 0644 "${srcdir}/${TCB_SIGNING_UBOOT_DTB_NOKEYS}" \
+                    "${DEPLOYDIR}/${TCB_SIGNING_UBOOT_DTB_NOKEYS}"
+}
+
+concat_dtb:prepend:verdin-am62() {
+    tcbsgn_snapshot_pristine_dtb "$@"
+}
+
+do_deploy:append:verdin-am62() {
+    # Mirrors the condition under which uboot_assemble_fitimage_helper() calls
+    # concat_dtb(), i.e. exactly the case in which the snapshot is taken.
+    #
+    # TODO: gate this on the K3 counterpart of TCB_SIGNING_SUPPORT once the
+    # tarball export defines it, instead of repeating the condition here.
+    if [ "${UBOOT_SIGN_ENABLE}" = "1" -a -n "${UBOOT_DTB_BINARY}" ]; then
+        tcbsgn_deploy_pristine_dtb
+    fi
 }

--- a/recipes-bsp/u-boot/u-boot-tcb-sign.inc
+++ b/recipes-bsp/u-boot/u-boot-tcb-sign.inc
@@ -140,13 +140,118 @@ concat_dtb:prepend:verdin-am62() {
     tcbsgn_snapshot_pristine_dtb "$@"
 }
 
+# TCB signing export tree, for the AM62. Its two multiconfigs produce files with
+# identical basenames and different content, so the flat file list used on the
+# iMX8M cannot describe them: export one root per multiconfig instead, each a
+# binman working directory a consumer can enter and run binman in. Deliberately
+# absent, for the consumer to supply: arch/arm/mach-k3/keys/ and u-boot.dtb.
+
+# Root of the export tree, relative to DEPLOYDIR. TCB_SIGNING_FILELIST must
+# name the same directory; keep the two in step.
+TCB_SIGNING_EXPORT_DIR ?= "tcb-signing"
+TCB_SIGNING_EXPORT_DIR_A53 ?= "${TCB_SIGNING_EXPORT_DIR}/a53"
+
+# Where the binman descriptor's include path looks for firmware. Fixed, so that
+# distro configuration cannot move it out from under a consumer.
+TCB_SIGNING_EXPORT_FWDIR ?= "usr/lib/firmware"
+
+# Install a regular file into the export tree, creating its directory. Symlinks
+# are dereferenced, so the tarball carries no dangling link and no duplicate.
+tcbsgn_export_install() {
+    local src="${1?source file}"
+    local dstdir="${2?destination directory}"
+
+    if [ ! -f "${src}" ]; then
+        bbfatal "\"${src}\" not found, but it is required by the TCB signing" \
+                "export for MACHINE \"${MACHINE}\". Either the U-Boot build" \
+                "layout changed or this artifact is no longer produced;" \
+                "do_deploy() must be reviewed."
+    fi
+
+    install -d "${dstdir}"
+    install -m 0644 "${src}" "${dstdir}/"
+}
+
+# Everything binman needs to rebuild and re-sign tispl.bin, u-boot.img and
+# firmware-verdin-am62-*. All of it comes from this recipe's own workdir, ${S}
+# or sysroot, which is why the tarball recipe needs no other producer.
+tcbsgn_deploy_am62_export_a53() {
+    local def_dt="k3-am625-verdin-wifi-dev"
+    local boarddir="board/toradex/verdin-am62"
+    local root="${DEPLOYDIR}/${TCB_SIGNING_EXPORT_DIR_A53}"
+    local srcfw="${RECIPE_SYSROOT}${nonarch_base_libdir}/firmware"
+    local dstfw="${root}/${TCB_SIGNING_EXPORT_FWDIR}"
+    local f
+
+    tcbsgn_uboot_set_config_dir
+
+    # Assumptions the paths below are written against. The of-list checks also
+    # guard the layout: one DTB per root holds only while binman builds one DT.
+    tcbsgn_check_config "CONFIG_SYS_VENDOR" "toradex"
+    tcbsgn_check_config "CONFIG_SYS_BOARD" "verdin-am62"
+    tcbsgn_check_config "CONFIG_DEFAULT_DEVICE_TREE" "${def_dt}"
+    tcbsgn_check_config "CONFIG_OF_LIST" "${def_dt}"
+    tcbsgn_check_config "CONFIG_SPL_OF_LIST" "${def_dt}"
+
+    # The binman image descriptor, taken from the key-free snapshot: u-boot.dtb
+    # in the build tree already carries this build's FIT key.
+    tcbsgn_export_install "${tcbsgn_cfgdir}/${TCB_SIGNING_UBOOT_DTB_NOKEYS}" "${root}"
+
+    # Payload of the u-boot FIT subimage.
+    tcbsgn_export_install "${tcbsgn_cfgdir}/u-boot-nodtb.bin" "${root}"
+
+    # Only u-boot-spl-nodtb.bin is a payload; binman reads the unstripped ELF
+    # and u-boot-spl.sym to resolve SPL symbols.
+    for f in u-boot-spl u-boot-spl.bin u-boot-spl-dtb.bin u-boot-spl-nodtb.bin \
+             u-boot-spl.sym; do
+        tcbsgn_export_install "${tcbsgn_cfgdir}/spl/${f}" "${root}/spl"
+    done
+
+    # SPL control DTB: tispl.bin's signed fdt-0 payload.
+    tcbsgn_export_install "${tcbsgn_cfgdir}/spl/dts/${def_dt}.dtb" "${root}/spl/dts"
+
+    # of-list DTB. Same basename as the SPL control and kernel DTBs, different
+    # content, which is why this export is a tree and not a file list.
+    tcbsgn_export_install "${tcbsgn_cfgdir}/arch/arm/dts/${def_dt}.dtb" \
+                          "${root}/arch/arm/dts"
+
+    # binman regenerates the TIFS and DM config blobs from these rather than
+    # reusing the built ones; each root keeps its own copy to stay independent.
+    for f in board pm rm sec; do
+        tcbsgn_export_install "${S}/${boarddir}/${f}-cfg.yaml" "${root}/${boarddir}"
+    done
+    tcbsgn_export_install "${S}/arch/arm/mach-k3/schema.yaml" \
+                          "${root}/arch/arm/mach-k3"
+
+    # Firmware subimage inputs, at the sysroot paths meta-ti's u-boot-ti.inc
+    # uses (PACKAGECONFIG[atf], [optee], [dm]). bl31.bin sits at the root.
+    tcbsgn_export_install "${RECIPE_SYSROOT}/firmware/bl31.bin" "${root}/firmware"
+    tcbsgn_export_install "${srcfw}/bl32.bin" "${dstfw}"
+    tcbsgn_export_install "${srcfw}/ti-dm/${PLAT_SFX}/${DM_FIRMWARE}" \
+                          "${dstfw}/ti-dm/${PLAT_SFX}"
+
+    # All three stub blobs go into tispl.bin whatever the device type; the
+    # per-variant ones belong to the k3r5 root.
+    for f in gp hs-cert hs-enc; do
+        tcbsgn_export_install "${srcfw}/ti-sysfw/ti-fs-stub-firmware-am62x-${f}.bin" \
+                              "${dstfw}/ti-sysfw"
+    done
+
+    # The A53 descriptor assembles the OTA container byproducts from these;
+    # do_compile stages them from the k3r5 multiconfig through mcdepends.
+    for f in gp hs hs-fs; do
+        tcbsgn_export_install "${srcfw}/tiboot3-am62x-${f}-verdin.bin" "${root}"
+    done
+}
+
 do_deploy:append:verdin-am62() {
     # Mirrors the condition under which uboot_assemble_fitimage_helper() calls
-    # concat_dtb(), i.e. exactly the case in which the snapshot is taken.
+    # concat_dtb(): without the snapshot the export tree is incomplete anyway.
     #
     # TODO: gate this on the K3 counterpart of TCB_SIGNING_SUPPORT once the
     # tarball export defines it, instead of repeating the condition here.
     if [ "${UBOOT_SIGN_ENABLE}" = "1" -a -n "${UBOOT_DTB_BINARY}" ]; then
         tcbsgn_deploy_pristine_dtb
+        tcbsgn_deploy_am62_export_a53
     fi
 }

--- a/recipes-bsp/u-boot/u-boot-tcb-sign.inc
+++ b/recipes-bsp/u-boot/u-boot-tcb-sign.inc
@@ -1,5 +1,11 @@
 # Deploy additional files needed by TorizonCore Builder to recreate the
 # bootloader container from its constituent parts, for TCB's signing feature.
+#
+# Both the u-boot-toradex (NXP) and u-boot-toradex-ti (K3) bbappends parse this,
+# so nothing here may assume one SoC family: every task append is keyed to a
+# machine override. The export root comes from the include below, whose file
+# list must name the same directory this file installs into.
+require recipes-bsp/tcb-signing-files/tcb-signing-files.inc
 
 # Set ${tcbsgn_cfgdir} to the directory U-Boot was built in, following the same
 # two branches as oe-core's do_uboot_assemble_fitimage(). More than one
@@ -158,9 +164,8 @@ concat_dtb:prepend:verdin-am62() {
 # binman working directory a consumer can enter and run binman in. Deliberately
 # absent, for the consumer to supply: arch/arm/mach-k3/keys/ and u-boot.dtb.
 
-# Root of the export tree, relative to DEPLOYDIR. TCB_SIGNING_FILELIST must
-# name the same directory; keep the two in step.
-TCB_SIGNING_EXPORT_DIR ?= "tcb-signing"
+# One root per multiconfig inside the export tree. TCB_SIGNING_EXPORT_DIR names
+# the tree itself and is defined in the include required above.
 TCB_SIGNING_EXPORT_DIR_A53 ?= "${TCB_SIGNING_EXPORT_DIR}/a53"
 TCB_SIGNING_EXPORT_DIR_K3R5 ?= "${TCB_SIGNING_EXPORT_DIR}/k3r5"
 

--- a/recipes-bsp/u-boot/u-boot-tcb-sign.inc
+++ b/recipes-bsp/u-boot/u-boot-tcb-sign.inc
@@ -1,12 +1,34 @@
 # Deploy additional files needed by TorizonCore Builder to recreate the bootloader container from its constituent parts
 # This is needed by TCB for its signing feature
 
+# Set ${tcbsgn_cfgdir} to the directory U-Boot was built in, following the same
+# two branches as oe-core's do_uboot_assemble_fitimage(). More than one
+# UBOOT_MACHINE entry is fatal, since every deploy name here is flat. The result
+# comes back in a variable because BitBake emits only the shell functions it
+# sees called, and a call inside a command substitution is not one of them.
+tcbsgn_uboot_set_config_dir() {
+    if [ -n "${UBOOT_CONFIG}" ]; then
+        set -- ${UBOOT_MACHINE}
+        if [ $# -ne 1 ]; then
+            bbfatal "Expected a single U-Boot config in UBOOT_MACHINE" \
+                    "(\"${UBOOT_MACHINE}\"); do_deploy() must be reviewed."
+        fi
+        tcbsgn_cfgdir="${B}/$1"
+    else
+        tcbsgn_cfgdir="${B}"
+    fi
+}
+
 tcbsgn_check_config() {
     local cfg="${1?property name in the U-Boot config}"
     local exp="${2?property value}"
     local cur
 
-    cur=$(cat "${B}/${MACHINE}_defconfig/.config" | sed -ne "s/^${cfg}=\"\(.*\)\"$/\1/p")
+    tcbsgn_uboot_set_config_dir
+
+    # An absent property and an empty one both yield ""; either way the
+    # assumption being checked no longer holds.
+    cur=$(sed -ne "s/^${cfg}=\"\(.*\)\"$/\1/p" "${tcbsgn_cfgdir}/.config")
     if [ "${cur}" != "${exp}" ]; then
         bbfatal "Value of \"${cfg}\" property in the U-Boot config" \
 		"(\"${cur}\") does not match the expected value (\"${exp}\");" \
@@ -15,16 +37,21 @@ tcbsgn_check_config() {
 }
 
 tcbsgn_deploy_common_files_imx8m() {
-    install -m 0644 ${B}/${MACHINE}_defconfig/.config ${DEPLOYDIR}/uboot_config
+    tcbsgn_uboot_set_config_dir
+
+    install -m 0644 ${tcbsgn_cfgdir}/.config ${DEPLOYDIR}/uboot_config
     install -d ${DEPLOYDIR}/spl
-    install -m 0644 ${B}/${MACHINE}_defconfig/spl/u-boot-spl ${DEPLOYDIR}/spl/
-    install -m 0644 ${B}/${MACHINE}_defconfig/spl/u-boot-spl.dtb ${DEPLOYDIR}/spl/
-    install -m 0644 ${B}/${MACHINE}_defconfig/spl/u-boot-spl-nodtb.bin ${DEPLOYDIR}/spl/
+    install -m 0644 ${tcbsgn_cfgdir}/spl/u-boot-spl ${DEPLOYDIR}/spl/
+    install -m 0644 ${tcbsgn_cfgdir}/spl/u-boot-spl.dtb ${DEPLOYDIR}/spl/
+    install -m 0644 ${tcbsgn_cfgdir}/spl/u-boot-spl-nodtb.bin ${DEPLOYDIR}/spl/
 }
 
 do_deploy:append:verdin-imx8mp() {
-    # Check assumptions:
     local def_dt="freescale/imx8mp-verdin-wifi-dev"
+
+    tcbsgn_uboot_set_config_dir
+
+    # Check assumptions:
     tcbsgn_check_config "CONFIG_DEFAULT_DEVICE_TREE" "${def_dt}"
     tcbsgn_check_config "CONFIG_OF_LIST" "${def_dt}"
 
@@ -33,13 +60,16 @@ do_deploy:append:verdin-imx8mp() {
 
     # Deploy files specific to the imx8mp:
     install -d "${DEPLOYDIR}/u-boot-dtbs/freescale"
-    install -m 0644 "${B}/${MACHINE}_defconfig/dts/upstream/src/arm64/${def_dt}.dtb" \
+    install -m 0644 "${tcbsgn_cfgdir}/dts/upstream/src/arm64/${def_dt}.dtb" \
                     "${DEPLOYDIR}/u-boot-dtbs/freescale/"
 }
 
 do_deploy:append:verdin-imx8mm() {
-    # Check assumptions:
     local def_dt="freescale/imx8mm-verdin-wifi-dev"
+
+    tcbsgn_uboot_set_config_dir
+
+    # Check assumptions:
     tcbsgn_check_config "CONFIG_DEFAULT_DEVICE_TREE" "${def_dt}"
     tcbsgn_check_config "CONFIG_OF_LIST" "${def_dt}"
 
@@ -48,6 +78,6 @@ do_deploy:append:verdin-imx8mm() {
 
     # Deploy files specific to the imx8mm:
     install -d "${DEPLOYDIR}/u-boot-dtbs/freescale"
-    install -m 0644 "${B}/${MACHINE}_defconfig/dts/upstream/src/arm64/${def_dt}.dtb" \
+    install -m 0644 "${tcbsgn_cfgdir}/dts/upstream/src/arm64/${def_dt}.dtb" \
                     "${DEPLOYDIR}/u-boot-dtbs/freescale/"
 }


### PR DESCRIPTION
TorizonCore Builder re-signs a pre-built image's bootloader with the customer's own keys; on the Verdin AM62 the artifacts it needs never leave the U-Boot work directory. This branch exports them as a tarball in the Tezi image, as the iMX8M already does, and first restructures that mechanism, which cannot describe a two-multiconfig machine.

## Main changes

- **`recipes-bsp/tcb-signing-files/`** (new, TOR-4583): the tarball moves out of a `do_image_teziimg` prefunc that tarred a glob list out of `DEPLOY_DIR_IMAGE` into `WORKDIR`. It is now built once by a recipe of its own, shared through sstate, buildable without an image, and packed reproducibly (sorted members, `SOURCE_DATE_EPOCH` mtimes, `0/0` ownership). Fixes a stale tarball shipped with signing off, and per-image repacking of the deploy directory. Building it in a configuration that has signing off now fails with a message naming the reason, and it is kept out of `bitbake world`.
- **`image_type_torizon.bbclass`**: the image side is now a conditional dependency plus a conditional `TEZI_ARTIFACTS` entry. `TCB_SIGNING_SUPPORT` is hashed by its computed value, so a signature moves when a machine switches the export on or off, not when a helper is reworded.
- **`u-boot-tcb-sign.inc`** (TOR-4543): the AM62 export. The two multiconfigs produce colliding basenames (`u-boot.dtb`, `spl/*`, everything under `arch/arm/dts/`) with different content, so instead of a flat file set the export is a tree with one binman working directory per multiconfig (`a53/`, `k3r5/`), 41 files: unpack, enter a root, run binman. It also deploys a key-free `u-boot.dtb` snapshot, taken before oe-core injects the build's FIT key, and a `manifest.json` giving format version, machine, U-Boot revision and expected roots. No key material is exported. Gated on `TCB_SIGNING_SUPPORT`, keyed on `TDX_K3_SECBOOT_ENABLE`, plus a second form for the FIT-less k3r5 multiconfig.

iMX8M tarball name, contents and placement unchanged.

## Migration

Existing build directories need one cleanup before the first build, and the recipe to clean differs by machine. Fresh directories, and builds served from a shared sstate cache, are unaffected.

- **`verdin-imx8mp` / `verdin-imx8mm`** — the tarball's owner moves from the image recipe to the new one, and sstate refuses to install over the file already sitting in `DEPLOY_DIR_IMAGE`: `Recipe tcb-signing-files is trying to install files into a shared area when those files already exist`. Run `bitbake -c cleansstate <image>` once; the tarball then repacks to identical contents.
- **`verdin-am62`** — the pristine-DTB guard fires once on a tree that already holds a signed U-Boot. This branch moves `do_uboot_assemble_fitimage`'s signature and not `do_compile`'s, so BitBake re-runs the former alone over the `u-boot.dtb` the previous build signed in place. Run `bitbake -c cleansstate u-boot-toradex-ti` once. The same guard fires after `UBOOT_SIGN_KEYDIR` or `UBOOT_SIGN_KEYNAME` changes, where it also stops a key-free file being exported with the previous key still in it.

## Tests

- All five AM62 artifacts re-signed from the tarball alone; payloads byte-identical to the deployed binaries (certificates differ — the checking toolchain predates the companion `meta-toradex-security` pinning).
- iMX8M: twelve members and archive bytes identical.
- Tarball built standalone, reproducible across repacks, in the Tezi image once and unmodified.
- Feature off: nothing built, stale tarball not shipped.
- Each multiconfig deploys only its own root.
- The feature gate exercised both ways on `verdin-imx8mp`: with signing on `do_compile` runs and packs the twelve members; with `TCB_SIGNING_SUPPORT` forced to `0` the build stops at that task with the recipe's own error.
- The migration above checked against the signatures rather than assumed: `do_compile`'s signature data for `u-boot-toradex-ti` contains no reference to anything this branch adds, while `do_uboot_assemble_fitimage`'s does.

Related-to: TOR-4543  
Related-to: TOR-4583


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for packaging bootloader files required to re-sign Torizon OS images.
  - Added Trusted Computing Base signing support for supported Verdin i.MX8 and AM62 platforms.
  - Added AM62 signing exports for A53 and K3R5 targets, including versioned manifests.
  - Torizon OS image builds now include the required signing package when signing support is enabled.

- **Improvements**
  - Improved U-Boot artifact handling for machine-specific configurations and signing workflows.
  - Added validation for missing signing artifacts and unsupported configuration selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
