### PR TITLE
u-boot: record the signing conditions in the AM62 manifest

### DIFF
--- a/recipes-bsp/u-boot/u-boot-tcb-sign.inc
+++ b/recipes-bsp/u-boot/u-boot-tcb-sign.inc
@@ -11,7 +11,7 @@ require recipes-bsp/tcb-signing-files/tcb-signing-files.inc
 # two branches as oe-core's do_uboot_assemble_fitimage(). More than one
 # UBOOT_MACHINE entry is fatal, since every deploy name here is flat. The result
 # comes back in a variable because BitBake emits only the shell functions it
-# sees called, and a call inside a command substitution is not one of them.
+# sees called, and scarthgap's parser misses a call inside a quoted expansion.
 tcbsgn_uboot_set_config_dir() {
     if [ -n "${UBOOT_CONFIG}" ]; then
         set -- ${UBOOT_MACHINE}
@@ -271,14 +271,40 @@ tcbsgn_deploy_am62_export_a53() {
     done
 }
 
-# Manifest at the root of the export tree: which layout to expect, and which
-# U-Boot produced the artifacts, so that a consumer whose binman comes from
-# another revision is detectable instead of silently producing different output.
-# The A53 side writes it alone, since everything in it is build-wide and both
-# multiconfigs build one recipe at one SRCREV.
+# Echoes whether the certificate's validity was pinned. Measured, not taken
+# from the switch that asks for it: the signing tool pins validity only when
+# its openssl is new enough, so intent and outcome can differ. Pass a k3r5
+# artifact: the A53's own outputs are FIT images, whose certificates are not
+# at offset 0. Unreadable is "false", the answer that costs a consumer least.
+tcbsgn_am62_certificates_pinned() {
+    local notbefore epoch
+    local certfile="${1?certificate file}"
+
+    [ -f "${certfile}" ] || { echo "false"; return 0; }
+
+    notbefore=$(openssl x509 -inform DER -in "${certfile}" -noout -startdate \
+                2>/dev/null | sed -ne 's/^notBefore=//p')
+    [ -n "${notbefore}" ] || { echo "false"; return 0; }
+
+    # Task scripts run under set -e, where a bare assignment from a failing
+    # command ends the shell on dash even though bash survives it.
+    epoch=$(date -u -d "${notbefore}" +%s 2>/dev/null) || epoch=""
+    if [ -n "${epoch}" -a "${epoch}" = "${SOURCE_DATE_EPOCH}" ]; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
+# Manifest at the root of the export tree: which layout to expect, which U-Boot
+# produced the artifacts, and under which conditions they were signed, so a
+# consumer whose binman differs is detectable instead of silently producing
+# different output. The A53 side writes it alone: everything in it is
+# build-wide, and both multiconfigs build one recipe at one SRCREV.
 tcbsgn_write_am62_manifest() {
     local outdir="${DEPLOYDIR}/${TCB_SIGNING_EXPORT_DIR}"
     local verfile ubootversion ubootrelease roots sep r
+    local pinned opensslver epoch
 
     tcbsgn_uboot_set_config_dir
     tcbsgn_uboot_set_config_type
@@ -306,10 +332,29 @@ tcbsgn_write_am62_manifest() {
         sep=", "
     done
 
+    # The a53 root's own copy, installed earlier in this same append, so this
+    # reaches into no other multiconfig's deploy directory.
+    pinned=$(tcbsgn_am62_certificates_pinned \
+             "${DEPLOYDIR}/${TCB_SIGNING_EXPORT_DIR_A53}/tiboot3-am62x-hs-fs-verdin.bin")
+
+    # Provenance only: this task's openssl, which the k3r5 side takes from the
+    # same recipe at the same version. Consumers do not branch on it.
+    opensslver=$(openssl version | awk '{print $2}')
+    if [ -z "${opensslver}" ]; then
+        bbfatal "\"openssl version\" produced nothing; the manifest records it" \
+                "as the provenance of the certificates the export carries."
+    fi
+
+    # Empty would leave the field with no value at all, which is not JSON. A
+    # shell default here would read as BitBake's and be the shell's, so: two lines.
+    epoch="${SOURCE_DATE_EPOCH}"
+    [ -n "${epoch}" ] || epoch="null"
+
     install -d "${outdir}"
-    printf '{\n  "format_version": %s,\n  "machine": "%s",\n  "uboot": {\n    "version": "%s",\n    "release": "%s"\n  },\n  "roots": [%s]\n}\n' \
+    printf '{\n  "format_version": %s,\n  "machine": "%s",\n  "uboot": {\n    "version": "%s",\n    "release": "%s"\n  },\n  "roots": [%s],\n  "signing": {\n    "source_date_epoch": %s,\n    "certificates_pinned": %s,\n    "openssl": "%s"\n  }\n}\n' \
            "${TCB_SIGNING_MANIFEST_VERSION}" "${MACHINE}" \
            "${ubootversion}" "${ubootrelease}" "${roots}" \
+           "${epoch}" "${pinned}" "${opensslver}" \
            > "${outdir}/manifest.json"
 
     # Explicit mode: the tarball preserves it, and a umask-dependent one would


### PR DESCRIPTION
TorizonCore Builder re-signs a pre-built image's bootloader with the customer's own keys, then checks its work by comparing bytes against the original. Whether that comparison can succeed depends on two things the AM62 signing export does not state: the epoch its certificates were dated from, and whether their validity was pinned at all. This adds them to the manifest the export already carries.

Summary of changes:

- `tcb-signing/manifest.json` gains a `signing` object with three fields.
- `source_date_epoch`: the value binman ran with, from the task environment.
- `certificates_pinned`: measured by reading `notBefore` out of a deployed certificate and comparing it with `SOURCE_DATE_EPOCH`, not derived from `TDX_K3_SECBOOT_REPRODUCIBLE`. Unreadable is `false`.
- `openssl`: the version that produced them, as provenance.
- New helper `tcbsgn_am62_certificates_pinned` takes that measurement, on a k3r5 artifact.
- `format_version` stays at 1. AM62 only; the iMX8M machines are untouched.

Related-to: TOR-4543

<details>
  <summary>Details</summary>

  ## Main changes

  `recipes-bsp/u-boot/u-boot-tcb-sign.inc` — `tcb-signing/manifest.json` gains a `signing` object:
   
  ```json
  "signing": {
    "source_date_epoch": 0,
    "certificates_pinned": true,
    "openssl": "3.5.7"
  }
  ```

  - **`source_date_epoch`** — the value binman ran with. Both sides of the re-signing path hardcode zero today, independently, with nothing connecting them; recording it turns that accidental agreement into one a consumer can check.
  - **`certificates_pinned`** — measured, not derived from `TDX_K3_SECBOOT_REPRODUCIBLE`. The signing tool sets the validity period only when its openssl is 3.4 or newer, and otherwise warns and carries on, so a build can ask for reproducible certificates and deploy wall-clock ones. The value is established by reading `notBefore` back out of a deployed certificate and comparing it with `SOURCE_DATE_EPOCH`. Unreadable is `false`, which costs a consumer nothing it was not already doing.
  - **`openssl`** — provenance, in the same spirit as `uboot.release`: a different X.509 encoder is the first suspect when bytes differ beyond the validity fields. Not something to branch on.

  The certificate read is a k3r5 one: `tiboot3-am62x-hs-fs-verdin.bin` is the only export member that begins with a certificate, `tispl.bin` and `u-boot.img` being FIT images. Both halves are signed by one source tree through one patch, so the result generalises, but the field is documented as that measurement rather than as a claim about every certificate exported.

  `format_version` stays at 1: no released image carries this manifest, so there is no v1 consumer to protect.

  Requested by TCB-898, which consumes the export. AM62 only; the iMX8M machines carry no manifest and are untouched.

  ## Tests

  On `verdin-am62` with signing enabled:
   
  - Manifest correct in the packed tarball, not only in the deploy directory: `source_date_epoch` a JSON number, `certificates_pinned` a JSON boolean, mode `0644`.
  - Built without `-f`, so task selection is itself the evidence: 1 task of 2505 re-ran, `do_deploy`. `do_compile` does not move, so no U-Boot rebuild and no signature churn elsewhere.
  - Negative case: with `TDX_K3_SECBOOT_REPRODUCIBLE = "0"` the field reads `false`, and the certificate corroborates it independently — wall-clock `notBefore`, `notAfter` exactly 30 days later, fresh random serial.
  - The comparison exercised against a non-zero epoch, since the build's is zero and zero is also what several failure modes produce: exact match `true`, one second out `false`, one day out `false`. Unaffected by timezone (host `-03`, container UTC).
  - Reproducible: after `bitbake -c cleansstate u-boot-toradex-ti mc:k3r5:u-boot-toradex-ti` and a rebuild from source on both multiconfigs, the tarball is byte-identical and the certificate serial unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AM62 TCB signing manifests now include signing provenance, including the source date, certificate validity pinning status, and the OpenSSL version used.
  * The source date is recorded as unavailable when no value is provided.

* **Bug Fixes**
  * Certificate pinning status is now reported as false when certificates are missing, unreadable, or contain invalid dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->