### PR TITLE
Bump SRCREV to latest for Torizon OS 7.8.0-devel-202609 monthly pre-release

### DIFF
--- a/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
+++ b/recipes-sota/aktualizr-torizon/aktualizr-torizon_git.bb
@@ -15,7 +15,7 @@ SRC_URI = " \
   https://github.com/uptane/ota-tuf/releases/download/v${UPTANE_SIGN_PV}/cli-${UPTANE_SIGN_PV}.tgz;unpack=0;name=uptanesign \
 "
 
-SRCREV = "a789fdc9728026eb434c456cf25fdfbb0a519fd2"
+SRCREV = "e317a8cc2101613b95ecbb9bcb98bcb751fa63c7"
 SRCREV:use-head-next = "${AUTOREV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Related-to: TOR-4609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the bundled aktualizr-torizon source to a newer upstream revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->